### PR TITLE
[Feat] 챌린지 참가 API 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -22,7 +22,6 @@ import com.hrr.backend.global.response.SliceResponseDto;
 import com.hrr.backend.global.response.SuccessCode;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -120,7 +119,7 @@ public class ChallengeController {
 			)
 	)
 	@PostMapping("")
-	public ApiResponse<ChallengeResponseDto.CreateChallengeResDto> createChallenge(
+	public ApiResponse<ChallengeResponseDto.CreateChallengeDto> createChallenge(
 			@Parameter(hidden = true)
 			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@Valid @RequestBody ChallengeRequestDto.CreateChallengeDto request
@@ -137,7 +136,7 @@ public class ChallengeController {
 			description = "사용자가 특정 챌린지에 참가합니다. 비공개 챌린지인 경우 비밀번호 검증이 수행됩니다."
 	)
 	@PostMapping("/{challengeId}/join")
-	public ApiResponse<ChallengeResponseDto.JoinChallengeResDto> joinChallenge(
+	public ApiResponse<ChallengeResponseDto.JoinChallengeDto> joinChallenge(
 			@Parameter(hidden = true)
 			@AuthenticationPrincipal CustomUserDetails userDetails,
 

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -139,10 +139,8 @@ public class ChallengeController {
 	public ApiResponse<ChallengeResponseDto.JoinChallengeDto> joinChallenge(
 			@Parameter(hidden = true)
 			@AuthenticationPrincipal CustomUserDetails userDetails,
-
 			@PathVariable("challengeId") Long challengeId,
-
-			@RequestBody ChallengeRequestDto.JoinChallengeDto request
+			@Valid @RequestBody ChallengeRequestDto.JoinChallengeDto request
 	) {
 		Long userId = userDetails.getUser().getId();
 

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -131,4 +131,25 @@ public class ChallengeController {
 				challengeService.createChallenge(userId, request)
 		);
 	}
+
+	@Operation(
+			summary = "챌린지 참가",
+			description = "사용자가 특정 챌린지에 참가합니다. 비공개 챌린지인 경우 비밀번호 검증이 수행됩니다."
+	)
+	@PostMapping("/{challengeId}/join")
+	public ApiResponse<ChallengeResponseDto.JoinChallengeResDto> joinChallenge(
+			@Parameter(hidden = true)
+			@AuthenticationPrincipal CustomUserDetails userDetails,
+
+			@PathVariable("challengeId") Long challengeId,
+
+			@RequestBody ChallengeRequestDto.JoinChallengeDto request
+	) {
+		Long userId = userDetails.getUser().getId();
+
+		return ApiResponse.onSuccess(
+				SuccessCode.OK,
+				challengeService.joinChallenge(userId, challengeId, request)
+		);
+	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -52,7 +52,7 @@ public class ChallengeConverter {
         return challenge;
     }
 
-    public ChallengeResponseDto.CreateChallengeResDto toCreateResponseDto(Challenge challenge) {
-        return new ChallengeResponseDto.CreateChallengeResDto(challenge.getId());
+    public ChallengeResponseDto.CreateChallengeDto toCreateResponseDto(Challenge challenge) {
+        return new ChallengeResponseDto.CreateChallengeDto(challenge.getId());
     }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -86,6 +86,7 @@ public class ChallengeRequestDto {
     public static class JoinChallengeDto {
 
         @Schema(description = "비공개 챌린지 비밀번호 (공개일 경우 null 또는 빈 값)", example = "1234")
+        @Size(max = 4)
         private String password;
     }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -79,4 +79,13 @@ public class ChallengeRequestDto {
         @Schema(description = "챌린지 이미지 URL (없으면 서버에서 기본 이미지 사용)", example = "https://example.com/images/challenge-default.png")
         private String imageUrl;
     }
+
+    @Getter
+    @NoArgsConstructor
+    @Schema(description = "챌린지 참가 요청 DTO")
+    public static class JoinChallengeDto {
+
+        @Schema(description = "비공개 챌린지 비밀번호 (공개일 경우 null 또는 빈 값)", example = "1234")
+        private String password;
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -86,7 +86,7 @@ public class ChallengeRequestDto {
     public static class JoinChallengeDto {
 
         @Schema(description = "비공개 챌린지 비밀번호 (공개일 경우 null 또는 빈 값)", example = "1234")
-        @Size(max = 4)
+        @Pattern(regexp = "^\\d{4}$", message = "비밀번호는 4자리 숫자여야 합니다.")
         private String password;
     }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -81,4 +81,13 @@ public class ChallengeResponseDto {
 		private Long id;
 	}
 
+	@Getter
+	@AllArgsConstructor
+	@Schema(description = "챌린지 참가 응답 DTO")
+	public static class JoinChallengeResDto {
+
+		@Schema(description = "참가한 챌린지 ID", example = "1")
+		private Long challengeId;
+	}
+
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -75,7 +75,7 @@ public class ChallengeResponseDto {
 	@Getter
 	@AllArgsConstructor
 	@Schema(description = "챌린지 개설 응답 DTO")
-	public static class CreateChallengeResDto {
+	public static class CreateChallengeDto {
 
 		@Schema(description = "생성된 챌린지 ID", example = "1")
 		private Long id;
@@ -84,7 +84,7 @@ public class ChallengeResponseDto {
 	@Getter
 	@AllArgsConstructor
 	@Schema(description = "챌린지 참가 응답 DTO")
-	public static class JoinChallengeResDto {
+	public static class JoinChallengeDto {
 
 		@Schema(description = "참가한 챌린지 ID", example = "1")
 		private Long challengeId;

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
@@ -93,4 +93,9 @@ public class Challenge extends BaseEntity {
     @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = false)
     private List<RecommendationResult> recommendationResults = new ArrayList<>();
 
+	// 참가자 수 증가 편의 메서드
+	public void increaseCurrentParticipants() {
+		this.currentParticipants++;
+	}
+
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -38,4 +38,11 @@ public interface ChallengeService {
 			ChallengeRequestDto.CreateChallengeDto requestDto
 	);
 
+	// 챌린지 참가
+	ChallengeResponseDto.JoinChallengeResDto joinChallenge(
+			Long userId,
+			Long challengeId,
+			ChallengeRequestDto.JoinChallengeDto requestDto
+	);
+
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -33,13 +33,13 @@ public interface ChallengeService {
 	List<ChallengeResponseDto.DailyTopDto> getDailyTopChallenges(int number);
 
 	// 챌린지 생성
-	ChallengeResponseDto.CreateChallengeResDto createChallenge(
+	ChallengeResponseDto.CreateChallengeDto createChallenge(
 			Long userId,
 			ChallengeRequestDto.CreateChallengeDto requestDto
 	);
 
 	// 챌린지 참가
-	ChallengeResponseDto.JoinChallengeResDto joinChallenge(
+	ChallengeResponseDto.JoinChallengeDto joinChallenge(
 			Long userId,
 			Long challengeId,
 			ChallengeRequestDto.JoinChallengeDto requestDto

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -21,6 +21,7 @@ import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -350,8 +351,13 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 		// 참가 처리
 		UserChallenge userChallenge = userChallengeConverter.toChallenger(user, challenge);
-		userChallengeRepository.save(userChallenge);
 
+		try {
+			userChallengeRepository.save(userChallenge);
+		} catch (DataIntegrityViolationException e) {
+			// DB 수준에서 중복(Unique 제약조건 위배) 발생 시, 우리가 정의한 에러로 변환
+			throw new GlobalException(ErrorCode.CHALLENGE_ALREADY_JOINED);
+		}
 		// 챌린지 인원 업데이트
 		challenge.increaseCurrentParticipants();
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -18,9 +18,9 @@ import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.user.converter.UserChallengeConverter;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
-import com.hrr.backend.domain.user.entity.enums.UserChallengeRole;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -331,6 +331,33 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return challengeConverter.toCreateResponseDto(saved);
 	}
 
+	@Override
+	@Transactional
+	public ChallengeResponseDto.JoinChallengeResDto joinChallenge(
+			Long userId,
+			Long challengeId,
+			ChallengeRequestDto.JoinChallengeDto req
+	) {
+		// 엔티티 조회
+		Challenge challenge = challengeRepository.findById(challengeId)
+				.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+		User user = userRepository.findById(userId)
+				.orElseThrow(() -> new GlobalException(ErrorCode.AUTH_USER_NOT_FOUND));
+
+		// 비즈니스 룰 검증
+		validateJoinRequest(challenge, user, req.getPassword());
+
+		// 참가 처리
+		UserChallenge userChallenge = userChallengeConverter.toChallenger(user, challenge);
+		userChallengeRepository.save(userChallenge);
+
+		// 챌린지 인원 업데이트
+		challenge.increaseCurrentParticipants();
+
+		return new ChallengeResponseDto.JoinChallengeResDto(challenge.getId());
+	}
+
 	private void validateBusinessRules(ChallengeRequestDto.CreateChallengeDto req) {
 		// 인증 시간 검증: 종료 시간 > 시작 시간
 		if (!req.getVerifyEndTime().isAfter(req.getVerifyStartTime())) {
@@ -352,6 +379,33 @@ public class ChallengeServiceImpl implements ChallengeService {
 			// 공개인데 비밀번호가 입력된 경우
 			if (req.getPassword() != null && !req.getPassword().isBlank()) {
 				throw new GlobalException(ErrorCode.CHALLENGE_PUBLIC_PASSWORD_INPUT);
+			}
+		}
+	}
+
+	/**
+	 * 챌린지 참가 요청에 대한 비즈니스 검증 로직
+	 */
+	private void validateJoinRequest(Challenge challenge, User user, String inputPassword) {
+		// 모집 상태 검증 (UPCOMING 상태인지)
+		if (challenge.getStatus() != ChallengeStatus.UPCOMING) {
+			throw new GlobalException(ErrorCode.CHALLENGE_NOT_RECRUITING);
+		}
+
+		// 중복 참가 검증
+		if (userChallengeRepository.existsByUserAndChallenge(user, challenge)) {
+			throw new GlobalException(ErrorCode.CHALLENGE_ALREADY_JOINED);
+		}
+
+		// 정원 초과 검증
+		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
+			throw new GlobalException(ErrorCode.CHALLENGE_FULL);
+		}
+
+		// 비밀번호 검증 (비공개 챌린지인 경우)
+		if (!challenge.getIsPublic()) {
+			if (inputPassword == null || !inputPassword.equals(challenge.getPassword())) {
+				throw new GlobalException(ErrorCode.CHALLENGE_PASSWORD_MISMATCH);
 			}
 		}
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -293,7 +293,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 	@Override
 	@Transactional
-	public ChallengeResponseDto.CreateChallengeResDto createChallenge(
+	public ChallengeResponseDto.CreateChallengeDto createChallenge(
 			Long userId,
 			ChallengeRequestDto.CreateChallengeDto req
 	) {
@@ -333,7 +333,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 	@Override
 	@Transactional
-	public ChallengeResponseDto.JoinChallengeResDto joinChallenge(
+	public ChallengeResponseDto.JoinChallengeDto joinChallenge(
 			Long userId,
 			Long challengeId,
 			ChallengeRequestDto.JoinChallengeDto req
@@ -355,7 +355,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 챌린지 인원 업데이트
 		challenge.increaseCurrentParticipants();
 
-		return new ChallengeResponseDto.JoinChallengeResDto(challenge.getId());
+		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
 	}
 
 	/**

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -298,7 +298,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 			ChallengeRequestDto.CreateChallengeDto req
 	) {
 		// 비즈니스 룰 검증
-		validateBusinessRules(req);
+		validateCreateRequest(req);
 
 		boolean isPublic = req.getIsPublic();
 		boolean isViewerMode = isPublic && req.getIsViewerMode();
@@ -358,7 +358,10 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return new ChallengeResponseDto.JoinChallengeResDto(challenge.getId());
 	}
 
-	private void validateBusinessRules(ChallengeRequestDto.CreateChallengeDto req) {
+	/**
+	 * 챌린지 생성 요청에 대한 비즈니스 검증 로직
+	 */
+	private void validateCreateRequest(ChallengeRequestDto.CreateChallengeDto req) {
 		// 인증 시간 검증: 종료 시간 > 시작 시간
 		if (!req.getVerifyEndTime().isAfter(req.getVerifyStartTime())) {
 			throw new GlobalException(ErrorCode.CHALLENGE_INVALID_VERIFY_TIME);

--- a/src/main/java/com/hrr/backend/domain/user/converter/UserChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/user/converter/UserChallengeConverter.java
@@ -17,4 +17,13 @@ public class UserChallengeConverter {
                 .role(UserChallengeRole.OWNER)
                 .build();
     }
+
+    // 챌린지 참가자를 CHALLENGER로 매핑하는 UserChallenge 생성
+    public UserChallenge toChallenger(User user, Challenge challenge) {
+        return UserChallenge.builder()
+                .user(user)
+                .challenge(challenge)
+                .role(UserChallengeRole.CHALLENGER)
+                .build();
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
@@ -17,7 +17,12 @@ import org.hibernate.annotations.ColumnDefault;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "user_challenge")
+@Table(
+        name = "user_challenge",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "challenge_id"})
+        }
+)
 public class UserChallenge extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepository.java
@@ -1,7 +1,10 @@
 package com.hrr.backend.domain.user.repository;
 
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserChallengeRepository extends JpaRepository<UserChallenge, Long> {
+    boolean existsByUserAndChallenge(User user, Challenge challenge);
 }

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -30,6 +30,10 @@ public enum ErrorCode implements BaseCode{
 	CHALLENGE_PRIVATE_VIEWER_MODE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "CHALLENGE4003", "비공개 챌린지는 관찰자 모드를 사용할 수 없습니다."),
 	CHALLENGE_INVALID_MAX_PARTICIPANTS(HttpStatus.BAD_REQUEST, "CHALLENGE4004", "참가자 수는 1명 이상이어야 합니다."),
 	CHALLENGE_PUBLIC_PASSWORD_INPUT(HttpStatus.BAD_REQUEST, "CHALLENGE4005", "공개 챌린지는 비밀번호를 설정할 수 없습니다."),
+	CHALLENGE_ALREADY_JOINED(HttpStatus.CONFLICT, "CHALLENGE4091", "이미 참가한 챌린지입니다."),
+	CHALLENGE_FULL(HttpStatus.CONFLICT, "CHALLENGE4092", "챌린지 정원이 초과되었습니다."),
+	CHALLENGE_PASSWORD_MISMATCH(HttpStatus.BAD_REQUEST, "CHALLENGE4006", "비밀번호가 일치하지 않습니다."),
+	CHALLENGE_NOT_RECRUITING(HttpStatus.BAD_REQUEST, "CHALLENGE4007", "모집 중인 챌린지가 아닙니다."),
 
 	// auth
     AUTH_INVALID_TOKEN(HttpStatus.UNAUTHORIZED, "AUTH001", "유효하지 않은 토큰입니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #43 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

사용자가 특정 챌린지에 참가하는 기능(`POST /api/v1/challenges/{challengeId}/join`)을 구현했습니다.

* **API 엔드포인트 구현**: 챌린지 ID를 path variable로, (비공개인 경우) 비밀번호를 body로 받아 참가 요청을 처리합니다.
* **비즈니스 검증 로직 구현 (`validateJoinRequest`)**:
    * **상태 검증**: 모집 중(`UPCOMING`)인 챌린지인지 확인
    * **중복 검증**: 이미 참가한 유저인지 확인 (`UserChallengeRepository`)
    * **정원 검증**: 최대 인원(`maxParticipants`)을 초과하지 않는지 확인
    * **비밀번호 검증**: 비공개 챌린지의 경우 입력된 비밀번호 일치 여부 확인
* **데이터 처리**:
    * `UserChallenge` 엔티티 생성 (Role: `CHALLENGER`) 및 저장
    * `Challenge` 엔티티의 `currentParticipants` (현재 인원) 증가 처리
* **응답 처리**: 참가 성공 시 해당 `challengeId`를 반환합니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 스웨거를 이용한 API 요청 테스트
* **결과 요약:**
    1.  **정상 참가:** 공개/비공개 챌린지 참가 성공 및 DB 반영 확인 (UserChallenge 생성, 인원수 증가)
    2.  **예외 처리:**
        * 비밀번호 불일치 시 `CHALLENGE_PASSWORD_MISMATCH` 반환 확인
        * 이미 참가한 챌린지 요청 시 `CHALLENGE_ALREADY_JOINED` 반환 확인
        * 정원 초과 시 `CHALLENGE_FULL` 반환 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
#### 요청 성공
<img width="1171" height="356" alt="image" src="https://github.com/user-attachments/assets/e3b5f32d-47b8-4a8f-bf1e-d604ebb2e5e1" />

#### 중복 참가
<img width="1173" height="331" alt="image" src="https://github.com/user-attachments/assets/3b5447d6-88f0-4693-ae03-43f543ad4a54" />

#### 비밀번호 불일치
<img width="1171" height="325" alt="image" src="https://github.com/user-attachments/assets/2fba84ec-854c-429b-9efa-04c826af06bf" />

#### 모집 중이 아닌 챌린지
<img width="1165" height="316" alt="image" src="https://github.com/user-attachments/assets/c562d53b-b120-4380-ae99-e0265cabec8b" />

#### 챌린지 정원 초과
<img width="1172" height="328" alt="image" src="https://github.com/user-attachments/assets/5694fd06-2b41-44b6-a6b7-a2a18e65559e" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
1.  **비즈니스 로직 분리**: `ChallengeServiceImpl`에서 검증 로직이 길어져 `validateJoinRequest`라는 별도의 private 메서드로 분리했습니다. 가독성 측면에서 괜찮은지 확인 부탁드립니다.
2.  **도메인 로직**: 챌린지 참여 인원 증가 로직을 Setter 대신 `challenge.increaseCurrentParticipants()`라는 편의 메서드로 구현했습니다.
3.  **동시성 이슈**: 현재는 DB Lock 없이 구현되어 있는데, 추후 인원이 몰릴 경우 정원 초과 문제가 발생할 가능성이 있어 보입니다. 이 부분은 추후 고도화 단계에서 개선할 예정입니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 사용자가 기존 챌린지에 참가할 수 있는 신규 API 추가(비공개 챌린지 비밀번호 입력 지원)
* **버그 수정 / 개선**
  * 중복 참가 차단 및 정원 초과 방지 로직 추가
  * 참가 성공 시 챌린지의 참여자 수가 즉시 반영되도록 개선
  * 챌린지 생성 응답 형식이 일부 변경됨 (클라이언트 주의)

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->