### PR TITLE
[BUG] 챌린지 추천 응답 이미지 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/recommendation/dto/response/ChallengeItemDto.java
+++ b/src/main/java/com/hrr/backend/domain/recommendation/dto/response/ChallengeItemDto.java
@@ -26,5 +26,6 @@ public class ChallengeItemDto {
     private String goal_text;
     private LocalTime verifyStartTime;
     private LocalTime verifyEndTime;
+    private String imageKey;
     private List<Float> embedding;
 }

--- a/src/main/java/com/hrr/backend/domain/recommendation/dto/response/ChallengeItemResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/recommendation/dto/response/ChallengeItemResponseDto.java
@@ -20,4 +20,6 @@ public class ChallengeItemResponseDto {
     private String goalText;
     private LocalTime verifyStartTime;
     private LocalTime verifyEndTime;
+    @JsonProperty("image_key")
+    private String imageKey;
 }

--- a/src/main/java/com/hrr/backend/domain/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/recommendation/repository/RecommendationRepository.java
@@ -34,6 +34,7 @@ public class RecommendationRepository {
                     c.rule AS goal_text,
                     c.verify_start_time,
                     c.verify_end_time,
+                    c.image_key,
                     ce.challenge_embedding
                 FROM challenge c
                 LEFT JOIN challenge_embedding ce
@@ -57,6 +58,7 @@ public class RecommendationRepository {
                     .goal_text(rs.getString("goal_text"))
                     .verifyStartTime(start)
                     .verifyEndTime(end)
+                    .imageKey(rs.getString("image_key"))
                     .embedding(bytesToFloatList(embeddingBytes))
                     .build();
         });

--- a/src/main/java/com/hrr/backend/domain/recommendation/service/ChallengeRecommendationService.java
+++ b/src/main/java/com/hrr/backend/domain/recommendation/service/ChallengeRecommendationService.java
@@ -9,6 +9,7 @@ import com.hrr.backend.domain.recommendation.dto.response.ModelApiResponse;
 import com.hrr.backend.domain.recommendation.dto.response.ChallengeRecommendResult;
 import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.s3.S3UrlUtil;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -25,6 +26,7 @@ public class ChallengeRecommendationService {
 
     private final RecommendationRepository challengeRepository;
     private final ModelApiClient modelApiClient;
+    private final S3UrlUtil s3UrlUtil;
 
     private static final int EMBED_DIM = 768;
 
@@ -154,7 +156,9 @@ public class ChallengeRecommendationService {
                                     .goalText(base.getGoal_text())
                                     .verifyStartTime(base.getVerifyStartTime())
                                     .verifyEndTime(base.getVerifyEndTime())
-                                    .imageKey(base.getImageKey())
+                                    .imageKey(
+                                            s3UrlUtil.toFullUrl(base.getImageKey())
+                                    )
                                     .build();
                         })
                         .filter(Objects::nonNull)

--- a/src/main/java/com/hrr/backend/domain/recommendation/service/ChallengeRecommendationService.java
+++ b/src/main/java/com/hrr/backend/domain/recommendation/service/ChallengeRecommendationService.java
@@ -154,6 +154,7 @@ public class ChallengeRecommendationService {
                                     .goalText(base.getGoal_text())
                                     .verifyStartTime(base.getVerifyStartTime())
                                     .verifyEndTime(base.getVerifyEndTime())
+                                    .imageKey(base.getImageKey())
                                     .build();
                         })
                         .filter(Objects::nonNull)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #126 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

챌린지를 추천 받는 응답에 챌린지 프로필 이미지의 url까지 반환되도록 추가

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Postman
* **결과 요약:** 
<img width="1988" height="1198" alt="image" src="https://github.com/user-attachments/assets/6134aa63-6c92-4fc3-aa5e-2c343ec18f1d" />


---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 추천 응답에 이미지 키 필드 추가 — 이제 추천 항목에 이미지 식별자(image_key)가 포함되어 반환됩니다.
  * 이미지 키는 응답에서 전체 접근 가능한 이미지 URL로 변환되어 제공되므로 클라이언트에서 바로 사용 가능합니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->