### PR TITLE
[REFACTOR] 인증 과정과 '오늘의 인기 챌린지 조회' 관련 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/auth/service/JwtService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/JwtService.java
@@ -17,12 +17,15 @@ public class JwtService {
     @Value("${jwt.secret}")
     private String secret;
 
-    //액세스 토큰 만료시간 (예: 30분)
-    private final long ACCESS_TOKEN_VALIDITY = 1000L * 60 * 30;
-    // 리프레시 토큰 만료시간 (예: 7일)
-    private final long REFRESH_TOKEN_VALIDITY = 1000L * 60 * 60 * 24 * 7;
+	//액세스 토큰 만료시간
+	@Value("${jwt.access-token-validity}")
+	private long accessTokenValidity;
 
-    private SecretKey getSigningKey() {
+	// 리프레시 토큰 만료시간
+	@Value("${jwt.refresh-token-validity}")
+	private long refreshTokenValidity;
+
+	private SecretKey getSigningKey() {
         return Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
     }
 
@@ -32,7 +35,7 @@ public class JwtService {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + ACCESS_TOKEN_VALIDITY))
+                .setExpiration(new Date(now.getTime() + accessTokenValidity))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }
@@ -44,7 +47,7 @@ public class JwtService {
         return Jwts.builder()
                 .setSubject(String.valueOf(userId))
                 .setIssuedAt(now)
-                .setExpiration(new Date(now.getTime() + REFRESH_TOKEN_VALIDITY))
+                .setExpiration(new Date(now.getTime() + refreshTokenValidity))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
                 .compact();
     }

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -2,6 +2,7 @@ package com.hrr.backend.domain.challenge.controller;
 
 import java.util.List;
 
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,12 +22,15 @@ import com.hrr.backend.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @Tag(name = "Challenge", description = "챌린지 관련 API")
 @RestController
 @RequestMapping("/api/v1/challenges")
 @RequiredArgsConstructor
