### PR TITLE
[Feat] 라운드 시스템 도입을 위한 엔티티 설계 및 기반 로직 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -18,8 +18,7 @@ public class ChallengeConverter {
             ChallengeRequestDto.CreateChallengeDto req,
             boolean isPublic,
             boolean isViewerMode,
-            String password,
-            String imageUrl
+            String password
     ) {
         Challenge challenge = Challenge.builder()
                 .isPublic(isPublic)
@@ -36,7 +35,7 @@ public class ChallengeConverter {
                 .rule(req.getRule())
                 .currentParticipants(1)
                 .status(ChallengeStatus.UPCOMING)
-                .imageUrl(imageUrl)
+                .imageUrl(req.getImageUrl())
                 .likeCount(0)
                 .build();
 

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -76,7 +76,8 @@ public class ChallengeRequestDto {
         @NotEmpty(message = "daysOfWeek는 최소 1개 이상이어야 합니다.")
         private List<ChallengeDays> daysOfWeek;
 
-        @Schema(description = "챌린지 이미지 URL (없으면 서버에서 기본 이미지 사용)", example = "https://example.com/images/challenge-default.png")
+        @Schema(description = "챌린지 이미지 URL", example = "https://example.com/images/my-challenge.png")
+        @NotBlank(message = "챌린지 대표 이미지는 필수입니다.")
         private String imageUrl;
     }
 

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
@@ -5,6 +5,7 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.global.common.BaseEntity;
 import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
@@ -25,9 +26,21 @@ import lombok.NoArgsConstructor;
 @Table(name = "challenge")
 @Builder
 public class Challenge extends BaseEntity {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+
+	// 비즈니스 규칙
+	public static final int ROUND_WEEKS = 3;              // 챌린지 1라운드 길이 (3주)
+	public static final int OWNER_DECISION_DAYS = 5;      // 방장 연장 결정 (종료 5일 전)
+	public static final int CHALLENGER_DECISION_DAYS = 3; // 팀원 연장 결정 (종료 3일 전)
+	public static final int FINALIZATION_DAYS = 1;        // 최종 확정 및 신규 모집 (종료 1일 전)
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	// 현재 진행 중인 라운드
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "current_round_id")
+	private Round currentRound;
 
 	@Column(name = "is_public", nullable = false)
 	private Boolean isPublic;
@@ -74,7 +87,7 @@ public class Challenge extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "status", nullable = false, length = 20)
 	@Builder.Default
-	private ChallengeStatus status=ChallengeStatus.UPCOMING;
+	private ChallengeStatus status = ChallengeStatus.UPCOMING;
 
 	@Column(name = "image_url")
 	private String imageUrl;
@@ -86,16 +99,20 @@ public class Challenge extends BaseEntity {
 	@Builder.Default
 	private List<ChallengeDayJoin> challengeDays = new ArrayList<>();
 
-    @OneToOne(mappedBy = "challenge", cascade = CascadeType.ALL)
-    private ChallengeEmbedding embedding;
+	@OneToOne(mappedBy = "challenge", cascade = CascadeType.ALL)
+	private ChallengeEmbedding embedding;
 
-    @Builder.Default
-    @OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = false)
-    private List<RecommendationResult> recommendationResults = new ArrayList<>();
+	@Builder.Default
+	@OneToMany(mappedBy = "challenge", cascade = CascadeType.ALL, orphanRemoval = false)
+	private List<RecommendationResult> recommendationResults = new ArrayList<>();
 
 	// 참가자 수 증가 편의 메서드
 	public void increaseCurrentParticipants() {
 		this.currentParticipants++;
 	}
 
+	// 라운드 교체
+	public void changeCurrentRound(Round round) {
+		this.currentRound = round;
+	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -123,40 +123,6 @@ public class ChallengeServiceImpl implements ChallengeService {
 				pageable
 		);
 
-		// // ---응답 dto에 추가할 요일 정보 조회---
-		// // 모든 challengeId 추출
-		// List<Long> challengeIds = tempDtoSlice.getContent().stream()
-		// 	.map(ChallengeResponseDto.InfoDto::getChallengeId)
-		// 	.toList();
-		//
-		// // 해당 challenge들을 가진 ChallengeDayJoin 엔티티 조회
-		// List<ChallengeDayJoin> allDays = challengeDayJoinRepository.findByChallengeIdIn(challengeIds);
-		//
-		// // 챌린지 아이디-요일 리스트 매핑
-		// Map<Long, List<ChallengeDays>> daysMap = allDays.stream()
-		// 	.collect(Collectors.groupingBy(
-		// 		dayJoin -> dayJoin.getChallenge().getId(), // key: 챌린지 아이디
-		// 		Collectors.mapping(ChallengeDayJoin::getDayOfWeek, Collectors.toList()) // value: 요일 리스트
-		// 	));
-		//
-		//
-		// // Repository에서 조회해 온 dto 기반으로 결과 dto 필드 일부 채우기
-		// Slice<ChallengeResponseDto.InfoDto> finalDtoSlice = tempDtoSlice.map(tempDto -> {
-		//
-		// 	LocalDate challengeStartDate = tempDto.getStartDate().toLocalDate();
-		// 	LocalDate today = LocalDate.now();
-		//
-		// 	long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
-		// 	boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
-		//
-		// 	// dto 나머지 필드 채우기(isUpcoming, dDayUntilStart, dayOfWeek)
-		// 	tempDto.setIsUpcoming(isUpcomingResult);
-		// 	tempDto.setDDayUntilStart((int)Math.max(0, dDay));	// 시작 전일 경우에만 남은 날짜를 set, else 0
-		// 	tempDto.setDaysOfWeek(daysMap.getOrDefault(tempDto.getChallengeId(), List.of()));
-		//
-		// 	return tempDto;
-		// });
-
 		// dto 나머지 필드 보강 (isUpcoming, dDayUntilStart, dayOfWeek)
 		List<ChallengeResponseDto.InfoDto> rawContent = tempDtoSlice.getContent();
 		List<ChallengeResponseDto.InfoDto> enrichedContent = enrichChallengeInfo(rawContent);

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -121,6 +121,40 @@ public class ChallengeServiceImpl implements ChallengeService {
 				pageable
 		);
 
+		// // ---응답 dto에 추가할 요일 정보 조회---
+		// // 모든 challengeId 추출
+		// List<Long> challengeIds = tempDtoSlice.getContent().stream()
+		// 	.map(ChallengeResponseDto.InfoDto::getChallengeId)
+		// 	.toList();
+		//
+		// // 해당 challenge들을 가진 ChallengeDayJoin 엔티티 조회
+		// List<ChallengeDayJoin> allDays = challengeDayJoinRepository.findByChallengeIdIn(challengeIds);
+		//
+		// // 챌린지 아이디-요일 리스트 매핑
+		// Map<Long, List<ChallengeDays>> daysMap = allDays.stream()
+		// 	.collect(Collectors.groupingBy(
+		// 		dayJoin -> dayJoin.getChallenge().getId(), // key: 챌린지 아이디
+		// 		Collectors.mapping(ChallengeDayJoin::getDayOfWeek, Collectors.toList()) // value: 요일 리스트
+		// 	));
+		//
+		//
+		// // Repository에서 조회해 온 dto 기반으로 결과 dto 필드 일부 채우기
+		// Slice<ChallengeResponseDto.InfoDto> finalDtoSlice = tempDtoSlice.map(tempDto -> {
+		//
+		// 	LocalDate challengeStartDate = tempDto.getStartDate().toLocalDate();
+		// 	LocalDate today = LocalDate.now();
+		//
+		// 	long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
+		// 	boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
+		//
+		// 	// dto 나머지 필드 채우기(isUpcoming, dDayUntilStart, dayOfWeek)
+		// 	tempDto.setIsUpcoming(isUpcomingResult);
+		// 	tempDto.setDDayUntilStart((int)Math.max(0, dDay));	// 시작 전일 경우에만 남은 날짜를 set, else 0
+		// 	tempDto.setDaysOfWeek(daysMap.getOrDefault(tempDto.getChallengeId(), List.of()));
+		//
+		// 	return tempDto;
+		// });
+
 		// dto 나머지 필드 보강 (isUpcoming, dDayUntilStart, dayOfWeek)
 		List<ChallengeResponseDto.InfoDto> rawContent = tempDtoSlice.getContent();
 		List<ChallengeResponseDto.InfoDto> enrichedContent = enrichChallengeInfo(rawContent);

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -340,9 +340,12 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 챌린지의 currentRound 설정
 		saved.changeCurrentRound(firstRound);
 
-		// UserChallenge 생성
+		// UserChallenge(방장) 생성
 		UserChallenge userChallenge = userChallengeConverter.toOwner(user, saved);
 		userChallengeRepository.save(userChallenge);
+
+		// RoundRecord(방장의 레코드) 생성
+		createRoundRecordOrFail(saved, userChallenge);
 
 		return challengeConverter.toCreateResponseDto(saved);
 	}
@@ -372,13 +375,24 @@ public class ChallengeServiceImpl implements ChallengeService {
 		challenge.increaseCurrentParticipants();
 
 		// 현재 진행 중인 라운드의 RoundRecord 생성
+		createRoundRecordOrFail(challenge, userChallenge);
+
+		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
+	}
+
+	private void createRoundRecordOrFail(Challenge challenge, UserChallenge userChallenge) {
+		Round currentRound = challenge.getCurrentRound();
+
+		// 챌린지가 있는데 라운드가 없는 건 서버 에러
+		if (currentRound == null) {
+			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
+		}
+
 		RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
-				challenge.getCurrentRound(),
+				currentRound,
 				userChallenge
 		);
 		roundRecordRepository.save(roundRecord);
-
-		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
 	}
 
 	@Override

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -79,9 +79,6 @@ public class ChallengeServiceImpl implements ChallengeService {
 	// 오늘의 클릭수를 저장할 Redis Key
 	private static final String TODAY_CHALLENGE_RANKING_KEY = "today:challenge:clicks";
 
-	// 기본 이미지 URL
-	private static final String DEFAULT_CHALLENGE_IMAGE_URL = "https://example.com/images/challenge-default.png";
-
 
 	@Override
 	public SliceResponseDto<ChallengeResponseDto.InfoDto> getChallengeList(
@@ -315,18 +312,12 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isViewerMode = isPublic && req.getIsViewerMode();
 		String password = isPublic ? null : req.getPassword();
 
-		String imageUrl = req.getImageUrl();
-		if (imageUrl == null || imageUrl.isBlank()) {
-			imageUrl = DEFAULT_CHALLENGE_IMAGE_URL;
-		}
-
 		// Challenge 생성
 		Challenge challenge = challengeConverter.toChallengeEntity(
 				req,
 				isPublic,
 				isViewerMode,
-				password,
-				imageUrl
+				password
 		);
 		Challenge saved = challengeRepository.save(challenge);
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -19,6 +19,11 @@ import com.hrr.backend.domain.challenge.entity.ChallengeLike; // Import 추가
 import com.hrr.backend.domain.challenge.entity.ChallengeWait;
 import com.hrr.backend.domain.challenge.repository.ChallengeLikeRepository; // Import 추가
 import com.hrr.backend.domain.challenge.repository.ChallengeWaitRepository;
+import com.hrr.backend.domain.round.converter.RoundConverter;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
 import com.hrr.backend.domain.user.converter.UserChallengeConverter;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
@@ -62,6 +67,10 @@ public class ChallengeServiceImpl implements ChallengeService {
 	private final UserRepository userRepository;
 	private final UserChallengeRepository userChallengeRepository;
 	private final UserChallengeConverter userChallengeConverter;
+
+	private final RoundRepository roundRepository;
+	private final RoundRecordRepository roundRecordRepository;
+	private final RoundConverter roundConverter;
 
 	private final RedisTemplate<String, String> redisTemplate;
 
@@ -287,6 +296,16 @@ public class ChallengeServiceImpl implements ChallengeService {
 		);
 		Challenge saved = challengeRepository.save(challenge);
 
+		// Round 생성
+		Round firstRound = roundConverter.toFirstRoundEntity(
+				saved,
+				req.getStartDate().toLocalDate()
+		);
+		roundRepository.save(firstRound);
+
+		// 챌린지의 currentRound 설정
+		saved.changeCurrentRound(firstRound);
+
 		// UserChallenge 생성
 		UserChallenge userChallenge = userChallengeConverter.toOwner(user, saved);
 		userChallengeRepository.save(userChallenge);
@@ -317,6 +336,18 @@ public class ChallengeServiceImpl implements ChallengeService {
 		}
 		// 챌린지 인원 업데이트
 		challenge.increaseCurrentParticipants();
+
+		// 현재 진행 중인 라운드의 RoundRecord 생성
+		Round currentRound = challenge.getCurrentRound();
+
+		// 예외 처리: 혹시라도 라운드가 생성되지 않았을 경우
+		if (currentRound != null) {
+			RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
+					currentRound,
+					userChallenge
+			);
+			roundRecordRepository.save(roundRecord);
+		}
 
 		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -30,6 +30,7 @@ import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +54,7 @@ import com.hrr.backend.global.response.SliceResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 public class ChallengeServiceImpl implements ChallengeService {
@@ -557,6 +559,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 		// 라운드가 존재하지 않는 경우
 		if (challenge.getCurrentRound() == null) {
+
+			log.error("[Data Error] 챌린지의 현재 라운드(CurrentRound)가 null입니다. challengeId={}", challenge.getId());
 			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
 		}
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -372,16 +372,11 @@ public class ChallengeServiceImpl implements ChallengeService {
 		challenge.increaseCurrentParticipants();
 
 		// 현재 진행 중인 라운드의 RoundRecord 생성
-		Round currentRound = challenge.getCurrentRound();
-
-		// 예외 처리: 혹시라도 라운드가 생성되지 않았을 경우
-		if (currentRound != null) {
-			RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
-					currentRound,
-					userChallenge
-			);
-			roundRecordRepository.save(roundRecord);
-		}
+		RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
+				challenge.getCurrentRound(),
+				userChallenge
+		);
+		roundRecordRepository.save(roundRecord);
 
 		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
 	}
@@ -515,8 +510,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 	 * 챌린지 참가 요청에 대한 비즈니스 검증 로직
 	 */
 	private void validateJoinRequest(Challenge challenge, User user, String inputPassword) {
-		// 모집 상태 검증 (UPCOMING 상태인지)
-		if (challenge.getStatus() != ChallengeStatus.UPCOMING) {
+		// 모집 상태 검증 (UPCOMING 이거나 RECRUITING 상태여야 함)
+		if (challenge.getStatus() != ChallengeStatus.UPCOMING &&
+				challenge.getStatus() != ChallengeStatus.RECRUITING) {
 			throw new GlobalException(ErrorCode.CHALLENGE_NOT_RECRUITING);
 		}
 
@@ -535,6 +531,11 @@ public class ChallengeServiceImpl implements ChallengeService {
 			if (inputPassword == null || !inputPassword.equals(challenge.getPassword())) {
 				throw new GlobalException(ErrorCode.CHALLENGE_PASSWORD_MISMATCH);
 			}
+		}
+
+		// 라운드가 존재하지 않는 경우
+		if (challenge.getCurrentRound() == null) {
+			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
 		}
 	}
 

--- a/src/main/java/com/hrr/backend/domain/round/converter/RoundConverter.java
+++ b/src/main/java/com/hrr/backend/domain/round/converter/RoundConverter.java
@@ -1,0 +1,38 @@
+package com.hrr.backend.domain.round.converter;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import org.springframework.stereotype.Component;
+import java.time.LocalDate;
+
+@Component
+public class RoundConverter {
+    /**
+     * 챌린지 생성 시, 1회차 라운드(Round) 엔티티를 생성
+     * 종료일(endDate)은 시작일로부터 3주 뒤로 자동 계산
+     */
+    public Round toFirstRoundEntity(Challenge challenge, LocalDate startDate) {
+        return Round.builder()
+                .challenge(challenge)
+                .roundNumber(1)
+                .startDate(startDate)
+                .endDate(startDate.plusWeeks(Challenge.ROUND_WEEKS).minusDays(1))
+                .build();
+    }
+
+    /**
+     * 초기화된(점수 0, 연장 여부 미정) RoundRecord 엔티티 생성
+     */
+    public RoundRecord toRoundRecordEntity(Round round, UserChallenge userChallenge) {
+        return RoundRecord.builder()
+                .round(round)
+                .userChallenge(userChallenge)
+                .verificationCount(0)
+                .warnCount(0)
+                .nextRoundIntent(NextRoundIntent.UNDECIDED)
+                .build();
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/entity/Round.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/Round.java
@@ -15,7 +15,18 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
-@Table(name = "round")
+@Table(
+        name = "round",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_challenge_round_number",
+                        columnNames = {"challenge_id", "roundNumber"}
+                )
+        },
+        indexes = {
+                @Index(name = "idx_round_end_date", columnList = "endDate")
+        }
+)
 public class Round extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/hrr/backend/domain/round/entity/Round.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/Round.java
@@ -20,7 +20,7 @@ import java.time.LocalDate;
         uniqueConstraints = {
                 @UniqueConstraint(
                         name = "uk_challenge_round_number",
-                        columnNames = {"challenge_id", "roundNumber"}
+                        columnNames = {"challenge_id", "round_number"}
                 )
         },
         indexes = {

--- a/src/main/java/com/hrr/backend/domain/round/entity/Round.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/Round.java
@@ -1,11 +1,37 @@
 package com.hrr.backend.domain.round.entity;
 
+import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
 
 @Entity
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Table(name = "round")
 public class Round extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "challenge_id", nullable = false)
+    private Challenge challenge;
+
+    @Column(nullable = false)
+    private Integer roundNumber;
+
+    @Column(nullable = false)
+    private LocalDate startDate;
+
+    @Column(nullable = false)
+    private LocalDate endDate;
+
 }

--- a/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
@@ -2,7 +2,6 @@ package com.hrr.backend.domain.round.entity;
 
 import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.user.entity.UserChallenge;
-import com.hrr.backend.domain.user.entity.enums.UserVerificationStatus;
 import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
@@ -20,8 +19,22 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@Table(name = "round_record",
-        indexes = @Index(name = "idx_round_rank", columnList = "round_id, verification_count DESC"))
+@Table(
+        name = "round_record",
+        uniqueConstraints = {
+                @UniqueConstraint(
+                        name = "uk_round_user",
+                        columnNames = {"round_id", "user_challenge_id"}
+                )
+        },
+        indexes = {
+                // 검색용 기본 인덱스
+                @Index(name = "idx_round_id", columnList = "round_id"),
+
+                // 내 히스토리 조회용 인덱스
+                @Index(name = "idx_user_history", columnList = "user_challenge_id")
+        }
+)
 public class RoundRecord extends BaseEntity {
 
     @Id

--- a/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
@@ -69,6 +69,7 @@ public class RoundRecord extends BaseEntity {
 
     // 양방향 매핑
     @OneToMany(mappedBy = "roundRecord", cascade = CascadeType.ALL)
+    @Builder.Default
     private List<Verification> verifications = new ArrayList<>();
 
     // 비즈니스 메서드

--- a/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/RoundRecord.java
@@ -1,0 +1,73 @@
+package com.hrr.backend.domain.round.entity;
+
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.UserVerificationStatus;
+import com.hrr.backend.domain.verification.entity.Verification;
+import com.hrr.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Table(name = "round_record",
+        indexes = @Index(name = "idx_round_rank", columnList = "round_id, verification_count DESC"))
+public class RoundRecord extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "round_id", nullable = false)
+    private Round round;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_challenge_id", nullable = false)
+    private UserChallenge userChallenge;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    @Builder.Default
+    private Integer verificationCount = 0;
+
+    @Column(nullable = false)
+    @ColumnDefault("0")
+    @Builder.Default
+    private Integer warnCount = 0;
+
+    @Column(name = "final_rank")
+    private Integer finalRank;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    @Builder.Default
+    private NextRoundIntent nextRoundIntent = NextRoundIntent.UNDECIDED;
+
+    // 양방향 매핑
+    @OneToMany(mappedBy = "roundRecord", cascade = CascadeType.ALL)
+    private List<Verification> verifications = new ArrayList<>();
+
+    // 비즈니스 메서드
+    public void increaseVerificationCount() {
+        this.verificationCount++;
+    }
+
+    public void updateFinalRank(Integer rank) {
+        this.finalRank = rank;
+    }
+
+    public void updateNextRoundIntent(NextRoundIntent intent) {
+        this.nextRoundIntent = intent;
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/entity/enums/NextRoundIntent.java
+++ b/src/main/java/com/hrr/backend/domain/round/entity/enums/NextRoundIntent.java
@@ -1,0 +1,15 @@
+package com.hrr.backend.domain.round.entity.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NextRoundIntent {
+
+    UNDECIDED("결정 전"), // 기본값
+    CONTINUE("계속하기"), // 방장: 연장함 / 팀원: 참여함
+    STOP("그만하기");     // 방장: 종료함 / 팀원: 하차함
+
+    private final String description;
+}

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -1,0 +1,8 @@
+package com.hrr.backend.domain.round.repository;
+
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> {
+
+}

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRepository.java
@@ -1,0 +1,8 @@
+package com.hrr.backend.domain.round.repository;
+
+import com.hrr.backend.domain.round.entity.Round;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RoundRepository extends JpaRepository<Round, Long> {
+
+}

--- a/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
@@ -1,8 +1,8 @@
 package com.hrr.backend.domain.user.entity;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.entity.enums.UserChallengeRole;
-import com.hrr.backend.domain.user.entity.enums.UserVerificationStatus;
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -46,23 +46,16 @@ public class UserChallenge extends BaseEntity {
     private UserChallengeRole role = UserChallengeRole.CHALLENGER;
 
     @NotNull
-    @Builder.Default
     @Enumerated(EnumType.STRING)
-    @Column(name = "verification_status", nullable = false)
-    private UserVerificationStatus userVerificationStatus = UserVerificationStatus.PENDING;
-
-    @NotNull
-    @Column(name = "verification_count", nullable = false)
+    @Column(name = "status", nullable = false)
+    @ColumnDefault("'JOINED'")
     @Builder.Default
-    private Integer verificationCount = 0;
+    private ChallengeJoinStatus status = ChallengeJoinStatus.JOINED;
 
-    @NotNull
-    @Column(name = "verification_uncount", nullable = false)
+    // '내보내기 경고' 누적 횟수 (3회 되면 status = KICKED로 변경됨)
+    @Column(name = "kick_warnings", nullable = false)
+    @ColumnDefault("0")
     @Builder.Default
-    private Integer verificationUncount = 0;
+    private Integer kickWarnings = 0;
 
-    @NotNull
-    @Column(name = "warn_count", nullable = false)
-    @Builder.Default
-    private Integer warnCount = 0;
 }

--- a/src/main/java/com/hrr/backend/domain/user/entity/enums/ChallengeJoinStatus.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/enums/ChallengeJoinStatus.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.user.entity.enums;
+
+public enum ChallengeJoinStatus {
+    JOINED,   // 참여 중
+    DROPPED,  // 하차
+    KICKED    // 퇴출
+}

--- a/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
+++ b/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.verification.entity;
 
+import com.hrr.backend.domain.round.entity.RoundRecord;
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 
@@ -8,4 +9,8 @@ public class Verification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "round_record_id", nullable = false)
+    private RoundRecord roundRecord;
 }

--- a/src/main/java/com/hrr/backend/global/common/enums/ChallengeStatus.java
+++ b/src/main/java/com/hrr/backend/global/common/enums/ChallengeStatus.java
@@ -1,7 +1,8 @@
 package com.hrr.backend.global.common.enums;
 
 public enum ChallengeStatus {
-	UPCOMING,
-	ONGOING,
-	FINISHED
+	UPCOMING,	// 챌린지 시작 전
+	ONGOING,	// 라운드 진행 중 (가입 불가)
+	RECRUTING,	// 다음 라운드 모집 중
+	FINISHED	// 챌린지 종료
 }

--- a/src/main/java/com/hrr/backend/global/common/enums/ChallengeStatus.java
+++ b/src/main/java/com/hrr/backend/global/common/enums/ChallengeStatus.java
@@ -3,6 +3,6 @@ package com.hrr.backend.global.common.enums;
 public enum ChallengeStatus {
 	UPCOMING,	// 챌린지 시작 전
 	ONGOING,	// 라운드 진행 중 (가입 불가)
-	RECRUTING,	// 다음 라운드 모집 중
+	RECRUITING,	// 다음 라운드 모집 중
 	FINISHED	// 챌린지 종료
 }

--- a/src/main/resources/db/migration/V2.3__refactor_challenge_round_system.sql
+++ b/src/main/resources/db/migration/V2.3__refactor_challenge_round_system.sql
@@ -1,0 +1,88 @@
+-- Round 테이블 구조 변경
+ALTER TABLE `round`
+    ADD COLUMN challenge_id BIGINT NOT NULL,
+    ADD COLUMN round_number INT NOT NULL,
+    ADD COLUMN start_date DATE NOT NULL,
+    ADD COLUMN end_date DATE NOT NULL;
+
+-- 외래키
+ALTER TABLE `round`
+    ADD CONSTRAINT FK_round_challenge
+        FOREIGN KEY (challenge_id) REFERENCES challenge (id);
+
+-- 유니크: @UniqueConstraint(name = "uk_challenge_round_number", ...)
+ALTER TABLE `round`
+    ADD CONSTRAINT uk_challenge_round_number
+        UNIQUE (challenge_id, round_number);
+
+-- 인덱스: @Index(name = "idx_round_end_date", ...)
+CREATE INDEX idx_round_end_date ON `round` (end_date);
+
+
+-- Challenge 테이블 수정
+ALTER TABLE challenge
+    ADD COLUMN current_round_id BIGINT;
+
+ALTER TABLE challenge
+    ADD CONSTRAINT FK_challenge_current_round
+        FOREIGN KEY (current_round_id) REFERENCES `round` (id);
+
+
+-- UserChallenge 테이블 수정
+-- 기존 점수 관련 컬럼 삭제
+ALTER TABLE user_challenge
+DROP COLUMN verification_count,
+    DROP COLUMN verification_uncount,
+    DROP COLUMN warn_count,
+    DROP COLUMN verification_status;
+
+-- 신규 컬럼 추가
+ALTER TABLE user_challenge
+    ADD COLUMN status VARCHAR(255) DEFAULT 'JOINED' NOT NULL,
+    ADD COLUMN kick_warnings INT DEFAULT 0 NOT NULL;
+
+-- 유니크: @UniqueConstraint(columnNames = {"user_id", "challenge_id"})
+ALTER TABLE user_challenge
+    ADD CONSTRAINT uk_user_challenge_user_challenge
+        UNIQUE (user_id, challenge_id);
+
+
+-- RoundRecord 테이블 신규 생성
+CREATE TABLE round_record (
+                              id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                              created_at DATETIME(6) NOT NULL,
+                              updated_at DATETIME(6),
+
+                              round_id BIGINT NOT NULL,
+                              user_challenge_id BIGINT NOT NULL,
+
+                              verification_count INT DEFAULT 0 NOT NULL,
+                              warn_count INT DEFAULT 0 NOT NULL,
+                              final_rank INT,
+                              next_round_intent VARCHAR(255) DEFAULT 'UNDECIDED' NOT NULL,
+
+                              CONSTRAINT FK_round_record_round
+                                  FOREIGN KEY (round_id) REFERENCES `round` (id),
+                              CONSTRAINT FK_round_record_user_challenge
+                                  FOREIGN KEY (user_challenge_id) REFERENCES user_challenge (id)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+-- 유니크: @UniqueConstraint(name = "uk_round_user", ...)
+ALTER TABLE round_record
+    ADD CONSTRAINT uk_round_user
+        UNIQUE (round_id, user_challenge_id);
+
+-- 인덱스: @Index(name = "idx_round_id", ...)
+CREATE INDEX idx_round_id ON round_record (round_id);
+
+-- 인덱스: @Index(name = "idx_user_history", ...)
+CREATE INDEX idx_user_history ON round_record (user_challenge_id);
+
+
+-- Verification 테이블 구조 변경
+ALTER TABLE verification
+    ADD COLUMN round_record_id BIGINT NOT NULL;
+
+ALTER TABLE verification
+    ADD CONSTRAINT FK_verification_round_record
+        FOREIGN KEY (round_record_id) REFERENCES round_record (id);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #55

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

기존의 단발성 챌린지 구조를 3주 단위의 라운드(`Round`) 시스템으로 개편하고, 유저의 기록을 보존하기 위해 DB 설계 및 핵심 비즈니스 로직(챌린지 생성/참가) 리팩토링 작업을 했습니다.

추후 도입될 자동화 스케줄러(라운드 갱신 및 랭킹 산정)가 정상적으로 동작할 수 있도록 데이터 구조를 개편하고 데이터 무결성을 확보하는 데 집중했습니다.

(+ 실제 라운드 종료 및 갱신을 담당하는 Scheduler 로직은 이후에 구현할 예정입니ㅏㄷ)

### 주요 변경 내역
- **DB 스키마 변경**: `Round`, `RoundRecord` 테이블 신규 생성 및 기존 테이블(`Challenge`, `UserChallenge`, `Verification`) 구조 변경 (Flyway V2.3 스크립트 추가)
- **Entity 매핑**: JPA 엔티티 연관관계 재설정 및 비즈니스 편의 메서드 추가
- **API 로직 수정**: `ChallengeService`의 생성/참가 로직에 라운드 및 성적표 자동 생성 로직 반영
- **성능 최적화**: 주요 조회 쿼리를 위한 인덱스 및 데이터 무결성을 위한 유니크 제약조건 적용

### 기획 및 아키텍처 설명
이번 리팩토링은 다음 4가지 기획을 기술적으로 구현하기 위해 진행되었습니다.

**1. 3주 라운드 순환 시스템**
- 기존: 챌린지에 기간 개념이 모호하여 종료 및 재시작 처리가 불가능했음
- 변경: 모든 챌린지는 3주(21일) 단위의 `Round`로 쪼개져 운영, `Challenge` 엔티티는 `currentReound` 포인터를 통해 항상 현재 진행 중인 회차를 가리키도록 설계함

**2. 챌린저 입장 여부와 기록의 분리**
- 기존: `UserChallenge`에 점수 데이터가 있어, 라운드가 초기화되면 과거 기록이 소실됨
- 변경: `UserChallenge`는 해당 챌린지의 챌린저인지만 관리하고, 점수와 랭킹은 `RoundRecord`로 분리, 이를 통해 n라운드 때의 기록처럼 히스토리 조회가 가능해짐

**3. 단계별 의사 결정 및 상태 관리**
- 의사 결정: 다음 라운드로 넘어갈 때 유저의 의사를 확인하기 위해 `NextRoundIntent`를 도입함
- 상태 관리: 유저의 현재 상태를 명확히 하기 위해 `ChallengeJoinStatus`를 도입하여, 쿼리 조회 시 유효한 멤버만 빠르게 필터링 가능

**4. 3-Strike 퇴출 제도 및 중복 방지**
- 1/4 이상 경고 시 `kickWarnings`이 누적되며, 3회 누적 시 퇴출되는 로직을 위한 필드 추가
- DB 레벨에서 유니크 제약 조건을 걸어 중복 참여 봉쇄

### 기존 API 변경 사항
엔티티 구조 변경에 따라 `ChallengeService`의 핵심 메서드 로직 변경
**1. 챌린지 생성 API (`createChallenge`)**
- 기존: `Challenge` 저장 -> `UserChallenge`(방장) 저장 -> 끝
- 변경
- 1. `Challenge` 저장
- 2. 1회차 `Round` 자동 생성 (시작일 ~ 3주 뒤 종료일 자동 계산)
- 3. `Challenge.currentRound` 연결
- 4. `UserChallenge` (방장) 저장
- 5. 방장의 1회차 `RoundRecord` 생성

**2. 챌린지 참가**
- 기존: `UserChallenge`(참가자) 저장 -> 인원수 증가 -> 끝
- 변경
- 1. `UserChallenge`(참가자) 저장
- 2. 인원수 증가 
- 3. 현재 진행 중인 `Round` 조회
- 4. 참가자의 `RoundRecord` 생성

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:**  Swagger
* **결과 요약:** 
* `POST /challenges` 호출 시 `round` 테이블에 1회차 데이터 생성 확인 (endDate가 startDate + 20일로 설정됨)
* `POST /challenges/{id}/join` 호출 시 `round_record` 테이블에 데이터 생성 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

|설명|이미지|
|---|--------|
|챌린지 생성 API|<img width="1176" height="362" alt="image" src="https://github.com/user-attachments/assets/7f76186f-c0d8-4f41-9ae7-dbdefcbe9d68" />|
|챌린지 생성 후 `UserChallenge`|<img width="1363" height="167" alt="image" src="https://github.com/user-attachments/assets/d6c887f3-8ca9-495e-866e-a8c779e744ec" />|
|챌린지 생성 후 `RoundRecord`|<img width="1215" height="154" alt="image" src="https://github.com/user-attachments/assets/ee0499b1-665a-4185-9bad-12f2ecbf1b1b" />|
|챌린지 참가 API|<img width="1177" height="358" alt="image" src="https://github.com/user-attachments/assets/a7b25397-7d65-4373-91ca-3e1141201381" />|
|챌린지 참가 후 `RoundRecord`|<img width="1352" height="185" alt="image" src="https://github.com/user-attachments/assets/d6bb2cd1-5e74-4bd3-92c7-2c793a88f0ba" />|


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- 인덱스 설계가 조회 성능에 적절한지
- 일부 기획 변경 시에 유연하게 적용할 수 있는지

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 라운드 및 라운드기록 도입 — 첫 라운드 자동 생성 및 현재 라운드 지정, 라운드별 참가 기록 관리
  * 라운드 의도(UNDECIDED/CONTINUE/STOP) 상태 추가

* **변경/확장**
  * 참가 흐름 개선 — 생성·참가 시 라운드기록 자동 생성 및 중앙화된 처리
  * 참가 상태 확장: JOINED/DROPPED/KICKED 및 경고 카운트 추가
  * 챌린지 상태에 RECRUITING 추가

* **유효성/입력**
  * 챌린지 이미지 URL 필수화

* **데이터베이스 마이그레이션**
  * 라운드·라운드기록 테이블 및 관련 외래키·제약 추가, 기존 검증 관련 컬럼 제거/대체

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->