### PR TITLE
Feat: STOMP 기반 DM 읽음 처리 기능 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/dm/controller/DmStompController.java
+++ b/src/main/java/com/hrr/backend/domain/dm/controller/DmStompController.java
@@ -1,7 +1,9 @@
 package com.hrr.backend.domain.dm.controller;
 
 import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+import com.hrr.backend.domain.dm.dto.DmReadSocketDto;
 import com.hrr.backend.domain.dm.service.message.DmMessageService;
+import com.hrr.backend.domain.dm.service.read.DmReadService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageMapping;
@@ -10,10 +12,11 @@ import org.springframework.stereotype.Controller;
 
 @RequiredArgsConstructor
 @Controller
-public class DmChatController {
+public class DmStompController {
 
     private final SimpMessageSendingOperations messagingTemplate;
     private final DmMessageService dmMessageService;
+    private final DmReadService dmReadService;
 
     @MessageMapping("/dm.send")
     public void sendMessage(@Valid DmMessageSocketDto messageDto) {
@@ -22,5 +25,12 @@ public class DmChatController {
 
         // 해당 대화방 구독자에게 메시지 전송
         messagingTemplate.convertAndSend("/sub/dm/" + messageDto.getConversationId(), saved);
+    }
+
+    // 인바운드: SEND /pub/dm.read
+    @MessageMapping("/dm.read")
+    public void report(@Valid DmReadSocketDto.DmReadReport dto) {
+        dmReadService.report(dto);
+        // 응답 없음: AFTER_COMMIT 리스너가 /sub/dm/{conversationId}/read로 브로드캐스트
     }
 }

--- a/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
+++ b/src/main/java/com/hrr/backend/domain/dm/converter/DmConverter.java
@@ -1,9 +1,12 @@
 package com.hrr.backend.domain.dm.converter;
 
 import com.hrr.backend.domain.dm.dto.DmMessageSocketDto;
+import com.hrr.backend.domain.dm.dto.DmReadSocketDto;
 import com.hrr.backend.domain.dm.entity.*;
 import com.hrr.backend.domain.user.entity.User;
 import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
 
 @Component
 public class DmConverter {
@@ -25,6 +28,18 @@ public class DmConverter {
                 .content(entity.getContent())
                 .messageType(entity.getMessageType())
                 .clientMessageUuid(entity.getClientMessageUuid())
+                .build();
+    }
+
+    public DmReadSocketDto.DmReadEvent toReadEvent(Long conversationId,
+                                                   Long userId,
+                                                   Long lastReadMessageId,
+                                                   LocalDateTime readAt) {
+        return DmReadSocketDto.DmReadEvent.builder()
+                .conversationId(conversationId)
+                .userId(userId)
+                .lastReadMessageId(lastReadMessageId)
+                .readAt(readAt)
                 .build();
     }
 }

--- a/src/main/java/com/hrr/backend/domain/dm/dto/DmReadSocketDto.java
+++ b/src/main/java/com/hrr/backend/domain/dm/dto/DmReadSocketDto.java
@@ -1,0 +1,49 @@
+package com.hrr.backend.domain.dm.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+public class DmReadSocketDto {
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DmReadReport { // inbound (클 -> 서버)
+
+        @NotNull
+        private Long conversationId;
+
+        @NotNull
+        private Long userId;
+
+        @NotNull
+        @Min(1)
+        private Long lastReadMessageId;
+
+    }
+
+    @Getter
+    @Setter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public static class DmReadEvent { // outbound (서버 -> 클)
+
+        @NotNull
+        private Long conversationId;
+
+        @NotNull
+        private Long userId;
+
+        @NotNull
+        private Long lastReadMessageId;
+
+        @NotNull
+        private LocalDateTime readAt;
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/dm/event/DmReadEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/dm/event/DmReadEventListener.java
@@ -1,0 +1,22 @@
+package com.hrr.backend.domain.dm.event;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessageSendingOperations;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class DmReadEventListener {
+
+    private final SimpMessageSendingOperations messagingTemplate;
+
+    @TransactionalEventListener
+    public void onUpdated(DmReadUpdatedEvent event) {
+        var p = event.getPayload();
+        messagingTemplate.convertAndSend(
+                "/sub/dm/" + p.getConversationId() + "/read",
+                p
+        );
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/dm/event/DmReadUpdatedEvent.java
+++ b/src/main/java/com/hrr/backend/domain/dm/event/DmReadUpdatedEvent.java
@@ -1,0 +1,9 @@
+package com.hrr.backend.domain.dm.event;
+
+import com.hrr.backend.domain.dm.dto.DmReadSocketDto.DmReadEvent;
+import lombok.Value;
+
+@Value
+public class DmReadUpdatedEvent {
+    DmReadEvent payload;
+}

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmConversationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmConversationRepository.java
@@ -1,7 +1,21 @@
+// com.hrr.backend.domain.dm.repository.DmConversationRepository.java
 package com.hrr.backend.domain.dm.repository;
 
 import com.hrr.backend.domain.dm.entity.DmConversation;
-import org.springframework.data.jpa.repository.JpaRepository;
+import com.hrr.backend.domain.dm.entity.DmMessage;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
 
 public interface DmConversationRepository extends JpaRepository<DmConversation, Long> {
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update DmConversation c
+           set c.lastMessage = :msg
+         where c.id = :convId
+           and (c.lastMessage is null or c.lastMessage.id < :msgId)
+    """)
+    int advanceLastMessageIfGreater(@Param("convId") Long conversationId,
+                                    @Param("msgId") Long msgId,
+                                    @Param("msg") DmMessage msg);
 }

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmMessageRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface DmMessageRepository extends JpaRepository<DmMessage, Long> {
     Optional<DmMessage> findByClientMessageUuid(String clientMessageUuid);
+
+    Optional<DmMessage> findByIdAndConversation_Id(Long id, Long conversationId);
 }

--- a/src/main/java/com/hrr/backend/domain/dm/repository/DmReadRepository.java
+++ b/src/main/java/com/hrr/backend/domain/dm/repository/DmReadRepository.java
@@ -1,0 +1,32 @@
+// src/main/java/com/hrr/backend/domain/dm/repository/DmReadRepository.java
+package com.hrr.backend.domain.dm.repository;
+
+import com.hrr.backend.domain.dm.entity.DmMessage;
+import com.hrr.backend.domain.dm.entity.DmRead;
+import org.springframework.data.jpa.repository.*;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface DmReadRepository extends JpaRepository<DmRead, Long> {
+
+    Optional<DmRead> findByConversation_IdAndUser_Id(Long conversationId, Long userId);
+
+    boolean existsByConversation_IdAndUser_Id(Long conversationId, Long userId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+        update DmRead r
+           set r.lastReadMessage = :msg,
+               r.readAt = :now
+         where r.conversation.id = :convId
+           and r.user.id = :userId
+           and (r.lastReadMessage is null or r.lastReadMessage.id < :msgId)
+    """)
+    int advanceIfGreater(@Param("convId") Long conversationId,
+                         @Param("userId") Long userId,
+                         @Param("msgId") Long msgId,
+                         @Param("msg") DmMessage msg,
+                         @Param("now") LocalDateTime now);
+}

--- a/src/main/java/com/hrr/backend/domain/dm/service/read/DmReadService.java
+++ b/src/main/java/com/hrr/backend/domain/dm/service/read/DmReadService.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.dm.service.read;
+
+import com.hrr.backend.domain.dm.dto.DmReadSocketDto;
+
+public interface DmReadService {
+    void report(DmReadSocketDto.DmReadReport dto);
+}

--- a/src/main/java/com/hrr/backend/domain/dm/service/read/DmReadServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/dm/service/read/DmReadServiceImpl.java
@@ -1,0 +1,74 @@
+package com.hrr.backend.domain.dm.service.read;
+
+import com.hrr.backend.domain.dm.converter.DmConverter;
+import com.hrr.backend.domain.dm.dto.DmReadSocketDto;
+import com.hrr.backend.domain.dm.entity.DmRead;
+import com.hrr.backend.domain.dm.event.DmReadUpdatedEvent;
+import com.hrr.backend.domain.dm.repository.DmMessageRepository;
+import com.hrr.backend.domain.dm.repository.DmReadRepository;
+import com.hrr.backend.domain.dm.repository.DmConversationRepository;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class DmReadServiceImpl implements DmReadService {
+
+    private final DmReadRepository dmReadRepository;
+    private final DmMessageRepository dmMessageRepository;
+    private final DmConversationRepository conversationRepository;
+    private final UserRepository userRepository;
+    private final ApplicationEventPublisher publisher;
+    private final DmConverter dmConverter;
+
+    @Transactional
+    @Override
+    public void report(DmReadSocketDto.DmReadReport dto) {
+        // 1) 메시지-대화방 소속 검증
+        var msg = dmMessageRepository.findByIdAndConversation_Id(
+                dto.getLastReadMessageId(), dto.getConversationId()
+        ).orElseThrow(() -> new GlobalException(ErrorCode.DM_MESSAGE_NOT_FOUND));
+
+        var now = LocalDateTime.now();
+
+        // 2) 존재하면: 현재값 < 새값일 때만 갱신 (DB가 단조 증가 보장)
+        int updated = dmReadRepository.advanceIfGreater(
+                dto.getConversationId(), dto.getUserId(), msg.getId(), msg, now
+        );
+        if (updated > 0) {
+            publisher.publishEvent(new DmReadUpdatedEvent(
+                    dmConverter.toReadEvent(dto.getConversationId(), dto.getUserId(), msg.getId(), now)
+            ));
+            return;
+        }
+
+        // 3) 없으면 최초 생성
+        if (!dmReadRepository.existsByConversation_IdAndUser_Id(dto.getConversationId(), dto.getUserId())) {
+            var conv = conversationRepository.findById(dto.getConversationId())
+                    .orElseThrow(() -> new GlobalException(ErrorCode.DM_CONVERSATION_NOT_FOUND));
+            var user = userRepository.findById(dto.getUserId())
+                    .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+            var created = DmRead.builder()
+                    .conversation(conv)
+                    .user(user)
+                    .lastReadMessage(msg)
+                    .readAt(now)
+                    .build();
+
+            dmReadRepository.save(created);
+
+            publisher.publishEvent(new DmReadUpdatedEvent(
+                    dmConverter.toReadEvent(dto.getConversationId(), dto.getUserId(), msg.getId(), now)
+            ));
+        }
+        // 존재하지만 역행/동일 → 아무 것도 안 함(브로드캐스트 X)
+    }
+}

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode implements BaseCode{
 
 	// dm
 	DM_CONVERSATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화방입니다."),
+	DM_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화입니다."),
 
 	;
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #18 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- `STOMP /pub/dm.read` API 추가
- 사용자가 메시지를 읽을 때 `conversationId`, `userId`, `lastReadMessageId` 전달
- 서버에서 `DmRead` 엔티티로 읽음 상태를 관리하고 메시지 ID가 기존보다 클 때만 갱신하도록 `advanceIfGreater()` 적용
- 읽음 정보 갱신 또는 최초 생성 시 `DmReadUpdatedEvent` 발행
- `@TransactionalEventListener`로 커밋 이후 `/sub/dm/{conversationId}/read` 브로드캐스트
- 중복 이벤트 / 역행 읽음 방지 및 AFTER_COMMIT 시점 보장

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** Postman
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** 정상 읽음 시 브로드캐스트 1회, 역행, 동일값 시 무시

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
#### 메시지 송수신 결과
<img width="2011" height="480" alt="스크린샷 2025-11-02 192321" src="https://github.com/user-attachments/assets/64aef951-8ced-4c8b-9c0e-a0efc05d5fe2" />

#### 2번 메시지까지 읽음 -> dm_read 생성
<img width="1426" height="284" alt="스크린샷 2025-11-02 192354" src="https://github.com/user-attachments/assets/e57b2364-4a29-49d1-a0a1-86bf949072ae" />

#### 5번 메시지까지 읽음 -> 갱신
<img width="1418" height="226" alt="스크린샷 2025-11-02 192410" src="https://github.com/user-attachments/assets/7c84e62f-cd73-432a-9275-7880bb690454" />

#### 3번 메시지까지 읽음 -> 무시
<img width="1418" height="226" alt="스크린샷 2025-11-02 192410" src="https://github.com/user-attachments/assets/85fb0d09-9809-4b3a-b1d7-827de80be184" />

#### 6번 메시지까지 읽음 -> 에러 (존재하지 않는 메시지)
<img width="1524" height="438" alt="스크린샷 2025-11-02 192445" src="https://github.com/user-attachments/assets/32c41253-6817-4407-af87-5c78d2c6da8d" />

#### 포스트맨을 통한 테스트
<img width="1913" height="1048" alt="image" src="https://github.com/user-attachments/assets/1371dfe6-e012-41eb-bca9-75429724c7b8" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- STOMP API와 REST API의 컨트롤러를 분리하였는데, 네이밍이 직관적이지 못한 것 같아 이번 이슈에서 컨트롤러 파일을 리네이밍 했습니다.
- REST API는 도메인별로 `RequestDto`, `ResponseDto`를 두었는데 STOMP API의 경우 기능별로 Dto를 두는 게 일반적이라고 하여 그렇게 진행하였습니다 (저번 pr에서 설명했어야 했는데 까먹었습니다...)

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.
