### PR TITLE
[Feat] 챌린지 프로필 조회 API 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -80,6 +80,21 @@ public class ChallengeController {
 		return ApiResponse.onSuccess(SuccessCode.OK, response);
 	}
 
+	@GetMapping("/{challengeId}/profile")
+	@Operation(summary = "챌린지 프로필 조회 (참여 전/후 UI 통합)",
+			description = "로그인한 유저의 참여 상태에 따라 인증 현황을 포함하거나 제외하여 반환합니다.")
+	public ApiResponse<ChallengeResponseDto.ChallengeProfileDto> getChallengeProfile(
+			@PathVariable("challengeId") Long challengeId,
+			@Parameter(hidden = true)
+			@AuthenticationPrincipal CustomUserDetails userDetails
+	) {
+		ChallengeResponseDto.ChallengeProfileDto response = challengeService.getChallengeProfile(
+				userDetails.getUser(),
+				challengeId
+		);
+		return ApiResponse.onSuccess(SuccessCode.OK, response);
+	}
+
 	@PostMapping("/{challengeId}/click")
 	@Operation(summary = "챌린지 클릭 처리", description = "오늘의 인기 챌린지 집계를 위해 챌린지 클릭 시에 카운팅을 진행합니다.")
 	public ApiResponse<Long> clickChallenge(@PathVariable("challengeId") Long challengeId) {

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -102,4 +102,26 @@ public class ChallengeConverter {
                 .actionButtonStatus(actionButtonStatus)
                 .build();
     }
+
+    // ▼▼▼ [새로 추가된 메서드] ▼▼▼
+    public ChallengeResponseDto.ChallengeProfileDto toProfileDto(
+            Challenge challenge,
+            boolean isParticipating,
+            List<ChallengeDays> verifiedDays
+    ) {
+        // Entity의 ChallengeDayJoin 리스트를 Enum 리스트로 변환
+        List<ChallengeDays> targetDays = challenge.getChallengeDays().stream()
+                .map(ChallengeDayJoin::getDay)
+                .toList();
+
+        return ChallengeResponseDto.ChallengeProfileDto.builder()
+                .challengeId(challenge.getId())
+                .isParticipating(isParticipating)
+                .rule(challenge.getRule())
+                .targetDays(targetDays)
+                .verifyStartTime(challenge.getVerifyStartTime())
+                .verifyEndTime(challenge.getVerifyEndTime())
+                .verifiedDaysThisWeek(verifiedDays) // 미참여시 null
+                .build();
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -2,6 +2,7 @@ package com.hrr.backend.domain.challenge.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
@@ -170,6 +171,34 @@ public class ChallengeResponseDto {
 
 		@Schema(description = "방장 프로필 이미지 URL", example = "https://example.com/profile.jpg")
 		private String profileImageUrl;
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	@Schema(description = "챌린지 프로필(메인 화면) 응답 DTO - Flat Structure")
+	public static class ChallengeProfileDto {
+
+		@Schema(description = "챌린지 ID", example = "1")
+		private Long challengeId;
+
+		@Schema(description = "참여 여부 (true: 2번 UI / false: 1번 UI)", example = "true")
+		private Boolean isParticipating;
+
+		@Schema(description = "챌린지 규칙", example = "하루에 1만 보 이상 걸은 스크린샷을 인증해야 합니다.")
+		private String rule;
+
+		@Schema(description = "목표 요일 목록", example = "[\"MONDAY\", \"THURSDAY\"]")
+		private List<ChallengeDays> targetDays;
+
+		@Schema(description = "인증 가능 시작 시간", example = "10:00:00")
+		private LocalTime verifyStartTime;
+
+		@Schema(description = "인증 가능 종료 시간", example = "18:00:00")
+		private LocalTime verifyEndTime;
+
+		@Schema(description = "이번 주 인증 완료 요일 (참여 중일 때만 값 있음, 미참여시 null)", example = "[\"MONDAY\"]")
+		private List<ChallengeDays> verifiedDaysThisWeek;
 	}
 
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/ChallengeDayJoin.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/ChallengeDayJoin.java
@@ -39,4 +39,8 @@ public class ChallengeDayJoin extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	@Column(name = "day_of_week", nullable = false)
 	private ChallengeDays dayOfWeek;
+
+	public ChallengeDays getDay() {
+		return this.dayOfWeek;
+	}
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -24,8 +24,11 @@ public interface ChallengeService {
 		int size
 	);
 
-	// 챌린지 프로필 조회
+	// 챌린지 상단 헤더 조회
 	ChallengeResponseDto.HeaderInfoDto getChallengeHeaderInfo(Long challengeId, User user);
+
+	// 챌린지 프로필 조회
+	ChallengeResponseDto.ChallengeProfileDto getChallengeProfile(User user, Long challengeId);
 
 	// 챌린지 클릭 처리
 	Long clickChallenge(Long challengeId);

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -5,6 +5,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.temporal.ChronoUnit;
+import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -185,6 +186,46 @@ public class ChallengeServiceImpl implements ChallengeService {
 				challenge, ownerUc.getUser(), startDate, endDate, remainDays,
 				isParticipant, isLiked, buttonStatus
 		);
+	}
+
+	@Override
+	@Transactional(readOnly = true)
+	public ChallengeResponseDto.ChallengeProfileDto getChallengeProfile(User user, Long challengeId) {
+		// 챌린지 조회
+		Challenge challenge = findChallengeWithDays(challengeId);
+
+		// 참여 여부 확인
+		boolean isParticipating = userChallengeRepository.findByUserAndChallenge(user, challenge)
+				.map(uc -> uc.getStatus() == ChallengeJoinStatus.JOINED)
+				.orElse(false);
+
+		List<ChallengeDays> verifiedDaysThisWeek = null;
+
+		// 참여 중일 때만 계산
+		if (isParticipating) {
+			LocalDateTime now = LocalDateTime.now();
+
+			// 일요일 시작 ~ 토요일 종료 기준으로 범위 설정
+			LocalDateTime startOfWeek = now.with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)).with(LocalTime.MIN);
+			LocalDateTime endOfWeek = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.SATURDAY)).with(LocalTime.MAX);
+
+			// DB 조회
+			List<com.hrr.backend.domain.verification.entity.Verification> verifications = verificationRepository.findWeeklyVerifications(
+					user.getId(),
+					challengeId,
+					startOfWeek,
+					endOfWeek,
+					VerificationStatus.COMPLETED
+			);
+
+			// Enum 메서드 사용
+			verifiedDaysThisWeek = verifications.stream()
+					.map(v -> ChallengeDays.from(v.getCreatedAt().getDayOfWeek()))
+					.distinct()
+					.toList();
+		}
+
+		return challengeConverter.toProfileDto(challenge, isParticipating, verifiedDaysThisWeek);
 	}
 
 	@Override

