### PR TITLE
Feat: STOMP 기반 1:1 DM 실시간 전송 및 DB 저장 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,10 @@ dependencies {
 
 	// firebase
 	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
+	// WebSocket
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hrr/backend/domain/dm/controller/DmChatController.java
+++ b/src/main/java/com/hrr/backend/domain/dm/controller/DmChatController.java
@@ -1,0 +1,25 @@
+package com.hrr.backend.domain.dm.controller;
+
+import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+import com.hrr.backend.domain.dm.service.message.DmMessageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Controller;
+
+@RequiredArgsConstructor
+@Controller
+public class DmChatController {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+    private final DmMessageService dmMessageService;
+
+    @MessageMapping("/dm.send")
+    public void sendMessage(DmMessageSocketDto messageDto) {
+        // 메시지를 DB에 저장
+        DmMessageSocketDto saved = dmMessageService.saveMessage(messageDto);
+
+        // 해당 대화방 구독자에게 메시지 전송
+        messagingTemplate.convertAndSend("/sub/dm/" + messageDto.getConversationId(), saved);
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/dm/controller/DmChatController.java
+++ b/src/main/java/com/hrr/backend/domain/dm/controller/DmChatController.java
@@ -2,6 +2,7 @@ package com.hrr.backend.domain.dm.controller;
 
 import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
 import com.hrr.backend.domain.dm.service.message.DmMessageService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.simp.SimpMessageSendingOperations;
@@ -15,7 +16,7 @@ public class DmChatController {
     private final DmMessageService dmMessageService;
 
     @MessageMapping("/dm.send")
-    public void sendMessage(DmMessageSocketDto messageDto) {
+    public void sendMessage(@Valid DmMessageSocketDto messageDto) {
         // 메시지를 DB에 저장
         DmMessageSocketDto saved = dmMessageService.saveMessage(messageDto);
 

--- a/src/main/java/com/hrr/backend/domain/dm/controller/DmController.java
+++ b/src/main/java/com/hrr/backend/domain/dm/controller/DmController.java
@@ -1,0 +1,4 @@
+package com.hrr.backend.domain.dm.controller;
+
+public class DmController {
+}

--- a/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
+++ b/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
@@ -14,6 +14,7 @@ public class DmConverter {
                 .sender(sender)
                 .content(dto.getContent())
                 .messageType(dto.getMessageType())
+                .clientMessageUuid(dto.getClientMessageUuid())
                 .build();
     }
 
@@ -23,6 +24,7 @@ public class DmConverter {
                 .senderId(entity.getSender().getId())
                 .content(entity.getContent())
                 .messageType(entity.getMessageType())
+                .clientMessageUuid(entity.getClientMessageUuid())
                 .build();
     }
 }

--- a/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
+++ b/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
@@ -1,0 +1,28 @@
+package com.hrr.backend.domain.dm.converter;
+
+import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+import com.hrr.backend.domain.dm.entity.*;
+import com.hrr.backend.domain.user.entity.User;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DmConverter {
+
+    public DmMessage toMessageEntity(DmMessageSocketDto dto, DmConversation conversation, User sender) {
+        return DmMessage.builder()
+                .conversation(conversation)
+                .sender(sender)
+                .content(dto.getContent())
+                .messageType(dto.getMessageType())
+                .build();
+    }
+
+    public DmMessageSocketDto toMessageSocketDto(DmMessage entity) {
+        return DmMessageSocketDto.builder()
+                .conversationId(entity.getConversation().getId())
+                .senderId(entity.getSender().getId())
+                .content(entity.getContent())
+                .messageType(entity.getMessageType())
+                .build();
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/dm/dto/DmMessageSocketDto.java
+++ b/src/main/java/com/hrr/backend/domain/dm/dto/DmMessageSocketDto.java
@@ -1,0 +1,17 @@
+package com.hrr.backend.domain.dm.dto;
+
+import com.hrr.backend.domain.dm.entity.enums.DmMessageType;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class DmMessageSocketDto {
+
+    private Long conversationId; // 대화방 ID
+    private Long senderId;       // 보낸 사람 ID
+    private String content;      // 메시지 내용
+    private DmMessageType messageType; // 메시지 타입(TEXT/IMAGE 등)
+}

--- a/src/main/java/com/hrr/backend/domain/dm/dto/DmMessageSocketDto.java
+++ b/src/main/java/com/hrr/backend/domain/dm/dto/DmMessageSocketDto.java
@@ -1,17 +1,42 @@
 package com.hrr.backend.domain.dm.dto;
 
 import com.hrr.backend.domain.dm.entity.enums.DmMessageType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
 import lombok.*;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Schema(description = "STOMP 인바운드용 DM 메시지 DTO")
 public class DmMessageSocketDto {
 
-    private Long conversationId; // 대화방 ID
-    private Long senderId;       // 보낸 사람 ID
-    private String content;      // 메시지 내용
-    private DmMessageType messageType; // 메시지 타입(TEXT/IMAGE 등)
+    @Schema(description = "대화방 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "conversationId는 필수입니다.")
+    private Long conversationId;
+
+    @Schema(description = "보내는 사용자 ID", example = "1", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotNull(message = "senderId는 필수입니다.")
+    private Long senderId;
+
+    @Schema(description = "메시지 본문", example = "hello from client", requiredMode = Schema.RequiredMode.REQUIRED)
+    @NotBlank(message = "content는 비어 있을 수 없습니다.")
+    @Size(max = 1000, message = "content는 1000자를 초과할 수 없습니다.")
+    private String content;
+
+    @Schema(description = "메시지 타입", example = "TEXT", requiredMode = Schema.RequiredMode.REQUIRED,
+            allowableValues = {"TEXT","IMAGE","FILE"})
+    @NotNull(message = "messageType은 필수입니다.")
+    private DmMessageType messageType;
+
+    @Schema(description = "클라이언트 멱등성 키(UUID). 동일 메시지 재시도 시 중복 저장 방지용",
+            example = "6f9a0c8b-9c5a-4b05-8d7a-1d6d9f3f0a33", nullable = true)
+    @Length(max = 64, message = "clientMessageUuid는 64자를 초과할 수 없습니다.")
+    private String clientMessageUuid;
 }

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmConversationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmConversationRepository.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.dm.repository;
+
+import com.hrr.backend.domain.dm.entity.DmConversation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DmConversationRepository extends JpaRepository<DmConversation, Long> {
+}

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
@@ -3,5 +3,8 @@ package com.hrr.backend.domain.dm.repository;
 import com.hrr.backend.domain.dm.entity.DmMessage;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
+    Optional<DmMessage> findByClientMessageUuid(String clientMessageUuid);
 }

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.dm.repository;
+
+import com.hrr.backend.domain.dm.entity.DmMessage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
+}

--- a/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageService.java
+++ b/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageService.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.dm.service.message;
+
+import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+
+public interface DmMessageService {
+    DmMessageSocketDto saveMessage(DmMessageSocketDto dto);
+}

--- a/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageServiceImpl.java
@@ -11,8 +11,10 @@ import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -26,21 +28,33 @@ public class DmMessageServiceImpl implements DmMessageService {
     @Override
     @Transactional
     public DmMessageSocketDto saveMessage(DmMessageSocketDto dto) {
-        // 대화방 확인
-        DmConversation conversation = dmConversationRepository.findById(dto.getConversationId())
+        // 대화방/발신자 확인
+        var conversation = dmConversationRepository.findById(dto.getConversationId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.DM_CONVERSATION_NOT_FOUND));
-
-        // 발신자 확인
-        User sender = userRepository.findById(dto.getSenderId())
+        var sender = userRepository.findById(dto.getSenderId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
-        // DTO → Entity 변환
-        DmMessage message = dmConverter.toMessageEntity(dto, conversation, sender);
+        // 멱등성 선조회
+        if (StringUtils.hasText(dto.getClientMessageUuid())) {
+            var existed = dmMessageRepository.findByClientMessageUuid(dto.getClientMessageUuid());
+            if (existed.isPresent()) {
+                return dmConverter.toMessageSocketDto(existed.get());
+            }
+        }
 
-        // DB 저장
-        DmMessage saved = dmMessageRepository.save(message);
-
-        // Entity → DTO 변환
-        return dmConverter.toMessageSocketDto(saved);
+        // 신규 저장 시도
+        var entity = dmConverter.toMessageEntity(dto, conversation, sender);
+        try {
+            var saved = dmMessageRepository.save(entity);
+            return dmConverter.toMessageSocketDto(saved);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 저장으로 UNIQUE 충돌 → 재조회 후 기존 레코드 반환
+            if (StringUtils.hasText(dto.getClientMessageUuid())) {
+                return dmMessageRepository.findByClientMessageUuid(dto.getClientMessageUuid())
+                        .map(dmConverter::toMessageSocketDto)
+                        .orElseThrow(() -> e);
+            }
+            throw e;
+        }
     }
 }

--- a/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/dm/service/message/DmMessageServiceImpl.java
@@ -1,0 +1,46 @@
+package com.hrr.backend.domain.dm.service.message;
+
+import com.hrr.backend.domain.dm.converter.DmConverter;
+import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+import com.hrr.backend.domain.dm.entity.DmConversation;
+import com.hrr.backend.domain.dm.entity.DmMessage;
+import com.hrr.backend.domain.dm.repository.DmConversationRepository;
+import com.hrr.backend.domain.dm.repository.DmMessageRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class DmMessageServiceImpl implements DmMessageService {
+
+    private final DmMessageRepository dmMessageRepository;
+    private final DmConversationRepository dmConversationRepository;
+    private final UserRepository userRepository;
+    private final DmConverter dmConverter;
+
+    @Override
+    @Transactional
+    public DmMessageSocketDto saveMessage(DmMessageSocketDto dto) {
+        // 대화방 확인
+        DmConversation conversation = dmConversationRepository.findById(dto.getConversationId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.DM_CONVERSATION_NOT_FOUND));
+
+        // 발신자 확인
+        User sender = userRepository.findById(dto.getSenderId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // DTO → Entity 변환
+        DmMessage message = dmConverter.toMessageEntity(dto, conversation, sender);
+
+        // DB 저장
+        DmMessage saved = dmMessageRepository.save(message);
+
+        // Entity → DTO 변환
+        return dmConverter.toMessageSocketDto(saved);
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -2,8 +2,17 @@ package com.hrr.backend.domain.user.entity;
 
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "user")
 public class User extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hrr/backend/global/config/WebSocketConfig.java
+++ b/src/main/java/com/hrr/backend/global/config/WebSocketConfig.java
@@ -1,0 +1,25 @@
+package com.hrr.backend.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/ws") // 클라이언트 연결 주소
+                .setAllowedOriginPatterns("*") // CORS 허용
+                .withSockJS(); // SockJS 지원
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        registry.setApplicationDestinationPrefixes("/pub"); // 클라이언트 → 서버
+        registry.enableSimpleBroker("/sub"); // 서버 → 클라이언트
+    }
+}

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -19,6 +19,9 @@ public enum ErrorCode implements BaseCode{
 	// fcm
 	FCM_TOKEN_NOT_FOUND(HttpStatus.NOT_FOUND, "FCM404", "존재하지 않는 FCM 토큰입니다."),
 
+	// dm
+	DM_CONVERSATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화방입니다."),
+
 	;
 
 	private final HttpStatus status;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Close #16 

## ✨ 작업 내용 (Summary)

- STOMP 기반 **1:1 DM 채팅** 실시간 전송 기능 구현
- 수신 메시지를 **`DmMessage` 엔티티로 DB 저장** 후, 해당 방 구독자에게 브로드캐스트
- 서버/클라이언트 경로 컨벤션 명시 및 문서화
  - Handshake: `ws://<host>/ws`
  - Publish(클→서버): `/pub/dm.send`
  - Subscribe(서버→클): `/sub/dm/{conversationId}`

**주요 변경점**

- `WebSocketConfig`: STOMP 활성화, 엔드포인트/프리픽스 설정(`/ws`, `/pub`, `/sub`), CORS 허용
- `DmChatController`: `@MessageMapping("/dm.send")` 처리 → 저장 후 `/sub/dm/{conversationId}`로 전송
- `DmMessageService`: 메시지 영속화 로직(JPA)
- `DmMessageDto`: 송수신용 DTO 정의

---

## ✅ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 부분에 대한 테스트/수동 검증 수행
- [x] 문서(경로/흐름) 정리 및 공유
- [x] 팀 공지: 경로 컨벤션(`/pub`, `/sub`) 및 테스트 방법 공유

---

## 🧪 테스트 결과

- **테스트 환경:** 로컬 (Spring Boot, H2/로컬 DB)
- **테스트 방법:** Postman WebSocket(메시지 타입 **Binary + Base64**)로 STOMP 프레임 송수신 테스트

  * Handshake 성공: `GET /ws`, `New StandardWebSocketSession[...]`
  * CONNECT 처리: `Processing CONNECT ...` → 클라이언트 `CONNECTED` 수신
  * 구독 성공: `Processing SUBSCRIBE /sub/dm/1`
  * 전송 성공: `SEND /pub/dm.send` → 클라이언트에서 `MESSAGE destination:/sub/dm/1` 수신
  * DB 검증: `dm_message` 테이블에 `conversation_id=1`, `sender_id=1`, 내용 일치 레코드 삽입 확인 + uuid가 같을 경우 삽입 되지 않음
* **결과 요약:** 정상 동작 확인(핸드셰이크/구독/전송/브로드캐스트/DB 저장)

---

## 📸 스크린샷

#### Postman
<img width="1910" height="493" alt="image" src="https://github.com/user-attachments/assets/56993cff-454d-4626-9758-ab0223cb9854" />

#### DB
<img width="1725" height="257" alt="image" src="https://github.com/user-attachments/assets/85964916-3dcd-46e1-970f-10ee657a6560" />


---

## 💬 리뷰 요구사항

---

## 📎 참고 자료
- [WebSocket Test 방법](https://www.notion.so/WebSocket-Test-29aa7dfd778380d08d52ce5910bc1315?source=copy_link)
- 노션에서 BE/공유문서/WebSocket Test 들어가서 보셔도 됩니다
---