+@Validated
 public class ChallengeController {
 
 	private final ChallengeService challengeService;
@@ -77,7 +81,10 @@ public class ChallengeController {
 
 	@GetMapping("/daily-top")
 	@Operation(summary = "오늘의 인기 챌린지 조회", description = "오늘의 클릭 수를 기준으로 상위 n개 챌린지를 조회합니다.")
-	public ApiResponse<List<ChallengeResponseDto.DailyTopDto>> getDailyTopChallenges(@RequestParam("number") int number) {
+	public ApiResponse<List<ChallengeResponseDto.DailyTopDto>> getDailyTopChallenges(
+		@RequestParam("number")
+		@Min(value = 1, message = "조회 개수는 1 이상이어야 합니다")
+		@Max(value = 50, message = "성능상 조회 개수는 50 이하로 제한하고 있습니다.") int number) {
 
 		return ApiResponse.onSuccess(SuccessCode.OK, challengeService.getDailyTopChallenges(number));
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -76,9 +76,9 @@ public class ChallengeController {
 	}
 
 	@GetMapping("/daily-top")
-	@Operation(summary = "오늘의 인기 챌린지 조회", description = "오늘의 클릭 수를 기준으로 상위 3개 챌린지를 조회합니다.")
-	public ApiResponse<List<ChallengeResponseDto.DailyTopDto>> getDailyTopChallenges() {
+	@Operation(summary = "오늘의 인기 챌린지 조회", description = "오늘의 클릭 수를 기준으로 상위 n개 챌린지를 조회합니다.")
+	public ApiResponse<List<ChallengeResponseDto.DailyTopDto>> getDailyTopChallenges(@RequestParam("number") int number) {
 
-		return ApiResponse.onSuccess(SuccessCode.OK, challengeService.getDailyTopChallenges());
+		return ApiResponse.onSuccess(SuccessCode.OK, challengeService.getDailyTopChallenges(number));
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -29,7 +29,7 @@ public interface ChallengeService {
 	Long clickChallenge(Long challengeId);
 
 	// 오늘의 인기 챌린지 조회
-	List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges();
+	List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges(int number);
 
 
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.function.Function;
@@ -158,16 +159,24 @@ public class ChallengeServiceImpl implements ChallengeService {
 	@Override
 	public List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges(int number) {
 
-		// Top 3 조회
+		// 현재 목록 개수 범위를 넘어서면 있는 만큼 반환(UX 고려)
+		long currentListSize = Optional.ofNullable(
+			redisTemplate.opsForZSet().size(TODAY_CHALLENGE_RANKING_KEY)).orElse(0L);
+
+		// 데이터가 없을 경우 (아마 00시 직후) 빈 리스트 반환
+		if (currentListSize == 0) {
+			return Collections.emptyList();
+		}
+
+		if(number > currentListSize){
+			number = (int)currentListSize;
+		}
+
+		// Top N 조회
 		Set<ZSetOperations.TypedTuple<String>> topRankings = redisTemplate.opsForZSet().reverseRangeWithScores(
 			TODAY_CHALLENGE_RANKING_KEY,
 			0, number-1
 		);
-
-		// 데이터가 없을 경우 (아마 00시 직후) 빈 리스트 반환
-		if (topRankings == null || topRankings.isEmpty()) {
-			return Collections.emptyList();
-		}
 
 		// <챌린지 id, 클릭 수> 로딩
 		Map<Long, Long> clicksMap = topRankings.stream()

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -156,12 +156,12 @@ public class ChallengeServiceImpl implements ChallengeService {
 	}
 
 	@Override
-	public List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges() {
+	public List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges(int number) {
 
 		// Top 3 조회
 		Set<ZSetOperations.TypedTuple<String>> topRankings = redisTemplate.opsForZSet().reverseRangeWithScores(
 			TODAY_CHALLENGE_RANKING_KEY,
-			0, 2
+			0, number-1
 		);
 
 		// 데이터가 없을 경우 (아마 00시 직후) 빈 리스트 반환

--- a/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/hrr/backend/global/config/jwt/JwtAuthenticationFilter.java
@@ -46,48 +46,42 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
         String token = jwtService.resolveToken(request);
 
-        // 헤더에 토큰이 없으면 그냥 다음 필터로 진행
-        if (token == null) {
-            chain.doFilter(request, response);
-            return;
-        }
+        // 헤더에 토큰이 있고, SecurityContext에 인증 정보가 없는 경우에만 인증 처리
+        if (token != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+            try {
+                // 토큰 검증 (유효하지 않으면 GlobalException 던짐)
+                jwtService.validateToken(token);
 
-        try {
-            // 토큰 검증 (유효하지 않으면 GlobalException 던짐)
-            jwtService.validateToken(token);
+                // userId 추출
+                Long userId = jwtService.extractUserId(token);
 
-            // userId 추출
-            Long userId = jwtService.extractUserId(token);
+                // DB에서 유저 조회
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new GlobalException(ErrorCode.AUTH_USER_NOT_FOUND));
 
-            // DB에서 유저 조회
-            Optional<User> optionalUser = userRepository.findById(userId);
-            if (optionalUser.isEmpty()) {
-                throw new GlobalException(ErrorCode.AUTH_USER_NOT_FOUND);
+                // CustomUserDetails 객체로 userDetails를 대신함
+                UserDetails userDetails = new CustomUserDetails(user);
+
+                //인증 객체 구성
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails,
+                                null,
+                                userDetails.getAuthorities()
+                        );
+
+                authentication.setDetails(
+                        new WebAuthenticationDetailsSource().buildDetails(request)
+                );
+
+                // SecurityContext에 인증 객체 저장
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            } catch (GlobalException e) {
+                // 토큰 오류 시 SecurityContext를 비우고, 예외를 request에 저장
+                SecurityContextHolder.clearContext();
+                request.setAttribute("jwtException", e);
             }
-
-            User user = optionalUser.get();
-
-			// CustomUserDetails 객체로 userDetails를 대신함
-			UserDetails userDetails = new CustomUserDetails(user);
-
-            //인증 객체 구성
-            UsernamePasswordAuthenticationToken authentication =
-                    new UsernamePasswordAuthenticationToken(
-                            userDetails,
-                            null,
-                            userDetails.getAuthorities()
-                    );
-
-            authentication.setDetails(
-                    new WebAuthenticationDetailsSource().buildDetails(request)
-            );
-
-            // SecurityContext에 인증 객체 저장
-            SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        } catch (GlobalException e) {
-            // 토큰 오류 시 필터 체인만 통과 (예외 전파 X)
-            request.setAttribute("jwtException", e);
         }
 
         chain.doFilter(request, response);

--- a/src/main/java/com/hrr/backend/global/exception/ExceptionAdvice.java
+++ b/src/main/java/com/hrr/backend/global/exception/ExceptionAdvice.java
@@ -35,7 +35,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 			.findFirst()
 			.orElse(null);
 
-		return handleExceptionInternalConstraint(e, ErrorCode.valueOf(message), HttpHeaders.EMPTY,request);
+		return handleExceptionInternalFalse(e, ErrorCode._BAD_REQUEST, HttpHeaders.EMPTY, HttpStatus.BAD_REQUEST, request, message);
 	}
 
 	@Override

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,8 +20,8 @@ springdoc:
 
 jwt:
   secret : ${JWT_SECRET}
-  access-token-validity : 1800000L           # 1000L * 60 * 30 (30분) : 임시
-  refresh-token-validity : 604800000L       # 1000L * 60 * 60 * 24 * 7 (7일) : 임시
+  access-token-validity : 1800000           # 1000L * 60 * 30 (30분) : 임시
+  refresh-token-validity : 604800000       # 1000L * 60 * 60 * 24 * 7 (7일) : 임시
 
 #카카오 로그인
 kakao:

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -20,8 +20,8 @@ springdoc:
 
 jwt:
   secret : ${JWT_SECRET}
-  access-token-validity : 2592000000           # 임시
-  refresh-token-validity : 2592000000       # 임시
+  access-token-validity : 1800000L           # 1000L * 60 * 30 (30분) : 임시
+  refresh-token-validity : 604800000L       # 1000L * 60 * 60 * 24 * 7 (7일) : 임시
 
 #카카오 로그인
 kakao:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -20,8 +20,8 @@ springdoc:
 
 jwt:
   secret : ${JWT_SECRET}
-  access-token-validity : 1800000L           # 1000L * 60 * 30 (30분)
-  refresh-token-validity : 604800000L       # 1000L * 60 * 60 * 24 * 7 (7일)
+  access-token-validity : 1800000           # 1000L * 60 * 30 (30분)
+  refresh-token-validity : 604800000       # 1000L * 60 * 60 * 24 * 7 (7일)
 
 #카카오 로그인
 kakao:

--- a/src/main/resources/application-docker.yml
+++ b/src/main/resources/application-docker.yml
@@ -20,8 +20,8 @@ springdoc:
 
 jwt:
   secret : ${JWT_SECRET}
-  access-token-validity : 2592000000           # 임시
-  refresh-token-validity : 2592000000       # 임시
+  access-token-validity : 1800000L           # 1000L * 60 * 30 (30분)
+  refresh-token-validity : 604800000L       # 1000L * 60 * 60 * 24 * 7 (7일)
 
 #카카오 로그인
 kakao:


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #37 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 카카오 로그인을 계속 다시 해야한다 해서 jwt 인증 과정을 점검하였습니다. 확인 결과 문제는 없고 엑세스 토큰 유효시간이 30분이라 아마 30분마다 재발급을 받은 게 아닌가 싶습니다. 리프레시 토큰은 7일 동안 유효하니 카카오 로그인이 귀찮다면 '토큰 재발급' 사용하셔도 됩니다. 단 이 때는 Bearer 뒤에 붙이는 토큰이 엑세스 토큰이 아닌 리프레시 토큰이어야 합니다!!(이거 놓치고 헛고생 좀 했습니다..)
- 리팩토링 하는 김에 jwt 유효시간을 개발 환경별로 수정할 수 있게 변경하였습니다. 재발급 과정이 귀찮으신 분들은 application-local.yml에서 엑세스 토큰 유효시간을 더 늘려서 사용하셔도 됩니다.
- 오늘의 인기 챌린지 조회 시 필요한 챌린지 개수가 증가함에 따라 원하는 개수를 파라미터로 받을 수 있게 변경하였습니다.(현재 목록 개수보다 많을 시 최대치만큼만 반환됩니다.)

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

api 명세 및 application 파일 수정 완료

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Postman
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 6개 있는데 10개 조회 테스트 |
|---|
|<img width="1434" height="791" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/e87a437f-8896-4808-91bb-687585ba35fe" />|


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 일일 상위 챌린지를 조회할 때 반환 개수를 요청 파라미터로 지정할 수 있으며(1~50 범위 검증), 상위 N개를 반환합니다.

* **버그 수정**
  * JWT 기반 인증 처리 흐름이 강화되어 인증 안정성과 오류 처리(누락 사용자 처리 및 예외 정리)가 개선되었습니다.
  * 유효성 검사 오류 응답이 일관된 BAD_REQUEST 형태로 반환됩니다.

* **기타**
  * 토큰 유효 기간이 조정되었습니다. (액세스: 30분, 리프레시: 7일)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->