### PR TITLE
[FEAT] 오늘의 랜덤미션 관련 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,7 @@ src/main/resources/firebase/*.json
 ### Log Files ###
 *.log
 logs/
+
+# macOS files
+.DS_Store
+**/.*DS_Store

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -19,6 +19,7 @@ import com.hrr.backend.global.response.SliceResponseDto;
 import com.hrr.backend.global.response.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
@@ -67,11 +68,11 @@ public class ChallengeController {
 
 	@PostMapping("/{challengeId}/click")
 	@Operation(summary = "챌린지 클릭 처리", description = "오늘의 인기 챌린지 집계를 위해 챌린지 클릭 시에 카운팅을 진행합니다.")
-	public Long clickChallenge(@PathVariable("challengeId") Long challengeId) {
+	public ApiResponse<Long> clickChallenge(@PathVariable("challengeId") Long challengeId) {
 
 		// 테스트를 위해 임시로 클릭 수 반환
 
-		return challengeService.clickChallenge(challengeId);
+		return ApiResponse.onSuccess(SuccessCode.OK, challengeService.clickChallenge(challengeId));
 	}
 
 	@GetMapping("/daily-top")

--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
@@ -1,9 +1,19 @@
 package com.hrr.backend.domain.challenge.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.global.common.enums.Category;
 
 public interface ChallengeRepository extends JpaRepository<Challenge, Long>, ChallengeRepositoryCustom {
+
+	// 사용자가 참가 중인 챌린지들의 카테고리를 조회
+	// 없으면 빈 리스트 반환
+	@Query("SELECT DISTINCT c.category FROM Challenge c JOIN UserChallenge uc ON uc.challenge = c WHERE uc.user.id = :userId")
+	List<Category> findCategoriesByUserId(@Param("userId") Long userId);
 
 }

--- a/src/main/java/com/hrr/backend/domain/user/controller/UserMissionController.java
+++ b/src/main/java/com/hrr/backend/domain/user/controller/UserMissionController.java
@@ -1,0 +1,46 @@
+package com.hrr.backend.domain.user.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.service.UserMissionService;
+import com.hrr.backend.global.config.CustomUserDetails;
+import com.hrr.backend.global.response.ApiResponse;
+import com.hrr.backend.global.response.SliceResponseDto;
+import com.hrr.backend.global.response.SuccessCode;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "Mission", description = "랜덤미션 관련 API")
+@RestController
+@RequestMapping("/api/v1/users/mission/daily")
+@RequiredArgsConstructor
+public class UserMissionController {
+
+	private final UserMissionService userMissionService;
+
+	@GetMapping("")
+	@Operation(summary = "오늘의 랜덤미션 조회", description = "오늘의 랜덤미션을 조회합니다. ")
+	public ApiResponse<SliceResponseDto<ChallengeResponseDto.InfoDto>> getRandomMission(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+
+		return null;
+	}
+
+	@GetMapping("/completed")
+	@Operation(summary = "오늘의 랜덤미션 완료 여부 조회", description = "오늘의 랜덤미션을 완료하였는지 여부를 조회합니다.")
+	public ApiResponse<Boolean> getRandomMissionStatus(
+		@AuthenticationPrincipal CustomUserDetails customUserDetails
+	) {
+		User user = customUserDetails.getUser();
+
+		return ApiResponse.onSuccess(SuccessCode.OK, userMissionService.getRandomMissionStatus(user));
+	}
+}

--- a/src/main/java/com/hrr/backend/domain/user/controller/UserMissionController.java
+++ b/src/main/java/com/hrr/backend/domain/user/controller/UserMissionController.java
@@ -5,12 +5,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.user.dto.UserMissionResponseDto;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.service.UserMissionService;
 import com.hrr.backend.global.config.CustomUserDetails;
 import com.hrr.backend.global.response.ApiResponse;
-import com.hrr.backend.global.response.SliceResponseDto;
 import com.hrr.backend.global.response.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -27,11 +26,12 @@ public class UserMissionController {
 
 	@GetMapping("")
 	@Operation(summary = "오늘의 랜덤미션 조회", description = "오늘의 랜덤미션을 조회합니다. ")
-	public ApiResponse<SliceResponseDto<ChallengeResponseDto.InfoDto>> getRandomMission(
+	public ApiResponse<UserMissionResponseDto.DetailDto> getRandomMission(
 		@AuthenticationPrincipal CustomUserDetails customUserDetails
 	) {
+		User user = customUserDetails.getUser();
 
-		return null;
+		return ApiResponse.onSuccess(SuccessCode.OK, userMissionService.getRandomMission(user));
 	}
 
 	@GetMapping("/completed")

--- a/src/main/java/com/hrr/backend/domain/user/dto/UserMissionResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/user/dto/UserMissionResponseDto.java
@@ -1,0 +1,33 @@
+package com.hrr.backend.domain.user.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+public class UserMissionResponseDto {
+
+	@Setter
+	@Getter
+	@Builder
+	@NoArgsConstructor
+	@AllArgsConstructor
+	@Schema(description = "오늘의 랜덤미션 상세정보 DTO")
+	public static class DetailDto {
+
+		@Schema(description = "유저-미션 아이디", example = "101")
+		private Long userMissionId;
+
+		@Schema(description = "미션 제목", example = "오운완")
+		private String title;
+
+		@Schema(description = "미션 내용", example = "운동 앱에 저장된 내 운동 내역을 인증해요.")
+		private String content;
+
+		@Schema(description = "완료 여부", example = "true")
+		private Boolean isCompleted;
+
+	}
+}

--- a/src/main/java/com/hrr/backend/domain/user/dto/UserMissionResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/user/dto/UserMissionResponseDto.java
@@ -17,8 +17,8 @@ public class UserMissionResponseDto {
 	@Schema(description = "오늘의 랜덤미션 상세정보 DTO")
 	public static class DetailDto {
 
-		@Schema(description = "유저-미션 아이디", example = "101")
-		private Long userMissionId;
+		@Schema(description = "미션 아이디", example = "101")
+		private Long missionId;
 
 		@Schema(description = "미션 제목", example = "오운완")
 		private String title;

--- a/src/main/java/com/hrr/backend/domain/user/entity/RandomMission.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/RandomMission.java
@@ -1,0 +1,30 @@
+package com.hrr.backend.domain.user.entity;
+
+import com.hrr.backend.global.common.BaseEntity;
+import com.hrr.backend.global.common.enums.Category;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "random_mission")
+public class RandomMission extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(name = "title", nullable = false, length = 255)
+	private String title;
+
+	@Lob
+	@Column(name = "content", columnDefinition = "TEXT", nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "category", nullable = false)
+	private Category category;
+}

--- a/src/main/java/com/hrr/backend/domain/user/entity/RandomMission.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/RandomMission.java
@@ -17,11 +17,10 @@ public class RandomMission extends BaseEntity {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
-	@Column(name = "title", nullable = false, length = 255)
+	@Column(name = "title", nullable = false, length = 15)
 	private String title;
 
-	@Lob
-	@Column(name = "content", columnDefinition = "TEXT", nullable = false)
+	@Column(name = "content", nullable = false, length = 30)
 	private String content;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -99,6 +99,9 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<UserFavor> userFavors = new ArrayList<>();
 
+	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private List<UserMission> userMissions = new ArrayList<>();
+
     /** 카카오 로그인용 팩토리 메서드 */
     public static User newKakao(Long kakaoId, String nickname, String profileImage) {
         User user = new User();

--- a/src/main/java/com/hrr/backend/domain/user/entity/UserMission.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/UserMission.java
@@ -30,8 +30,9 @@ public class UserMission {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
+	@Setter
 	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "mission_id", nullable = false)
+	@JoinColumn(name = "mission_id")
 	private RandomMission mission;
 
 	@Column(name = "date", nullable = false)

--- a/src/main/java/com/hrr/backend/domain/user/entity/UserMission.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/UserMission.java
@@ -1,0 +1,42 @@
+package com.hrr.backend.domain.user.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(
+	name = "user_mission", // 테이블명: UserMission
+	uniqueConstraints = {
+		// 사용자는 하루에 하나의 미션만 가질 수 있도록 유니크 제약 조건 설정
+		@UniqueConstraint(
+			name = "UK_user_mission_date",
+			columnNames = {"user_id", "date"}
+		)
+	}
+)
+public class UserMission {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "mission_id", nullable = false)
+	private RandomMission mission;
+
+	@Column(name = "date", nullable = false)
+	private LocalDate date;
+
+	@Column(name = "is_completed", nullable = false)
+	private Boolean isCompleted;
+}

--- a/src/main/java/com/hrr/backend/domain/user/repository/RandomMissionRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/RandomMissionRepository.java
@@ -1,0 +1,14 @@
+package com.hrr.backend.domain.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hrr.backend.domain.user.entity.RandomMission;
+import com.hrr.backend.global.common.enums.Category;
+
+public interface RandomMissionRepository extends JpaRepository<RandomMission, Long> {
+
+	// 카테고리 리스트에 해당하는 미션들을 조회
+	List<RandomMission> findByCategoryIn(List<Category> categoryList);
+}

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserFavorRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserFavorRepository.java
@@ -1,0 +1,16 @@
+package com.hrr.backend.domain.user.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import com.hrr.backend.domain.user.entity.UserFavor;
+import com.hrr.backend.global.common.enums.Category;
+
+public interface UserFavorRepository extends JpaRepository<UserFavor, Long> {
+
+	// 사용자의 선호 카테고리 조회
+	@Query("SELECT uf.category FROM UserFavor uf WHERE uf.user.id = :userId")
+	List<Category> findCategoriesByUserId(Long userId);
+}

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserMissionRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserMissionRepository.java
@@ -1,0 +1,14 @@
+package com.hrr.backend.domain.user.repository;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserMission;
+
+public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
+
+	Optional<UserMission> findByUserAndDate(User user, LocalDate date);
+}

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionService.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionService.java
@@ -1,0 +1,13 @@
+package com.hrr.backend.domain.user.service;
+
+import com.hrr.backend.domain.user.dto.UserMissionResponseDto;
+import com.hrr.backend.domain.user.entity.User;
+
+public interface UserMissionService {
+
+	// 오늘의 랜덤미션 조회
+	UserMissionResponseDto.DetailDto getRandomMission(Long userId);
+
+	// 오늘의 랜덤미션 완료 여부 조회
+	Boolean	getRandomMissionStatus(User user);
+}

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionService.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionService.java
@@ -6,7 +6,7 @@ import com.hrr.backend.domain.user.entity.User;
 public interface UserMissionService {
 
 	// 오늘의 랜덤미션 조회
-	UserMissionResponseDto.DetailDto getRandomMission(Long userId);
+	UserMissionResponseDto.DetailDto getRandomMission(User user);
 
 	// 오늘의 랜덤미션 완료 여부 조회
 	Boolean	getRandomMissionStatus(User user);

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -102,7 +102,7 @@ public class UserMissionServiceImpl implements UserMissionService {
 	// 사용 빈도가 적을 것 같아 별도의 클래스가 아닌 private 메소드로 생성
 	private UserMissionResponseDto.DetailDto convertToDetailDto(UserMission userMission) {
 		return UserMissionResponseDto.DetailDto.builder()
-			.userMissionId(userMission.getId())
+			.missionId(userMission.getMission().getId())
 			.title(userMission.getMission().getTitle())
 			.content(userMission.getMission().getContent())
 			.isCompleted(userMission.getIsCompleted())

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -1,0 +1,38 @@
+package com.hrr.backend.domain.user.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+
+import com.hrr.backend.domain.user.dto.UserMissionResponseDto;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserMission;
+import com.hrr.backend.domain.user.repository.UserMissionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class UserMissionServiceImpl implements UserMissionService {
+
+	private final UserMissionRepository userMissionRepository;
+
+	@Override
+	public UserMissionResponseDto.DetailDto getRandomMission(Long userId) {
+		return null;
+	}
+
+	@Override
+	public Boolean getRandomMissionStatus(User user) {
+		LocalDate today = LocalDate.now();
+
+		UserMission userMission = userMissionRepository.findByUserAndDate(user, today).orElse(null);
+
+		if (userMission == null || !userMission.getIsCompleted()) {
+			// 오늘자 랜덤미션이 아직 생성되지 않았거나 완료되지 않았을 때, false
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Random;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.user.dto.UserMissionResponseDto;
@@ -20,7 +21,6 @@ import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -71,7 +71,7 @@ public class UserMissionServiceImpl implements UserMissionService {
 			} else {
 				// --- 데이터는 있는데, 미션 할당이 안 된 경우 ---
 				userMission = optionalUserMission.get();
-				userMission.setMission(selectRandomMission(user));	// 미션만 할당
+				userMission.setMission(randomMission);	// 미션만 할당
 			}
 		} catch (DataIntegrityViolationException e) {
 			// 동시성 충돌 발생 시: DB에 이미  저장된 레코드를 재조회하여 복구
@@ -88,6 +88,7 @@ public class UserMissionServiceImpl implements UserMissionService {
 	}
 
 	@Override
+	@Transactional(readOnly = true)
 	public Boolean getRandomMissionStatus(User user) {
 		LocalDate today = LocalDate.now();
 

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
@@ -132,7 +133,7 @@ public class UserMissionServiceImpl implements UserMissionService {
 		}
 
 		// 랜덤 인덱스 생성
-		int randomIndex = new Random().nextInt(missionList.size());
+		int randomIndex = ThreadLocalRandom.current().nextInt(missionList.size());
 		return missionList.get(randomIndex);
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -74,7 +74,7 @@ public class UserMissionServiceImpl implements UserMissionService {
 				userMission.setMission(randomMission);	// 미션만 할당
 			}
 		} catch (DataIntegrityViolationException e) {
-			// 동시성 충돌 발생 시: DB에 이미  저장된 레코드를 재조회하여 복구
+			// 동시성 충돌 발생 시: DB에 이미 저장된 레코드를 재조회하여 복구
 			userMission = userMissionRepository.findByUserAndDate(user, today)
 				.orElseThrow(() -> {
 					log.error("동시성 충돌 복구 실패: UserMission 레코드를 찾을 수 없음. User ID: {}, Date: {}, DB Error: {}",
@@ -82,6 +82,11 @@ public class UserMissionServiceImpl implements UserMissionService {
 
 					return new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
 				});
+
+			// 재조회한 레코드에 미션이 없는 경우 할당
+			if (userMission.getMission() == null) {
+				userMission.setMission(selectRandomMission(user));
+			}
 		}
 
 		return convertToDetailDto(userMission);

--- a/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserMissionServiceImpl.java
@@ -1,38 +1,132 @@
 package com.hrr.backend.domain.user.service;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.user.dto.UserMissionResponseDto;
+import com.hrr.backend.domain.user.entity.RandomMission;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserMission;
+import com.hrr.backend.domain.user.repository.RandomMissionRepository;
+import com.hrr.backend.domain.user.repository.UserFavorRepository;
 import com.hrr.backend.domain.user.repository.UserMissionRepository;
+import com.hrr.backend.global.common.enums.Category;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class UserMissionServiceImpl implements UserMissionService {
 
 	private final UserMissionRepository userMissionRepository;
+	private final ChallengeRepository challengeRepository;
+	private final RandomMissionRepository randomMissionRepository;
+	private final UserFavorRepository userFavorRepository;
 
 	@Override
-	public UserMissionResponseDto.DetailDto getRandomMission(Long userId) {
-		return null;
+	@Transactional
+	public UserMissionResponseDto.DetailDto getRandomMission(User user) {
+		UserMission userMission;
+
+		//upsert 방식 적용
+		LocalDate today = LocalDate.now();
+
+		// 조회 먼저
+		Optional<UserMission> optionalUserMission = userMissionRepository.findByUserAndDate(user, today);
+
+		// 이미 미션이 있으면 바로 반환
+		if(optionalUserMission.isPresent() && optionalUserMission.get().getMission()!=null) {
+			return convertToDetailDto(optionalUserMission.get());
+		}
+
+		// 데이터가 없거나 미션이 배정되지 않았으면 생성 시도
+		try {
+			// 랜덤미션 선택
+			RandomMission randomMission = selectRandomMission(user);
+
+			if (optionalUserMission.isEmpty()) {
+				// --- 데이터가 없는 경우 ----
+
+				// UserMission 생성
+				userMission = UserMission.builder()
+					.user(user)
+					.mission(randomMission)
+					.date(today)
+					.isCompleted(false)
+					.build();
+
+				// DB에 저장 - 동시성 문제 발생 가능
+				userMissionRepository.save(userMission);
+			} else {
+				// --- 데이터는 있는데, 미션 할당이 안 된 경우 ---
+				userMission = optionalUserMission.get();
+				userMission.setMission(selectRandomMission(user));	// 미션만 할당
+			}
+		} catch (DataIntegrityViolationException e) {
+			// 동시성 충돌 발생 시: DB에 이미  저장된 레코드를 재조회하여 복구
+			userMission = userMissionRepository.findByUserAndDate(user, today)
+				.orElseThrow(() -> {
+					log.error("동시성 충돌 복구 실패: UserMission 레코드를 찾을 수 없음. User ID: {}, Date: {}, DB Error: {}",
+						user.getId(), today, e.getMessage(), e);
+
+					return new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
+				});
+		}
+
+		return convertToDetailDto(userMission);
 	}
 
 	@Override
 	public Boolean getRandomMissionStatus(User user) {
 		LocalDate today = LocalDate.now();
 
-		UserMission userMission = userMissionRepository.findByUserAndDate(user, today).orElse(null);
+		// UserMission을 조회하고, 존재하면 isCompleted 추출 / 없으면 false
+		return userMissionRepository.findByUserAndDate(user, today)
+			// 미션 기록이 존재하면 isCompleted 추출
+			.map(UserMission::getIsCompleted)
+			// 없으면 false 반환
+			.orElse(false);
+	}
 
-		if (userMission == null || !userMission.getIsCompleted()) {
-			// 오늘자 랜덤미션이 아직 생성되지 않았거나 완료되지 않았을 때, false
-			return false;
+	// 사용 빈도가 적을 것 같아 별도의 클래스가 아닌 private 메소드로 생성
+	private UserMissionResponseDto.DetailDto convertToDetailDto(UserMission userMission) {
+		return UserMissionResponseDto.DetailDto.builder()
+			.userMissionId(userMission.getId())
+			.title(userMission.getMission().getTitle())
+			.content(userMission.getMission().getContent())
+			.isCompleted(userMission.getIsCompleted())
+			.build();
+	}
+
+	private RandomMission selectRandomMission(User user) {
+		// 참가 중인 챌린지들의 카테고리 추출
+		List<Category> categoryList = challengeRepository.findCategoriesByUserId(user.getId());
+
+		// 참가 중인 챌린지가 없을 경우, 온보딩 시 선택한 선호 카테고리 적용
+		if (categoryList.isEmpty()) {
+			categoryList = userFavorRepository.findCategoriesByUserId(user.getId());
 		}
 
-		return true;
+		// 카테고리 리스트에 해당하는 미션 전체 조회
+		List<RandomMission> missionList = randomMissionRepository.findByCategoryIn(categoryList);
+
+		if (missionList.isEmpty()) {
+			throw new GlobalException(ErrorCode.RANDOM_MISSION_NOT_FOUND);
+		}
+
+		// 랜덤 인덱스 생성
+		int randomIndex = new Random().nextInt(missionList.size());
+		return missionList.get(randomIndex);
 	}
 }

--- a/src/main/java/com/hrr/backend/global/config/CustomUserDetails.java
+++ b/src/main/java/com/hrr/backend/global/config/CustomUserDetails.java
@@ -1,0 +1,67 @@
+package com.hrr.backend.global.config;
+
+import com.hrr.backend.domain.user.entity.User;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * Spring Security Context에 저장되는 사용자 인증 정보 객체
+ * User 엔티티를 래핑하여 DB 재조회 없이 사용자 정보에 접근할 수 있게 해줌
+ */
+@Getter
+public class CustomUserDetails implements UserDetails {
+	private final User user; // DB에서 조회된 실제 사용자 엔티티
+
+	public CustomUserDetails(User user) {
+		this.user = user;
+	}
+
+	// --- UserDetails 필수 메서드 override ---
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		// 모든 인증된 사용자에게 'ROLE_USER' 권한을 부여(임시)
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+
+/*		// User에서 권한을 가져와 부여
+		return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));*/
+	}
+
+	@Override
+	public String getPassword() {
+		// JWT 기반이므로 비밀번호는 미사용
+		return null;
+	}
+
+	@Override
+	public String getUsername() {
+		// 여기서의 name=사용자를 식별하는 고유값이기 떄문에 user_id를 사용
+		return String.valueOf(user.getId());
+	}
+
+	// JWT 기반에서는 토큰의 유효성으로 검증을 관리하므로 모두 true를 반환
+	@Override
+	public boolean isAccountNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isAccountNonLocked() {
+		return true;
+	}
+
+	@Override
+	public boolean isCredentialsNonExpired() {
+		return true;
+	}
+
+	@Override
+	public boolean isEnabled() {
+		return true;
+	}
+}

--- a/src/main/java/com/hrr/backend/global/config/CustomUserDetails.java
+++ b/src/main/java/com/hrr/backend/global/config/CustomUserDetails.java
@@ -25,11 +25,8 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public Collection<? extends GrantedAuthority> getAuthorities() {
-		// 모든 인증된 사용자에게 'ROLE_USER' 권한을 부여(임시)
-		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
-
-/*		// User에서 권한을 가져와 부여
-		return Collections.singletonList(new SimpleGrantedAuthority(user.getRole().name()));*/
+		// User에서 권한을 가져와 부여
+		return Collections.singletonList(new SimpleGrantedAuthority(user.getUserRole().name()));
 	}
 
 	@Override
@@ -40,7 +37,7 @@ public class CustomUserDetails implements UserDetails {
 
 	@Override
 	public String getUsername() {
-		// 여기서의 name=사용자를 식별하는 고유값이기 떄문에 user_id를 사용
+		// 여기서의 name=사용자를 식별하는 고유값이기 때문에 user_id를 사용
 		return String.valueOf(user.getId());
 	}
 

--- a/src/main/java/com/hrr/backend/global/config/CustomUserDetailsService.java
+++ b/src/main/java/com/hrr/backend/global/config/CustomUserDetailsService.java
@@ -5,6 +5,8 @@ import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
@@ -16,30 +18,40 @@ import org.springframework.stereotype.Service;
  */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class CustomUserDetailsService implements UserDetailsService {
 	private final UserRepository userRepository;
 
 	@Override
 	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
 		try {
-			// username을 Long 타입의 userId로 변환
+			// username을 Long 타입의 userId로 변환 - JWT에서 userId를 String 형태로 전달 받음
 			Long userId = Long.parseLong(username);
 
 			// DB에서 User 엔티티 조회
 			User user = userRepository.findById(userId)
 				.orElseThrow(() -> new GlobalException(ErrorCode.AUTH_USER_NOT_FOUND));
 
-			// 3. PrincipalDetails 객체로 변환하여 반환
+			// CustomUserDetails 객체로 변환하여 반환
 			return new CustomUserDetails(user);
 
 		}
 		// ---- Spring Security 표준 Exception 사용------
 		catch (NumberFormatException e) {
 			// ID 형식이 숫자가 아닌 경우
+			log.warn("userId 형식 오류 - username:{}",  username);
 			throw new UsernameNotFoundException("사용자 ID 형식이 올바르지 않습니다: " + username);
 		} catch (GlobalException e) {
 			// GlobalException을 UsernameNotFoundException으로 래핑하여 던집니다.
-			throw new UsernameNotFoundException(e.getMessage());
+			log.warn("GlobalException 발생 - username: {}, ErrorCode: {}, Message: {}", username, e.getErrorCode(), e.getMessage());
+
+			if (e.getErrorCode() == ErrorCode.AUTH_USER_NOT_FOUND) {
+				// 내부 상세 메시지를 숨겨 보안 향상
+				throw new UsernameNotFoundException("사용자를 찾을 수 없습니다.");
+			}
+
+			// 그 외 GlobalException 발생
+			throw new UsernameNotFoundException("사용자 인증 중 예기치 않은 오류가 발생했습니다.");
 		}
 	}
 }

--- a/src/main/java/com/hrr/backend/global/config/CustomUserDetailsService.java
+++ b/src/main/java/com/hrr/backend/global/config/CustomUserDetailsService.java
@@ -1,0 +1,45 @@
+package com.hrr.backend.global.config;
+
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+/**
+ * Spring Security에서 사용자 정보를 로드
+ * JWT에서 추출한 userId(username)를 기반으로 DB에서 사용자를 조회
+ */
+@Service
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+	private final UserRepository userRepository;
+
+	@Override
+	public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+		try {
+			// username을 Long 타입의 userId로 변환
+			Long userId = Long.parseLong(username);
+
+			// DB에서 User 엔티티 조회
+			User user = userRepository.findById(userId)
+				.orElseThrow(() -> new GlobalException(ErrorCode.AUTH_USER_NOT_FOUND));
+
+			// 3. PrincipalDetails 객체로 변환하여 반환
+			return new CustomUserDetails(user);
+
+		}
+		// ---- Spring Security 표준 Exception 사용------
+		catch (NumberFormatException e) {
+			// ID 형식이 숫자가 아닌 경우
+			throw new UsernameNotFoundException("사용자 ID 형식이 올바르지 않습니다: " + username);
+		} catch (GlobalException e) {
+			// GlobalException을 UsernameNotFoundException으로 래핑하여 던집니다.
+			throw new UsernameNotFoundException(e.getMessage());
+		}
+	}
+}

--- a/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
@@ -67,13 +67,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
             User user = optionalUser.get();
 
-            // Spring Security 인증 객체 생성
-/*            UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
-                    .username(String.valueOf(user.getId()))
-                    .password("") // JWT 기반이므로 비밀번호는 불필요
-                    .authorities("ROLE_USER")
-                    .build();*/
-
 			// CustomUserDetails 객체로 userDetails를 대신함
 			UserDetails userDetails = new CustomUserDetails(user);
 

--- a/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.hrr.backend.global.config.jwt;
 import com.hrr.backend.domain.auth.service.JwtService;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.config.CustomUserDetails;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import jakarta.servlet.FilterChain;
@@ -67,11 +68,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             User user = optionalUser.get();
 
             // Spring Security 인증 객체 생성
-            UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
+/*            UserDetails userDetails = org.springframework.security.core.userdetails.User.builder()
                     .username(String.valueOf(user.getId()))
                     .password("") // JWT 기반이므로 비밀번호는 불필요
                     .authorities("ROLE_USER")
-                    .build();
+                    .build();*/
+
+			// CustomUserDetails 객체로 userDetails를 대신함
+			UserDetails userDetails = new CustomUserDetails(user);
+
             //인증 객체 구성
             UsernamePasswordAuthenticationToken authentication =
                     new UsernamePasswordAuthenticationToken(

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -35,6 +35,9 @@ public enum ErrorCode implements BaseCode{
     AUTH_KAKAO_TOKEN_ERROR(HttpStatus.BAD_GATEWAY, "AUTH007", "카카오 토큰 요청 중 오류가 발생했습니다."),
     AUTH_KAKAO_USER_ERROR(HttpStatus.BAD_GATEWAY, "AUTH008", "카카오 사용자 정보 조회 중 오류가 발생했습니다."),
 
+	// mission
+	RANDOM_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "미션을 찾을 수 없습니다.")
+
     ;
 
 	private final HttpStatus status;

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -24,9 +24,7 @@ public enum ErrorCode implements BaseCode{
 	DM_MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "DM404", "존재하지 않는 대화입니다."),
 
 	// challenge
-	CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE404", "존재하지 않는 챌린지입니다.")
-
-	;
+	CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE404", "존재하지 않는 챌린지입니다."),
     // auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "유효하지 않은 토큰입니다."),
     AUTH_TOKEN_EXPIRED(HttpStatus.UNAUTHORIZED, "AUTH002", "토큰이 만료되었습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #35 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- UserMission, RandomMission 테이블 생성
- 오늘의 랜덤미션 완료 여부 조회 api 구현
- 오늘의 랜덤미션 조회 api 구현(upsert 방식)
    - 참가 중인 챌린지의 카테고리들(없으면 온보딩 시 선택한 선호 카테고리)에 해당하는 미션 중 하나를 랜덤하게 제공

- 사용자의 정보를 활용하기 위한 CustomUserDetails 구현
    - 플로우) 토큰에서 userId 추출→DB에서 User 엔티티 조회→CustomUserDetails 생성(기존에 사용하던 UserDetails를 커스텀)→CustomUserDetails를 SecurityContextHolder에 저장→추후 controller에서 접근 시 @AuthenticationPrincipal CustomUserDetails로 principle 객체 자체를 context에서 꺼내와 활용

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

api 명세에 추가했습니다.

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** postman 테스트
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

- 오늘의 랜덤미션 완료 여부 조회 api

| 데이터 없을 때 |
|---|
|<img width="1909" height="1024" alt="image" src="https://github.com/user-attachments/assets/8e591952-63f3-4621-8dda-db93d94ce578" />|

- 오늘의 랜덤미션 조회 api

|참가 중인 챌린지 없을 경우(사용자 선호에서 선택)|
|---|
|<img width="1904" height="1043" alt="image" src="https://github.com/user-attachments/assets/73fa921d-71c9-4e9f-bd33-670b081fefca" />|

|참가 중인 챌린지 있을 경우(참가 중 챌린지 아이디=3)|
|---|
|<img width="1905" height="1050" alt="image" src="https://github.com/user-attachments/assets/106bdfaa-ba87-4d63-b7e9-f8e3cbde4d26" />|
---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

CustomUserDetails 사용하여 사용자 정보 받아와 활용하는 플로우 숙지 바랍니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

CustomUserDetails 관련: https://wildeveloperetrain.tistory.com/324#google_vignette


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 일일 무작위 미션 조회 및 완료 상태 확인 API 추가
  * 사용자 미션 관련 엔티티 및 미션 저장/검색 기능 추가

* **개선사항**
  * 챌린지 클릭 응답을 표준 API 응답 구조로 변경
  * 사용자 인증 처리 개선(커스텀 사용자 정보 로딩 및 인증 흐름 통합)

* **기타**
  * macOS용 .gitignore 항목(.DS_Store) 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->