### PR TITLE
[Feat] 챌린지 자동 시작 스케줄러 기능 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
@@ -1,8 +1,10 @@
 package com.hrr.backend.domain.challenge.repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import com.hrr.backend.global.common.enums.ChallengeStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -29,4 +31,28 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long>, Cha
 	// 요일 정보(ChallengeDays)까지 한 번에 가져오는 Fetch Join 쿼리
 	@Query("SELECT c FROM Challenge c LEFT JOIN FETCH c.challengeDays WHERE c.id = :id")
 	Optional<Challenge> findByIdWithDays(@Param("id") Long id);
+
+	/**
+	 * 기준 시각 이전(포함)의 UPCOMING 챌린지 ID 조회
+	 * - 스케줄러가 로그용으로 먼저 조회할 때 사용
+	 */
+	@Query("SELECT c.id FROM Challenge c " +
+			"WHERE c.status = :currentStatus AND c.startDate <= :referenceTime")
+	List<Long> findIdsToStart(
+			@Param("currentStatus") ChallengeStatus currentStatus,
+			@Param("referenceTime") LocalDateTime referenceTime
+	);
+
+	/**
+	 * 기준 시각 이전(포함)의 UPCOMING 챌린지를 ONGOING으로 일괄 변경
+	 */
+	@Modifying(clearAutomatically = true)
+	@Query("UPDATE Challenge c SET c.status = :targetStatus " +
+			"WHERE c.status = :currentStatus AND c.startDate <= :referenceTime")
+	int updateChallengeStatusToOngoing(
+			@Param("targetStatus") ChallengeStatus targetStatus,
+			@Param("currentStatus") ChallengeStatus currentStatus,
+			@Param("referenceTime") LocalDateTime referenceTime
+	);
+
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
@@ -1,17 +1,27 @@
 package com.hrr.backend.global.scheduler;
 
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
 @Slf4j
 public class ChallengeScheduler {
+
 	private final RedisTemplate<String, String> redisTemplate;
+	private final ChallengeRepository challengeRepository;
+
 	private static final String TODAY_CHALLENGE_RANKING_KEY = "today:challenge:clicks";
 
 	/**
@@ -26,5 +36,43 @@ public class ChallengeScheduler {
 		if (isDeleted) {
 			log.info("00시 초기화 완료. 클릭수 Sorted Set 삭제됨.");
 		}
+	}
+
+	/**
+	 * 챌린지 상태 변경 (UPCOMING -> ONGOING)
+	 * - 기준 시간: 오늘 00:00:00
+	 * - startDate가 기준 시간 이전(포함)인 UPCOMING 챌린지를 ONGOING으로 변경
+	 */
+	@Scheduled(cron = "0 0 0 * * *")
+	@Transactional // DB 작업이므로 필수
+	public void updateChallengeStatus() {
+		// 기준 시간: 오늘 00:00:00
+		LocalDateTime referenceTime = LocalDate.now().atStartOfDay();
+
+		// 1) 먼저 어떤 챌린지가 대상인지 ID만 조회
+		List<Long> idsToStart = challengeRepository.findIdsToStart(
+				ChallengeStatus.UPCOMING,
+				referenceTime
+		);
+
+		if (idsToStart.isEmpty()) {
+			log.info("[Scheduler] 챌린지 상태 변경 대상 없음. 기준 시각: {}", referenceTime);
+			return;
+		}
+
+		// 2) 실제 상태 변경 수행
+		int updatedCount = challengeRepository.updateChallengeStatusToOngoing(
+				ChallengeStatus.ONGOING,
+				ChallengeStatus.UPCOMING,
+				referenceTime
+		);
+
+		// 3) 변경 로그 (기준 시각 + 변경 건수 + 대상 ID)
+		log.info(
+				"[Scheduler] 챌린지 상태 변경 완료. 기준 시각: {}, 변경 건수: {}, 대상 ID: {}",
+				referenceTime,
+				updatedCount,
+				idsToStart
+		);
 	}
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/ChallengeScheduler.java
@@ -49,7 +49,7 @@ public class ChallengeScheduler {
 		// 기준 시간: 오늘 00:00:00
 		LocalDateTime referenceTime = LocalDate.now().atStartOfDay();
 
-		// 1) 먼저 어떤 챌린지가 대상인지 ID만 조회
+		// 먼저 어떤 챌린지가 대상인지 ID만 조회
 		List<Long> idsToStart = challengeRepository.findIdsToStart(
 				ChallengeStatus.UPCOMING,
 				referenceTime
@@ -60,14 +60,14 @@ public class ChallengeScheduler {
 			return;
 		}
 
-		// 2) 실제 상태 변경 수행
+		// 실제 상태 변경 수행
 		int updatedCount = challengeRepository.updateChallengeStatusToOngoing(
 				ChallengeStatus.ONGOING,
 				ChallengeStatus.UPCOMING,
 				referenceTime
 		);
 
-		// 3) 변경 로그 (기준 시각 + 변경 건수 + 대상 ID)
+		// 변경 로그 (기준 시각 + 변경 건수 + 대상 ID)
 		log.info(
 				"[Scheduler] 챌린지 상태 변경 완료. 기준 시각: {}, 변경 건수: {}, 대상 ID: {}",
 				referenceTime,

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -1,0 +1,151 @@
+package com.hrr.backend.domain.challenge.repository;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.global.common.enums.Category;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.common.enums.VerificationType;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@DataJpaTest
+class ChallengeRepositoryTest {
+
+    @Autowired
+    private ChallengeRepository challengeRepository;
+
+    @Autowired
+    private TestEntityManager entityManager;
+
+    @TestConfiguration
+    static class QueryDslTestConfig {
+        @PersistenceContext
+        private EntityManager entityManager;
+
+        @Bean
+        public JPAQueryFactory jpaQueryFactory() {
+            return new JPAQueryFactory(entityManager);
+        }
+    }
+
+    @Test
+    @DisplayName("Bulk Update: 기준 시각(오늘 0시) 이전(포함)의 UPCOMING 챌린지들은 ONGOING으로 상태가 일괄 변경되어야 한다")
+    void updateChallengeStatusToOngoing_UpdatesCorrectChallenges() {
+        // Given
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
+        LocalDateTime yesterdayStart = today.minusDays(1).atStartOfDay();
+        LocalDateTime tomorrowStart = today.plusDays(1).atStartOfDay();
+
+        // [Target] 오늘 0시에 시작하는 챌린지 (UPCOMING -> ONGOING 대상)
+        Challenge targetToday = createChallenge("오늘시작", todayStart, ChallengeStatus.UPCOMING);
+
+        // [Target] 어제 0시에 시작했어야 하는 챌린지 (UPCOMING -> ONGOING 대상)
+        Challenge targetPast = createChallenge("과거시작", yesterdayStart, ChallengeStatus.UPCOMING);
+
+        // [Non-Target] 내일 0시에 시작하는 챌린지 (변경되면 안 됨)
+        Challenge futureChallenge = createChallenge("미래시작", tomorrowStart, ChallengeStatus.UPCOMING);
+
+        // [Non-Target] 이미 종료된 챌린지 (변경되면 안 됨)
+        Challenge finishedChallenge = createChallenge("이미종료", todayStart, ChallengeStatus.FINISHED);
+
+        // DB 반영
+        entityManager.persist(targetToday);
+        entityManager.persist(targetPast);
+        entityManager.persist(futureChallenge);
+        entityManager.persist(finishedChallenge);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        LocalDateTime referenceTime = todayStart;
+
+        int updatedCount = challengeRepository.updateChallengeStatusToOngoing(
+                ChallengeStatus.ONGOING,
+                ChallengeStatus.UPCOMING,
+                referenceTime
+        );
+
+        // Then
+        // 업데이트된 개수 검증 (Today + Past = 2개)
+        assertThat(updatedCount).isEqualTo(2);
+
+        // 상태 변경 검증
+        Challenge updatedToday = challengeRepository.findById(targetToday.getId()).orElseThrow();
+        Challenge updatedPast = challengeRepository.findById(targetPast.getId()).orElseThrow();
+        Challenge ignoredFuture = challengeRepository.findById(futureChallenge.getId()).orElseThrow();
+        Challenge ignoredFinished = challengeRepository.findById(finishedChallenge.getId()).orElseThrow();
+
+        assertThat(updatedToday.getStatus()).isEqualTo(ChallengeStatus.ONGOING);
+        assertThat(updatedPast.getStatus()).isEqualTo(ChallengeStatus.ONGOING);
+
+        assertThat(ignoredFuture.getStatus()).isEqualTo(ChallengeStatus.UPCOMING); // 그대로여야 함
+        assertThat(ignoredFinished.getStatus()).isEqualTo(ChallengeStatus.FINISHED); // 그대로여야 함
+    }
+
+    @Test
+    @DisplayName("findIdsToStart: 기준 시각(오늘 0시) 이전(포함)의 UPCOMING 챌린지 ID만 조회해야 한다")
+    void findIdsToStart_ReturnsCorrectIds() {
+        // Given
+        LocalDate today = LocalDate.now();
+        LocalDateTime todayStart = today.atStartOfDay();
+        LocalDateTime yesterdayStart = today.minusDays(1).atStartOfDay();
+        LocalDateTime tomorrowStart = today.plusDays(1).atStartOfDay();
+
+        Challenge targetToday = createChallenge("오늘시작", todayStart, ChallengeStatus.UPCOMING);
+        Challenge targetPast = createChallenge("과거시작", yesterdayStart, ChallengeStatus.UPCOMING);
+        Challenge futureChallenge = createChallenge("미래시작", tomorrowStart, ChallengeStatus.UPCOMING);
+        Challenge finishedChallenge = createChallenge("이미종료", todayStart, ChallengeStatus.FINISHED);
+
+        entityManager.persist(targetToday);
+        entityManager.persist(targetPast);
+        entityManager.persist(futureChallenge);
+        entityManager.persist(finishedChallenge);
+        entityManager.flush();
+        entityManager.clear();
+
+        // When
+        List<Long> ids = challengeRepository.findIdsToStart(
+                ChallengeStatus.UPCOMING,
+                todayStart
+        );
+
+        // Then
+        assertThat(ids)
+                .containsExactlyInAnyOrder(targetToday.getId(), targetPast.getId())
+                .doesNotContain(futureChallenge.getId(), finishedChallenge.getId());
+    }
+
+    // 테스트용 챌린지 생성 헬퍼
+    private Challenge createChallenge(String title, LocalDateTime startDate, ChallengeStatus status) {
+        return Challenge.builder()
+                .title(title)
+                .description("테스트 설명")
+                .startDate(startDate)
+                .status(status)
+                // 아래 필드들은 @Column(nullable = false) 이므로 더미 값을 채워줍니다.
+                .category(Category.values()[0])
+                .verificationType(VerificationType.values()[0])
+                .isPublic(true)
+                .isViewerMode(false)
+                .maxParticipants(10)
+                .currentParticipants(0)
+                .verifyStartTime(LocalTime.of(9, 0))
+                .verifyEndTime(LocalTime.of(18, 0))
+                .build();
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -137,7 +137,6 @@ class ChallengeRepositoryTest {
                 .description("테스트 설명")
                 .startDate(startDate)
                 .status(status)
-                // 아래 필드들은 @Column(nullable = false) 이므로 더미 값을 채워줍니다.
                 .category(Category.values()[0])
                 .verificationType(VerificationType.values()[0])
                 .isPublic(true)

--- a/src/test/java/com/hrr/backend/global/scheduler/ChallengeSchedulerTest.java
+++ b/src/test/java/com/hrr/backend/global/scheduler/ChallengeSchedulerTest.java
@@ -1,0 +1,93 @@
+package com.hrr.backend.global.scheduler;
+
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeSchedulerTest {
+
+    @InjectMocks
+    private ChallengeScheduler challengeScheduler;
+
+    @Mock
+    private ChallengeRepository challengeRepository;
+
+    @Test
+    @DisplayName("updateChallengeStatus: 시작 대상 챌린지가 있으면 findIdsToStart 후 bulk UPDATE를 수행한다")
+    void updateChallengeStatus_UpdatesDB_WhenTargetsExist() {
+        // Given
+        LocalDate today = LocalDate.now();
+        LocalDateTime expectedReferenceTime = today.atStartOfDay();
+
+        // findIdsToStart가 대상 ID들을 리턴하도록 세팅
+        when(challengeRepository.findIdsToStart(
+                eq(ChallengeStatus.UPCOMING),
+                any(LocalDateTime.class))
+        ).thenReturn(List.of(1L, 2L));
+
+        when(challengeRepository.updateChallengeStatusToOngoing(
+                any(), any(), any())
+        ).thenReturn(2);
+
+        // When
+        challengeScheduler.updateChallengeStatus();
+
+        // Then
+        ArgumentCaptor<LocalDateTime> referenceCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+
+        // findIdsToStart 호출 시점의 기준 시각 검증
+        verify(challengeRepository).findIdsToStart(
+                eq(ChallengeStatus.UPCOMING),
+                referenceCaptor.capture()
+        );
+
+        assertThat(referenceCaptor.getValue()).isEqualTo(expectedReferenceTime);
+
+        // updateChallengeStatusToOngoing도 동일한 기준 시각으로 호출되는지 검증
+        verify(challengeRepository).updateChallengeStatusToOngoing(
+                eq(ChallengeStatus.ONGOING),
+                eq(ChallengeStatus.UPCOMING),
+                eq(expectedReferenceTime)
+        );
+    }
+
+    @Test
+    @DisplayName("updateChallengeStatus: 시작 대상 챌린지가 없으면 bulk UPDATE는 호출되지 않는다")
+    void updateChallengeStatus_DoesNothing_WhenNoTargets() {
+        // Given
+        when(challengeRepository.findIdsToStart(
+                eq(ChallengeStatus.UPCOMING),
+                any(LocalDateTime.class))
+        ).thenReturn(List.of());
+
+        // When
+        challengeScheduler.updateChallengeStatus();
+
+        // Then
+        verify(challengeRepository).findIdsToStart(
+                eq(ChallengeStatus.UPCOMING),
+                any(LocalDateTime.class)
+        );
+
+        // UPDATE 쿼리는 호출되면 안 됨
+        verify(challengeRepository, never()).updateChallengeStatusToOngoing(
+                any(), any(), any()
+        );
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #이슈번호

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

이번 PR에서는 **챌린지 자동 시작 스케줄러 기능을 새롭게 추가**했습니다.

- 매일 자정(00시)에 동작하는 스케줄러 구현
- 챌린지의 `startDate`(0시 고정)가 오늘 0시 이전(포함)인 경우 자동으로 `UPCOMING → ONGOING` 상태 전환
- 시작 대상 챌린지 ID를 사전에 조회하여, 변경 내역을 명확히 확인할 수 있도록 로그 개선
- 레포지토리와 스케줄러 로직에 대한 단위 테스트 추가

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬 (IntelliJ + MySQL)
* **테스트 방법:** JUnit 기반 단위 테스트 실행  
* **결과 요약:**  
  - 기준 시각(오늘 0시) 이전(포함)의 UPCOMING 챌린지만 ONGOING으로 전환되는지 검증  
  - 시작 대상 챌린지가 없을 때는 bulk UPDATE가 호출되지 않는 동작 확인  
  - 신규 테스트 케이스 전부 정상 통과
---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 기능 | 스크린샷 |
|---|-------------|
| ChallengeSchedulerTest | <img width="2171" height="570" alt="image" src="https://github.com/user-attachments/assets/bb3669ee-75d6-4c16-8e14-4939c8934743" /> |
| ChallengeRepositoryTest | <img width="859" height="261" alt="image" src="https://github.com/user-attachments/assets/72cfdf02-b5a9-4f2b-b0b2-0df1a5bf4b6d" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 자동 시작 기준 시각을 `LocalDate.now().atStartOfDay()`로 설정한 부분이 도메인 요구사항(0시 시작 규칙)에 맞는지 검토 부탁드립니다.  
- 스케줄러 + bulk update 조합이 실제 운영 환경에서도 무리가 없는지 의견 부탁드립니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

TODO: [테스트 환경 개선] H2에서 예약어(user/hour 등)로 인해 발생하는 스키마 생성 오류 해결하기



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 매일 자정에 예정된 상태의 챌린지가 자동으로 진행 중 상태로 전환되는 스케줄된 작업이 추가되었습니다.

* **테스트**
  * 챌린지 저장소 및 스케줄러 기능에 대한 새로운 단위 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->