### PR TITLE
[FEAT] 오늘의 인기 챌린지 관련 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,11 +69,13 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 
     // QueryDsl
-
     implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
     annotationProcessor "com.querydsl:querydsl-apt:5.0.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    // Redis
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       SPRING_DATASOURCE_URL: ${LOCAL_DB_URL_DOCKER}
       SPRING_DATASOURCE_USERNAME: ${LOCAL_DB_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${LOCAL_DB_PASSWORD}
+      SPRING_DATA_REDIS_HOST: redis-server # Redis 서비스 이름(컨테이너 간 통신에 사용)
+      SPRING_DATA_REDIS_PORT: 6379
     depends_on:
       db:
         condition: service_healthy
@@ -34,5 +36,16 @@ services:
 
     volumes:
       - db-data:/var/lib/mysql
+
+  redis-server:
+    image: redis:7.4.2-alpine
+    container_name: hrr_redis
+    ports:
+      - "6379:6379"
+    restart: always
+    volumes:
+      - redis_data:/data    # 영속성 유지
+
 volumes:
   db-data:
+  redis_data:

--- a/src/main/java/com/hrr/backend/HrrBackendApiApplication.java
+++ b/src/main/java/com/hrr/backend/HrrBackendApiApplication.java
@@ -3,9 +3,11 @@ package com.hrr.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableScheduling
 public class HrrBackendApiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -60,12 +61,16 @@ public class ChallengeController {
 
 	@GetMapping("/{challengeId}")
 	@Operation(summary = "챌린지 프로필 조회", description = "챌린지 프로필을 조회합니다.")
-	public Integer getChallengeProfile(@PathVariable("challengeId") Long challengeId) {
+	public void getChallengeProfile(@PathVariable("challengeId") Long challengeId) {
 
-		// 챌린지 프로필 조회 api 내부에 챌린지 클릭 수 증가 로직을 구현하기 위해 임시로 스켈레톤 코드 작성
+	}
+
+	@PostMapping("/{challengeId}/click")
+	@Operation(summary = "챌린지 클릭 처리", description = "오늘의 인기 챌린지 집계를 위해 챌린지 클릭 시에 카운팅을 진행합니다.")
+	public Long clickChallenge(@PathVariable("challengeId") Long challengeId) {
+
 		// 테스트를 위해 임시로 클릭 수 반환
-		// TODO: 로직 제대로 구현
 
-		return challengeService.getChallengeProfile(challengeId);
+		return challengeService.clickChallenge(challengeId);
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -73,4 +73,11 @@ public class ChallengeController {
 
 		return challengeService.clickChallenge(challengeId);
 	}
+
+	@GetMapping("/daily-top")
+	@Operation(summary = "오늘의 인기 챌린지 조회", description = "오늘의 클릭 수를 기준으로 상위 3개 챌린지를 조회합니다.")
+	public ApiResponse<List<ChallengeResponseDto.DailyTopDto>> getDailyTopChallenges() {
+
+		return ApiResponse.onSuccess(SuccessCode.OK, challengeService.getDailyTopChallenges());
+	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -59,6 +59,7 @@ public class ChallengeController {
 	}
 
 	@GetMapping("/{challengeId}")
+	@Operation(summary = "챌린지 프로필 조회", description = "챌린지 프로필을 조회합니다.")
 	public Integer getChallengeProfile(@PathVariable("challengeId") Long challengeId) {
 
 		// 챌린지 프로필 조회 api 내부에 챌린지 클릭 수 증가 로직을 구현하기 위해 임시로 스켈레톤 코드 작성

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.challenge.controller;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -55,5 +56,15 @@ public class ChallengeController {
 		);
 
 		return ApiResponse.onSuccess(SuccessCode.OK, challenges);
+	}
+
+	@GetMapping("/{challengeId}")
+	public Integer getChallengeProfile(@PathVariable("challengeId") Long challengeId) {
+
+		// 챌린지 프로필 조회 api 내부에 챌린지 클릭 수 증가 로직을 구현하기 위해 임시로 스켈레톤 코드 작성
+		// 테스트를 위해 임시로 클릭 수 반환
+		// TODO: 로직 제대로 구현
+
+		return challengeService.getChallengeProfile(challengeId);
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -54,5 +54,23 @@ public class ChallengeResponseDto {
 		private LocalDateTime startDate;	// Querydsl로 조회하고 Service에서 사용 후 버릴 필드라 ignore 처리
 	}
 
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@Schema(description = "오늘의 인기 챌린지 DTO")
+	public static class DailyTopDto {
+
+		@Setter
+		@Schema(description = "랭킹", example = "1")
+		private Integer ranking;
+
+		@Schema(description = "클릭 수", example = "1500")
+		private Long clickCount;
+
+		@Schema(description = "챌린지 정보")
+		private InfoDto info;
+
+	}
+
 
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -23,4 +23,7 @@ public interface ChallengeRepositoryCustom {
 		String title,
 		Pageable pageable
 	);
+
+	// 챌린지 id 목록으로 정보 조회
+	List<ChallengeResponseDto.InfoDto> findChallengesByIds(List<Long> ids);
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -18,6 +18,7 @@ import com.hrr.backend.global.common.enums.SortType;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
@@ -77,7 +78,26 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom{
 	}
 
 
-	//-------동적 쿼리 관련 메소드들------------
+	@Override
+	public List<ChallengeResponseDto.InfoDto> findChallengesByIds(List<Long> ids) {
+		return jpaQueryFactory
+			.select(Projections.bean(ChallengeResponseDto.InfoDto.class,
+				qChallenge.id.as("challengeId"),
+				qChallenge.title,
+				qChallenge.description,
+				qChallenge.currentParticipants.as("currentParticipantCount"),
+				qChallenge.maxParticipants.as("maxParticipantCount"),
+				qChallenge.imageUrl.as("thumbnailUrl"),
+				qChallenge.startDate
+				// DB에 없는 isUpcoming, dDayUntilStart, daysOfWeek 필드 제외
+
+			))
+			.from(qChallenge)
+			.where(qChallenge.id.in(ids))
+			.fetch();
+	}
+
+	//-------필터링 동적 쿼리 관련 메소드들------------
 	// 필터링 및 정렬 조건이 없을 경우, null을 반환하여 WHERE 절에서 자동 제외 처리
 
 	private BooleanExpression categoryEq(Category category) {
@@ -117,13 +137,13 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom{
 		};
 	}
 
-	private BooleanExpression dayIn(List<ChallengeDays> days) {
-		if (days == null || days.isEmpty()) {
-			return null;
-		}
-
-		return qChallengeDayJoin.dayOfWeek.in(days);
-	}
+	// private BooleanExpression dayIn(List<ChallengeDays> days) {
+	// 	if (days == null || days.isEmpty()) {
+	// 		return null;
+	// 	}
+	//
+	// 	return qChallengeDayJoin.dayOfWeek.in(days);
+	// }
 
 	// 요일 필터에 해당하는 챌린지인지 판단
 	private BooleanExpression dayInExists(List<ChallengeDays> days) {

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -28,6 +28,9 @@ public interface ChallengeService {
 	// 챌린지 클릭 처리
 	Long clickChallenge(Long challengeId);
 
+	// 오늘의 인기 챌린지 조회
+	List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges();
+
 
 
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -22,4 +22,7 @@ public interface ChallengeService {
 		int size
 	);
 
+	// 챌린지 프로필 조회
+	Integer getChallengeProfile(Long challengeId);
+
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -23,6 +23,11 @@ public interface ChallengeService {
 	);
 
 	// 챌린지 프로필 조회
-	Integer getChallengeProfile(Long challengeId);
+	//Integer getChallengeProfile(Long challengeId);
+
+	// 챌린지 클릭 처리
+	Long clickChallenge(Long challengeId);
+
+
 
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
@@ -30,7 +31,12 @@ public class ChallengeServiceImpl implements ChallengeService {
 	private final ChallengeRepository challengeRepository;
 	private final ChallengeDayJoinRepository challengeDayJoinRepository;
 
+	private final RedisTemplate<String, String> redisTemplate;
+
 	private static final int UPCOMING_DAYS_CRITERIA = 5;	// '곧 시작' 챌린지 판단 기준 일자
+
+	// 오늘의 클릭수를 저장할 Redis Key
+	private static final String TODAY_CHALLENGE_RANKING_KEY = "today:challenge:clicks";
 
 	@Override
 	public SliceResponseDto<ChallengeResponseDto.InfoDto> getChallengeList(
@@ -105,5 +111,21 @@ public class ChallengeServiceImpl implements ChallengeService {
 		});
 
 		return new SliceResponseDto<>(finalDtoSlice);
+	}
+
+	@Override
+	public Integer getChallengeProfile(Long challengeId) {
+
+		// 클릭 수 증가 로직
+		Double updatedScore = redisTemplate.opsForZSet().incrementScore(
+			TODAY_CHALLENGE_RANKING_KEY,
+			String.valueOf(challengeId), // 챌린지 아이디를 key로 사용
+			1.0 // 클릭 수 1.0 증가(redis sorted set의 메서드 정의 상 double 타입 필요)
+		);
+
+		// TODO: 챌린지 프로필 조회 구현
+
+		// 임시로 로직 실행 후 클릭 수를 반환(정수 변환)
+		return Math.toIntExact((updatedScore != null) ? updatedScore.longValue() : 0L);
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -20,6 +20,8 @@ import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 import com.hrr.backend.global.common.enums.SortType;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.response.SliceResponseDto;
 
 import lombok.RequiredArgsConstructor;
@@ -113,19 +115,27 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return new SliceResponseDto<>(finalDtoSlice);
 	}
 
+	// @Override
+	// public Integer getChallengeProfile(Long challengeId) {
+	//
+	// 	// TODO: 챌린지 프로필 조회 구현
+	//
+	// 	return Math.toIntExact((updatedScore != null) ? updatedScore.longValue() : 0L);
+	// }
+
 	@Override
-	public Integer getChallengeProfile(Long challengeId) {
+	public Long clickChallenge(Long challengeId) {
+		// 챌린지 유효성 검사
+		challengeRepository.findById(challengeId)
+			.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
 
 		// 클릭 수 증가 로직
 		Double updatedScore = redisTemplate.opsForZSet().incrementScore(
 			TODAY_CHALLENGE_RANKING_KEY,
 			String.valueOf(challengeId), // 챌린지 아이디를 key로 사용
-			1.0 // 클릭 수 1.0 증가(redis sorted set의 메서드 정의 상 double 타입 필요)
+			1.0 // 클릭 수 1.0 증가 (redis sorted set의 메서드 정의 상 double 타입 필요)
 		);
 
-		// TODO: 챌린지 프로필 조회 구현
-
-		// 임시로 로직 실행 후 클릭 수를 반환(정수 변환)
-		return Math.toIntExact((updatedScore != null) ? updatedScore.longValue() : 0L);
+		return (updatedScore != null) ? updatedScore.longValue() : 0L;
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -3,14 +3,20 @@ package com.hrr.backend.domain.challenge.service;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.function.Function;
 
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
 import org.springframework.stereotype.Service;
 
 import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
@@ -78,39 +84,49 @@ public class ChallengeServiceImpl implements ChallengeService {
 			pageable
 		);
 
-		// ---응답 dto에 추가할 요일 정보 조회---
-		// 모든 challengeId 추출
-		List<Long> challengeIds = tempDtoSlice.getContent().stream()
-			.map(ChallengeResponseDto.InfoDto::getChallengeId)
-			.toList();
+		// // ---응답 dto에 추가할 요일 정보 조회---
+		// // 모든 challengeId 추출
+		// List<Long> challengeIds = tempDtoSlice.getContent().stream()
+		// 	.map(ChallengeResponseDto.InfoDto::getChallengeId)
+		// 	.toList();
+		//
+		// // 해당 challenge들을 가진 ChallengeDayJoin 엔티티 조회
+		// List<ChallengeDayJoin> allDays = challengeDayJoinRepository.findByChallengeIdIn(challengeIds);
+		//
+		// // 챌린지 아이디-요일 리스트 매핑
+		// Map<Long, List<ChallengeDays>> daysMap = allDays.stream()
+		// 	.collect(Collectors.groupingBy(
+		// 		dayJoin -> dayJoin.getChallenge().getId(), // key: 챌린지 아이디
+		// 		Collectors.mapping(ChallengeDayJoin::getDayOfWeek, Collectors.toList()) // value: 요일 리스트
+		// 	));
+		//
+		//
+		// // Repository에서 조회해 온 dto 기반으로 결과 dto 필드 일부 채우기
+		// Slice<ChallengeResponseDto.InfoDto> finalDtoSlice = tempDtoSlice.map(tempDto -> {
+		//
+		// 	LocalDate challengeStartDate = tempDto.getStartDate().toLocalDate();
+		// 	LocalDate today = LocalDate.now();
+		//
+		// 	long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
+		// 	boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
+		//
+		// 	// dto 나머지 필드 채우기(isUpcoming, dDayUntilStart, dayOfWeek)
+		// 	tempDto.setIsUpcoming(isUpcomingResult);
+		// 	tempDto.setDDayUntilStart((int)Math.max(0, dDay));	// 시작 전일 경우에만 남은 날짜를 set, else 0
+		// 	tempDto.setDaysOfWeek(daysMap.getOrDefault(tempDto.getChallengeId(), List.of()));
+		//
+		// 	return tempDto;
+		// });
 
-		// 해당 challenge들을 가진 ChallengeDayJoin 엔티티 조회
-		List<ChallengeDayJoin> allDays = challengeDayJoinRepository.findByChallengeIdIn(challengeIds);
+		// dto 나머지 필드 보강 (isUpcoming, dDayUntilStart, dayOfWeek)
+		List<ChallengeResponseDto.InfoDto> rawContent = tempDtoSlice.getContent();
+		List<ChallengeResponseDto.InfoDto> enrichedContent = enrichChallengeInfo(rawContent);
 
-		// 챌린지 아이디-요일 리스트 매핑
-		Map<Long, List<ChallengeDays>> daysMap = allDays.stream()
-			.collect(Collectors.groupingBy(
-				dayJoin -> dayJoin.getChallenge().getId(), // key: 챌린지 아이디
-				Collectors.mapping(ChallengeDayJoin::getDayOfWeek, Collectors.toList()) // value: 요일 리스트
-			));
-
-
-		// Repository에서 조회해 온 dto 기반으로 결과 dto 필드 일부 채우기
-		Slice<ChallengeResponseDto.InfoDto> finalDtoSlice = tempDtoSlice.map(tempDto -> {
-
-			LocalDate challengeStartDate = tempDto.getStartDate().toLocalDate();
-			LocalDate today = LocalDate.now();
-
-			long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
-			boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
-
-			// dto 나머지 필드 채우기(isUpcoming, dDayUntilStart, dayOfWeek)
-			tempDto.setIsUpcoming(isUpcomingResult);
-			tempDto.setDDayUntilStart((int)Math.max(0, dDay));	// 시작 전일 경우에만 남은 날짜를 set, else 0
-			tempDto.setDaysOfWeek(daysMap.getOrDefault(tempDto.getChallengeId(), List.of()));
-
-			return tempDto;
-		});
+		Slice<ChallengeResponseDto.InfoDto> finalDtoSlice = new SliceImpl<>(
+			enrichedContent,
+			pageable,
+			tempDtoSlice.hasNext()
+		);
 
 		return new SliceResponseDto<>(finalDtoSlice);
 	}
@@ -137,5 +153,114 @@ public class ChallengeServiceImpl implements ChallengeService {
 		);
 
 		return (updatedScore != null) ? updatedScore.longValue() : 0L;
+	}
+
+	@Override
+	public List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges() {
+
+		// Top 3 조회
+		Set<ZSetOperations.TypedTuple<String>> topRankings = redisTemplate.opsForZSet().reverseRangeWithScores(
+			TODAY_CHALLENGE_RANKING_KEY,
+			0, 2
+		);
+
+		// 데이터가 없을 경우 (아마 00시 직후) 빈 리스트 반환
+		if (topRankings == null || topRankings.isEmpty()) {
+			return Collections.emptyList();
+		}
+
+		// <챌린지 id, 클릭 수> 로딩
+		Map<Long, Long> clicksMap = topRankings.stream()
+			.collect(Collectors.toMap(
+				tuple -> Long.parseLong(Objects.requireNonNull(tuple.getValue())),
+				tuple -> (tuple.getScore() != null) ? tuple.getScore().longValue() : 0L
+			));
+
+		// 해당 챌린지들 DB에서 조회
+		List<Long> challengeIds = topRankings.stream()
+			.map(tuple -> Long.parseLong(Objects.requireNonNull(tuple.getValue())))
+			.toList();
+
+		List<ChallengeResponseDto.InfoDto> rawInfosFromRDB = challengeRepository.findChallengesByIds(challengeIds);
+
+		// D-Day, isUpcoming, daysOfWeek 추가
+		List<ChallengeResponseDto.InfoDto> enrichedInfos = enrichChallengeInfo(rawInfosFromRDB);
+
+		Map<Long, ChallengeResponseDto.InfoDto> infoMap = enrichedInfos.stream()
+			.collect(Collectors.toMap(
+				ChallengeResponseDto.InfoDto::getChallengeId,
+				Function.identity() // Identity function: InfoDto 객체 자체를 값으로 사용
+			));
+
+		// 최종 DTO
+		List<ChallengeResponseDto.DailyTopDto> results = topRankings.stream()
+			.map(tuple -> {
+				Long id = Long.parseLong(Objects.requireNonNull(tuple.getValue()));
+
+				// DB에서 받아온 챌린지 정보와 클릭 수 조회
+				ChallengeResponseDto.InfoDto info = infoMap.get(id);
+				Long clickCount = clicksMap.getOrDefault(id, 0L);
+
+				// 챌린지 정보가 조회되지 않으면 패스
+				if (info == null) return null;
+
+				return ChallengeResponseDto.DailyTopDto.builder()
+					.clickCount(clickCount)
+					.info(info)
+					.build();
+			})
+			.filter(Objects::nonNull)
+			.toList();
+
+		// 랭킹 정보 추가
+		for (int i = 0; i < results.size(); i++) {
+			results.get(i).setRanking(i + 1);
+		}
+
+		return results;
+	}
+
+	/**
+	 * DB에서 조회해 온 Challenge InfoDto에 누락되어있는 D-Day, isUpcoming, daysOfWeek 정보를 추가
+	 * @param rawInfos DB에서 조회된 ChallengeResponseDto.InfoDto 리스트
+	 */
+	private List<ChallengeResponseDto.InfoDto> enrichChallengeInfo(List<ChallengeResponseDto.InfoDto> rawInfos) {
+
+		if (rawInfos.isEmpty()) {
+			return rawInfos;
+		}
+
+		// ---응답 dto에 추가할 요일 정보 조회---
+		// 모든 challengeId 추출
+		List<Long> challengeIds = rawInfos.stream()
+			.map(ChallengeResponseDto.InfoDto::getChallengeId)
+			.toList();
+
+		// 해당 challenge들을 가진 ChallengeDayJoin 엔티티 조회
+		List<ChallengeDayJoin> allDays = challengeDayJoinRepository.findByChallengeIdIn(challengeIds);
+
+		// 챌린지 아이디-요일 리스트 매핑
+		Map<Long, List<ChallengeDays>> daysMap = allDays.stream()
+			.collect(Collectors.groupingBy(
+				dayJoin -> dayJoin.getChallenge().getId(), // key: 챌린지 아이디
+				Collectors.mapping(ChallengeDayJoin::getDayOfWeek, Collectors.toList()) // value: 요일 리스트
+			));
+
+		// Repository에서 조회해 온 dto 기반으로 결과 dto 필드 일부 채우기
+		return rawInfos.stream()
+			.map(infoDto -> {
+				LocalDate challengeStartDate = infoDto.getStartDate().toLocalDate();
+				LocalDate today = LocalDate.now();
+
+				long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
+				boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
+
+				// dto 나머지 필드 채우기 (isUpcoming, dDayUntilStart, dayOfWeek)
+				infoDto.setIsUpcoming(isUpcomingResult);
+				infoDto.setDDayUntilStart((int)Math.max(0, dDay)); // 시작 전일 경우에만 남은 날짜를 set, else 0
+				infoDto.setDaysOfWeek(daysMap.getOrDefault(infoDto.getChallengeId(), List.of()));
+
+				return infoDto;
+			}).toList();
 	}
 }

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -23,6 +23,9 @@ public enum ErrorCode implements BaseCode{
 	DM_CONVERSATION_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화방입니다."),
 	DM_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화입니다."),
 
+	// challenge
+	CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE404", "존재하지 않는 챌린지입니다.")
+
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
@@ -1,0 +1,30 @@
+package com.hrr.backend.global.scheduler;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeScheduler {
+	private final RedisTemplate<String, String> redisTemplate;
+	private static final String TODAY_CHALLENGE_RANKING_KEY = "today:challenge:clicks";
+
+	/**
+	 * 매일 자정(00시 00분 00초)에 챌린지별 오늘의 클릭 수 카운트를 초기화
+	 */
+	@Scheduled(cron = "0 0 0 * * *")
+	public void initializeDailyChallengeClicks() {
+
+		// 오늘의 클릭 수를 담고 있는 Sorted Set Key 자체를 삭제
+		Boolean isDeleted = redisTemplate.delete(TODAY_CHALLENGE_RANKING_KEY);
+
+		if (isDeleted) {
+			log.info("00시 초기화 완료. 클릭수 Sorted Set 삭제됨.");
+		}
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #31

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

홈화면에 띄울 '오늘의 인기 챌린지' 관련된 구현을 진행하였습니다.

2개의 api를 구현하였습니다. 
- 챌린지 클릭 처리 (/api/v1/challenges/{challengeId}/click)
- 오늘의 인기 챌린지 조회 (/api/v1/challenges/daily-top)
- (챌린지 프로필 조회 api는 원래 '챌린지 클릭 시'='챌린지 프로필 조회'로 생각해서 해당 api 내부에 챌린지 클릭 처리 로직을 넣으려다가, 프론트엔드와 상의 결과 클릭했을 때가 아니더라도 챌린지 프로필 조회 api를 사용하는 경우가 있을 것 같다고 하여 클릭 처리는 별도의 api로 구현하게 되었습니다. 추후 구현될 api여서 지우진 않고 스켈레톤 코드로 남겨놓았습니다.)

챌린지 클릭 수에 따라 홈화면에서 오늘의 인기 챌린지를 조회할 때마다 실시간으로 업데이트가 필요합니다. 
그래서 속도와 동시성 문제 모두를 해결하기 위해 redis를 도입하였고, 그 중에서도 sorted set를 적용하여 구현하였습니다.

'오늘' 발생한 클릭 기준이기 때문에 매일 00시에 클릭 데이터들이 초기화되는 로직 또한 스케쥴링으로 구현하였습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

**docker 킬 때 이제 docker compose up -d db redis-server 로 해주세요! (redis도 포함)**

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** postman
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 클릭 처리 시 예외 발생 | 클릭 결과(redis) |
|---|---|
|<img width="507" height="422" alt="1" src="https://github.com/user-attachments/assets/e58e0347-518c-4c0f-a02a-e751fae2829a" />|<img width="649" height="316" alt="2" src="https://github.com/user-attachments/assets/813b99e2-d947-4776-af1d-3d795bec3b83" />|

| 특정 시간에 초기화 (테스트용 임시 시간) |
|---|
|<img width="1268" height="725" alt="2-1" src="https://github.com/user-attachments/assets/d4c1bfe3-a8d8-497b-b3c3-c8499ef73e29" />|

| redis 상황 | 인기 챌린지 조회 | 관련 DB 정보 |
|---|---|---|
|<img width="645" height="333" alt="3" src="https://github.com/user-attachments/assets/6dca28f3-36a0-4f85-af6c-acbadddfc7c2" />|<img width="375" height="594" alt="4" src="https://github.com/user-attachments/assets/7d93ac3b-cc21-49a0-8d18-6df6d0b3ae3f" />|<img width="920" height="117" alt="5" src="https://github.com/user-attachments/assets/d6dac8f0-0927-45b6-aff7-08b0ffb26b67" />|

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---
디버깅 하다보니까 로그의 필요성을 다시 한 번 느껴서 노션에 '공유 문서-로깅 전략'에 정리해두었습니다! 참고해서 꼼꼼하게 적용해주세요

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

QueryDsl의 Projection: https://songpro98.tistory.com/3
Redis 설정: https://adjh54.tistory.com/672


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 클릭 수를 실시간으로 집계하여 순위화하는 기능 추가
  * 일일 상위 챌린지 조회 API 추가 (상위 3개 노출)
  * 챌린지 프로필 조회 및 클릭 등록 API 추가
  * 매일 자정에 일일 집계가 자동 초기화되는 스케줄링 추가

* **설치/인프라**
  * 애플리케이션에 일시적 데이터 저장(캐시)을 위한 Redis 연동 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->