### PR TITLE
[CHORE] 시간대 통일 및 이미지 접근 허용 설정

### DIFF
--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -38,10 +38,12 @@ services:
     image: ychan0/hrr-server:v1.0.0
     container_name: hrr_app_prod
     environment:
+      TZ: Asia/Seoul
+
       # Secrets Manager에서 가져온 환경 변수 사용
       SPRING_PROFILES_ACTIVE: prod
 
-      SPRING_DATASOURCE_URL: 'jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=UTC&characterEncoding=UTF-8&sslMode=REQUIRED'
+      SPRING_DATASOURCE_URL: 'jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sslMode=REQUIRED'
       SPRING_DATASOURCE_USERNAME: ${RDS_USERNAME}
       SPRING_DATASOURCE_PASSWORD: ${RDS_PASSWORD}
 
@@ -66,6 +68,8 @@ services:
     image: redis:7.4.2-alpine
     container_name: hrr_redis_prod
     restart: always
+    environment:
+      - TZ=Asia/Seoul
     volumes:
       - redis_data:/data
 
@@ -74,6 +78,8 @@ services:
     image: ychan0/hrr-model:v1.0.0
     container_name: hrr_model_prod
     restart: always
+    environment:
+      - TZ=Asia/Seoul
 
 volumes:
   db-data:

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -16,6 +16,8 @@ services:
     # 6시간마다 Nginx 설정을 재로드하여 갱신된 인증서 반영
     command: "/bin/sh -c 'while :; do sleep 6h & wait $${!}; nginx -s reload; done & nginx -g \"daemon off;\"'"
     restart: always
+    environment:
+      - TZ=Asia/Seoul
     depends_on:
       - app
 
@@ -30,6 +32,8 @@ services:
     # 12시간마다 갱신 시도하는 루프 스크립트
     entrypoint: "/bin/sh -c 'trap exit TERM; while :; do certbot renew; sleep 12h & wait $${!}; done;'"
     restart: always
+    environment:
+      - TZ=Asia/Seoul
 
 # ---- nginx 외 다른 서비스들은 외부 포트 사용 x ---
 

--- a/src/main/java/com/hrr/backend/global/s3/S3Service.java
+++ b/src/main/java/com/hrr/backend/global/s3/S3Service.java
@@ -7,6 +7,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 import software.amazon.awssdk.services.s3.presigner.S3Presigner;
 import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
@@ -32,6 +33,7 @@ public class S3Service {
 		// PutObjectRequest 생성
 		PutObjectRequest objectRequest = PutObjectRequest.builder()
 			.bucket(bucketName)
+			.acl(ObjectCannedACL.PUBLIC_READ)
 			.key(s3Key)
 			.build();
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sslMode=REQUIRED # 국제 표준시인 UTC 적용 및 UTF-8로 인코딩
+    url: jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sslMode=REQUIRED # UTF-8로 인코딩(시간대는 임시로 KST 적용)
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
 

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -11,7 +11,7 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=UTC&characterEncoding=UTF-8&sslMode=REQUIRED # 국제 표준시인 UTC 적용 및 UTF-8로 인코딩
+    url: jdbc:mysql://${RDS_URL}:3306/hrr_db?serverTimezone=Asia/Seoul&characterEncoding=UTF-8&sslMode=REQUIRED # 국제 표준시인 UTC 적용 및 UTF-8로 인코딩
     username: ${RDS_USERNAME}
     password: ${RDS_PASSWORD}
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #122

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

EC2, Docker 컨테이너, Redis, RDS, Spring Boot 등 전체 시스템을 KST로 통일(UTC로 설정 후 변환하는 게 정석인 줄 알지만 편의성을 위해 임시로,,)
S3 이미지 업로드 시 접근 제한으로 읽기 작업이 안되는 이슈가 있어서 임시로 public으로 올라가게 설정했습니다.(디미버스 이후에 접근용 url을 발급받는 방식으로 전환 예정)

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬 및 ec2 도커 체크
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 수동 테스트
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 변경 완료 |
|---|
|<img width="434" height="80" alt="image" src="https://github.com/user-attachments/assets/b74df569-7452-42b4-9274-5fc3f28d9544" />|

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 애플리케이션 전체 시간대를 Asia/Seoul로 통일하여 타임스탬프 처리 및 데이터 저장 일관성 개선.
  * 배포 환경 설정의 시간대 관련 설정과 주석을 정비하고 환경 블록의 형식을 일부 정리.

* **신기능**
  * 클라우드 스토리지에 업로드되는 파일에 공개 읽기 권한이 기본으로 설정되어 사용자 및 외부 리소스 접근이 가능.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->