--- a/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/UserChallenge.java
@@ -21,6 +21,12 @@ import org.hibernate.annotations.ColumnDefault;
         name = "user_challenge",
         uniqueConstraints = {
                 @UniqueConstraint(columnNames = {"user_id", "challenge_id"})
+        },
+        indexes = {
+                // 챌린지 ID 기준 조회 최적화 (FK)
+                @Index(name = "idx_user_challenge_challenge_id", columnList = "challenge_id"),
+                // 유저 ID 기준 조회 최적화
+                @Index(name = "idx_user_challenge_user_id", columnList = "user_id")
         }
 )
 public class UserChallenge extends BaseEntity {

--- a/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
+++ b/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
@@ -12,6 +12,15 @@ import lombok.*;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(
+        name = "verification",
+        indexes = {
+                // 날짜 범위 검색 최적화
+                @Index(name = "idx_verification_created_at", columnList = "createdAt"),
+                // 상태값 필터링 최적화
+                @Index(name = "idx_verification_status", columnList = "status")
+        }
+)
 public class Verification extends BaseEntity {
 
     @Id

--- a/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
+++ b/src/main/java/com/hrr/backend/domain/verification/entity/Verification.java
@@ -16,7 +16,7 @@ import lombok.*;
         name = "verification",
         indexes = {
                 // 날짜 범위 검색 최적화
-                @Index(name = "idx_verification_created_at", columnList = "createdAt"),
+                @Index(name = "idx_verification_created_at", columnList = "created_at"),
                 // 상태값 필터링 최적화
                 @Index(name = "idx_verification_status", columnList = "status")
         }

--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface VerificationRepository extends JpaRepository<Verification, Long> {
 
@@ -24,5 +25,20 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             @Param("status") VerificationStatus status,
             @Param("startOfDay") LocalDateTime startOfDay,
             @Param("endOfDay") LocalDateTime endOfDay
+    );
+
+    @Query("SELECT v FROM Verification v " +
+            "JOIN v.roundRecord r " +
+            "JOIN r.userChallenge uc " +
+            "WHERE uc.user.id = :userId " +
+            "AND uc.challenge.id = :challengeId " +
+            "AND v.createdAt BETWEEN :start AND :end " +
+            "AND v.status = :status")
+    List<Verification> findWeeklyVerifications(
+            @Param("userId") Long userId,
+            @Param("challengeId") Long challengeId,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end,
+            @Param("status") VerificationStatus status
     );
 }

--- a/src/main/java/com/hrr/backend/global/common/enums/ChallengeDays.java
+++ b/src/main/java/com/hrr/backend/global/common/enums/ChallengeDays.java
@@ -3,6 +3,8 @@ package com.hrr.backend.global.common.enums;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.time.DayOfWeek;
+
 @Getter
 @RequiredArgsConstructor
 public enum ChallengeDays {
@@ -19,4 +21,16 @@ public enum ChallengeDays {
 
 	private final String koreanName;
 	private final int dayCode;       // 일요일=0 시작
+
+	public static ChallengeDays from(DayOfWeek dayOfWeek) {
+		return switch (dayOfWeek) {
+			case MONDAY -> MONDAY;
+			case TUESDAY -> TUESDAY;
+			case WEDNESDAY -> WEDNESDAY;
+			case THURSDAY -> THURSDAY;
+			case FRIDAY -> FRIDAY;
+			case SATURDAY -> SATURDAY;
+			case SUNDAY -> SUNDAY;
+		};
+	}
 }

--- a/src/main/resources/db/migration/V2.6__add_performance_indexes.sql
+++ b/src/main/resources/db/migration/V2.6__add_performance_indexes.sql
@@ -1,0 +1,15 @@
+-- findWeeklyVerifications 쿼리 성능 최적화를 위한 인덱스 추가
+
+-- Verification 테이블 검색 최적화
+-- 날짜 범위 검색(BETWEEN) 속도 향상
+CREATE INDEX idx_verification_created_at ON verification (created_at);
+
+-- 상태값(COMPLETED 등) 필터링 속도 향상
+CREATE INDEX idx_verification_status ON verification (status);
+
+-- UserChallenge 테이블 조인(Join) 및 검색 최적화
+-- 챌린지 ID로 검색할 때 속도 향상 (기존 복합키는 user_id가 앞이라 challenge_id 검색엔 비효율적일 수 있음)
+CREATE INDEX idx_user_challenge_challenge_id ON user_challenge (challenge_id);
+
+-- 유저 ID로 검색할 때 속도 향상
+CREATE INDEX idx_user_challenge_user_id ON user_challenge (user_id);

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -34,7 +34,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 
 @ExtendWith(MockitoExtension.class)
-class ChallengeServiceImplTest {
+class ChallengeServiceInfoTest {
 
     @InjectMocks
     private ChallengeServiceImpl challengeService;

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -1,0 +1,253 @@
+package com.hrr.backend.domain.challenge.service;
+
+import com.hrr.backend.domain.challenge.converter.ChallengeConverter;
+import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.domain.verification.entity.Verification;
+import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
+import com.hrr.backend.domain.verification.repository.VerificationRepository;
+import com.hrr.backend.global.common.enums.ChallengeDays;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeServiceProfileTest {
+
+    @InjectMocks
+    private ChallengeServiceImpl challengeService;
+
+    @Mock private ChallengeRepository challengeRepository;
+    @Mock private UserChallengeRepository userChallengeRepository;
+    @Mock private VerificationRepository verificationRepository;
+
+    // Converter는 로직이 있으므로 실제 객체(Spy) 사용
+    @Spy private ChallengeConverter challengeConverter;
+
+    @Test
+    @DisplayName("1. [부분 인증] 인증 요일이 월/목인데 '월요일'만 인증한 경우 -> 리스트에 MONDAY 하나만 존재")
+    void getChallengeProfile_PartialVerification() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        // 챌린지: 월, 목 인증 목표
+        Challenge challenge = createChallenge(challengeId, "부분 인증 테스트", List.of(ChallengeDays.MONDAY, ChallengeDays.THURSDAY));
+
+        // 유저 참여 중
+        mockParticipating(user, challenge);
+
+        // 인증 내역: 이번 주 월요일 1건
+        List<Verification> verifications = List.of(
+                createVerification(DayOfWeek.MONDAY)
+        );
+
+        // Mocking
+        mockRepositoryCalls(user, challenge, verifications);
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getIsParticipating()).isTrue();
+        assertThat(result.getTargetDays()).contains(ChallengeDays.MONDAY, ChallengeDays.THURSDAY); // 목표는 2개
+        assertThat(result.getVerifiedDaysThisWeek()).hasSize(1); // 인증은 1개
+        assertThat(result.getVerifiedDaysThisWeek()).containsOnly(ChallengeDays.MONDAY); // 월요일만 포함
+    }
+
+    @Test
+    @DisplayName("2. [완료 인증] 인증 요일이 월/목이고 둘 다 인증한 경우 -> 리스트에 둘 다 존재")
+    void getChallengeProfile_FullVerification() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Challenge challenge = createChallenge(challengeId, "완료 인증 테스트", List.of(ChallengeDays.MONDAY, ChallengeDays.THURSDAY));
+
+        mockParticipating(user, challenge);
+
+        // 인증 내역: 월요일, 목요일 2건
+        List<Verification> verifications = List.of(
+                createVerification(DayOfWeek.MONDAY),
+                createVerification(DayOfWeek.THURSDAY)
+        );
+
+        mockRepositoryCalls(user, challenge, verifications);
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getVerifiedDaysThisWeek()).hasSize(2);
+        assertThat(result.getVerifiedDaysThisWeek()).containsExactlyInAnyOrder(ChallengeDays.MONDAY, ChallengeDays.THURSDAY);
+    }
+
+    @Test
+    @DisplayName("3. [주 시작일 인증] 일요일(주의 시작)에 인증한 경우 -> 이번 주 현황에 포함되어야 한다")
+    void getChallengeProfile_SundayVerification() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Challenge challenge = createChallenge(challengeId, "일요일 인증 테스트", List.of(ChallengeDays.SUNDAY));
+
+        mockParticipating(user, challenge);
+
+        // 인증 내역: 일요일 (Service 로직상 주의 시작일)
+        List<Verification> verifications = List.of(
+                createVerification(DayOfWeek.SUNDAY)
+        );
+
+        mockRepositoryCalls(user, challenge, verifications);
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getVerifiedDaysThisWeek()).contains(ChallengeDays.SUNDAY);
+    }
+
+    @Test
+    @DisplayName("4. [미참여] 챌린지에 참여하지 않은 경우 -> verifiedDaysThisWeek는 null이어야 한다")
+    void getChallengeProfile_NotParticipating() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Challenge challenge = createChallenge(challengeId, "미참여 테스트", List.of(ChallengeDays.MONDAY));
+
+        // Mocking (참여 정보 없음)
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.empty());
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getIsParticipating()).isFalse();
+        assertThat(result.getVerifiedDaysThisWeek()).isNull();
+    }
+
+    @Test
+    @DisplayName("5. [기간 제외] 지난 주(예: 지난 목요일)에 인증했더라도, 이번 주(일~토) 범위 밖이므로 안 떠야 한다")
+    void getChallengeProfile_LastWeekVerification_ShouldNotAppear() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Challenge challenge = createChallenge(challengeId, "지난 주 인증 제외 테스트", List.of(ChallengeDays.THURSDAY));
+
+        // 1. 참여 정보 Mocking
+        mockParticipating(user, challenge);
+
+        // 2. 챌린지 정보 조회 Mocking
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+
+        // 3. 인증 내역 Mocking (지난 주 데이터라 DB 쿼리 결과에는 안 잡힘을 가정 -> 빈 리스트 반환)
+        given(verificationRepository.findWeeklyVerifications(any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        // 1. 결과가 비어있어야 함
+        assertThat(result.getVerifiedDaysThisWeek()).isEmpty();
+
+        // 2. 서비스가 날짜 범위를 제대로 계산해서 DB에 넘겼는지 검증
+        ArgumentCaptor<LocalDateTime> captor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+        verify(verificationRepository).findWeeklyVerifications(
+                eq(user.getId()),
+                eq(challengeId),
+                captor.capture(),
+                captor.capture(),
+                eq(VerificationStatus.COMPLETED)
+        );
+
+        LocalDateTime capturedStart = captor.getAllValues().get(0);
+        LocalDateTime capturedEnd = captor.getAllValues().get(1);
+
+        // 시작일이 일요일, 종료일이 토요일이어야 함
+        assertThat(capturedStart.getDayOfWeek()).isEqualTo(DayOfWeek.SUNDAY);
+        assertThat(capturedEnd.getDayOfWeek()).isEqualTo(DayOfWeek.SATURDAY);
+    }
+
+    // 챌린지 생성 헬퍼
+    private Challenge createChallenge(Long id, String title, List<ChallengeDays> targetDays) {
+        Challenge challenge = Challenge.builder()
+                .id(id)
+                .title(title)
+                .rule("규칙")
+                .verifyStartTime(LocalTime.of(9, 0))
+                .verifyEndTime(LocalTime.of(18, 0))
+                .build();
+
+        // 목표 요일 추가
+        for (ChallengeDays day : targetDays) {
+            challenge.getChallengeDays().add(
+                    ChallengeDayJoin.builder().dayOfWeek(day).challenge(challenge).build()
+            );
+        }
+        return challenge;
+    }
+
+    // 인증 내역 생성 헬퍼 (Reflection으로 createdAt 주입)
+    private Verification createVerification(DayOfWeek dayOfWeek) {
+        Verification verification = Verification.builder().status(VerificationStatus.COMPLETED).build();
+
+        // 이번 주 해당 요일의 날짜 계산
+        LocalDateTime date = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY)) // 일요일로 이동
+                .with(TemporalAdjusters.nextOrSame(dayOfWeek)); // 해당 요일로 이동
+
+        if (dayOfWeek == DayOfWeek.SUNDAY) {
+            date = LocalDateTime.now().with(TemporalAdjusters.previousOrSame(DayOfWeek.SUNDAY));
+        }
+
+        ReflectionTestUtils.setField(verification, "createdAt", date);
+        return verification;
+    }
+
+    // 참여 상태 Mocking
+    private void mockParticipating(User user, Challenge challenge) {
+        UserChallenge uc = UserChallenge.builder()
+                .id(10L).user(user).challenge(challenge)
+                .status(ChallengeJoinStatus.JOINED)
+                .build();
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(uc));
+    }
+
+    // Repository 호출 Mocking (Common)
+    private void mockRepositoryCalls(User user, Challenge challenge, List<Verification> verifications) {
+        given(challengeRepository.findByIdWithDays(challenge.getId())).willReturn(Optional.of(challenge));
+        // any()를 사용한 날짜 범위 계산 로직
+        given(verificationRepository.findWeeklyVerifications(
+                eq(user.getId()),
+                eq(challenge.getId()),
+                any(LocalDateTime.class),
+                any(LocalDateTime.class),
+                eq(VerificationStatus.COMPLETED)
+        )).willReturn(verifications);
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -107,7 +107,33 @@ class ChallengeServiceProfileTest {
     }
 
     @Test
-    @DisplayName("3. [주 시작일 인증] 일요일(주의 시작)에 인증한 경우 -> 이번 주 현황에 포함되어야 한다")
+    @DisplayName("3. [중복 인증] 월요일에 2번 인증했더라도 -> 결과에는 MONDAY가 한 번만 나와야 한다 (distinct)")
+    void getChallengeProfile_DuplicateVerification() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Challenge challenge = createChallenge(challengeId, "중복 인증 테스트", List.of(ChallengeDays.MONDAY));
+
+        mockParticipating(user, challenge);
+
+        // 인증 내역: 월요일 아침, 월요일 저녁 (같은 요일 2건)
+        List<Verification> verifications = List.of(
+                createVerification(DayOfWeek.MONDAY),
+                createVerification(DayOfWeek.MONDAY)
+        );
+
+        mockRepositoryCalls(user, challenge, verifications);
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getVerifiedDaysThisWeek()).hasSize(1); // 중복 제거 확인
+        assertThat(result.getVerifiedDaysThisWeek()).containsOnly(ChallengeDays.MONDAY);
+    }
+
+    @Test
+    @DisplayName("4. [주 시작일 인증] 일요일(주의 시작)에 인증한 경우 -> 이번 주 현황에 포함되어야 한다")
     void getChallengeProfile_SundayVerification() {
         // Given
         Long challengeId = 1L;
@@ -131,7 +157,7 @@ class ChallengeServiceProfileTest {
     }
 
     @Test
-    @DisplayName("4. [미참여] 챌린지에 참여하지 않은 경우 -> verifiedDaysThisWeek는 null이어야 한다")
+    @DisplayName("5. [미참여] 챌린지에 참여하지 않은 경우 -> verifiedDaysThisWeek는 null이어야 한다")
     void getChallengeProfile_NotParticipating() {
         // Given
         Long challengeId = 1L;
@@ -151,7 +177,7 @@ class ChallengeServiceProfileTest {
     }
 
     @Test
-    @DisplayName("5. [기간 제외] 지난 주(예: 지난 목요일)에 인증했더라도, 이번 주(일~토) 범위 밖이므로 안 떠야 한다")
+    @DisplayName("6. [기간 제외] 지난 주(예: 지난 목요일)에 인증했더라도, 이번 주(일~토) 범위 밖이므로 안 떠야 한다")
     void getChallengeProfile_LastWeekVerification_ShouldNotAppear() {
         // Given
         Long challengeId = 1L;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #79 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

### 1. 챌린지 프로필 조회 API 구현
- 기능: 로그인한 유저의 참여 여부에 따라 다른 UI 데이터를 반환하도록 구현했습니다.
  - 참여 중인 경우, 이번 주(일요일~토요일) 인증 완료한 요일 리스트를 계산하여 반환합니다.
  - 미참여 시에는 챌린지 규칙과 기본 정보만 반환합니다.

### 도메인 로직 개선
- `Challenge` Enum에 `from(DayOfWeek)` 메서드를 추가하여 서비스 계층의 변환 로직을 위임했습니다.
- `ChallengeConverter`와 `ChallengeServiceImpl`의 간의 중복 코드를 제거했습니다.

### 테스트 코드 구조 개선
- 기존 `ChallengeServiceImplTest`를 기능 단위에 맞춰 `ChallengeServiceInfoTest`로 이름을 변경했습니다.
- 신규 검증을 위한 `ChallengeServiceProfileTest`를 작성했습니다. (부분 인증, 중복 인증, 지난 주 인증 제외 등 다양한 케이스 커버)

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger, 단위 테스트
* **결과 요약:** 스웨거로 프로필 정보 조회 확인, ChallengeServiceProfileTest의 총 6개 시나리오 테스트 통과

| ID | 테스트 시나리오 | 상황 (Given) | 예상 결과 (Then) | 검증 핵심 로직
-- | -- | -- | -- | --
1 | 부분 인증 | 목표가 '월/목'인 챌린지에서 '월요일'만 인증함 | verifiedDays 리스트에 'MONDAY' 하나만 존재 | 인증한 날짜만 정확히 필터링되어 반환되는지 확인
2 | 완료 인증 | 목표가 '월/목'인 챌린지에서 둘 다 인증함 | verifiedDays 리스트에 'MONDAY', 'THURSDAY' 모두 존재 | 다건 인증 데이터도 누락 없이 조회되는지 확인
3 | 중복 인증 | 같은 날(월요일)에 2번 이상 인증 기록이 있음 | verifiedDays 리스트에 'MONDAY'가 1번만 존재 | Stream의 .distinct()를 통한 중복 제거 동작 확인
4 | 주 시작일 | 이번 주의 시작인 **'일요일'**에 인증함 | verifiedDays 리스트에 'SUNDAY' 포함 | 날짜 계산 로직에서 시작일(일요일)이 포함되는지 확인
5 | 미참여 | 유저가 해당 챌린지에 참여하지 않음 | isParticipating = falseverifiedDays = null | 참여 여부에 따른 데이터 분기 처리(UI 변경용) 확인
6 | 기간 제외 | 지난 주 목요일에 인증함 (이번 주 범위 밖) | verifiedDays 리스트가 비어있음 (Empty) | 일요일~토요일 날짜 범위 계산이 정확하여 과거 기록을 제외하는지 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 설명 | 이미지 |
|---|-----------|
| 프로필 조회 API | <img width="1166" height="631" alt="image" src="https://github.com/user-attachments/assets/6e0a441b-f4a9-47f8-80f2-0c4d19e7b836" /> |
| 단위 테스트 | <img width="860" height="315" alt="image" src="https://github.com/user-attachments/assets/44071840-1277-4469-9489-02a3c30d1bf0" /> |


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- 도메인 로직 개선

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

## 추가 사항

- 테스트 코드 관련 커밋 메시지를 잘못 작성했습니다... pr 쓰고 나서 알았네요😢 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 프로필 조회 API 추가: GET /api/v1/challenges/{challengeId}/profile — 참여 여부, 규칙, 목표 요일, 검증 시간대, 이번 주 인증 완료 요일 등 통합 프로필 반환

* **테스트**
  * 챌린지 프로필 동작 검증용 단위 테스트 추가(다양한 인증·참여 시나리오 포함)

* **잡무(성능)**
  * 조회 성능 개선을 위한 DB 인덱스 추가 및 마이그레이션 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->