### PR TITLE
[FEAT] 애플 로그인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70' // .p8 파일 파싱용
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
-    implementation 'org.bouncycastle:bcpkix-jdk15on:1.70' // .p8 파일 파싱용
+    implementation 'org.bouncycastle:bcpkix-jdk18on:1.83'    // .p8 파일 파싱용
 
     // validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'

--- a/deploy.sh
+++ b/deploy.sh
@@ -45,6 +45,10 @@ export PROD_KAKAO_REDIRECT_URI=$(echo "$SECRET_JSON" | jq -r '.PROD_KAKAO_REDIRE
 export SPRING_PROFILES_ACTIVE=prod # Spring Profile 설정
 export FIREBASE_SERVICE_ACCOUNT_JSON=$(echo "$SECRET_JSON" | jq -r '.FIREBASE_SERVICE_ACCOUNT_JSON')
 export KAKAO_APP_REDIRECT_URI=$(echo "$SECRET_JSON" | jq -r '.KAKAO_APP_REDIRECT_URI')
+export APPLE_TEAM_ID=$(echo "$SECRET_JSON" | jq -r '.APPLE_TEAM_ID')
+export APPLE_CLIENT_ID=$(echo "$SECRET_JSON" | jq -r '.APPLE_CLIENT_ID')
+export APPLE_KEY_ID=$(echo "$SECRET_JSON" | jq -r '.APPLE_KEY_ID')
+export APPLE_P8_KEY=$(echo "$SECRET_JSON" | jq -r '.APPLE_P8_KEY')
 
 echo "--- 3/4: Docker Hub에서 이미지 Pull 및 베포 준비  ---"
 

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -65,6 +65,11 @@ services:
 
       FIREBASE_SERVICE_ACCOUNT_JSON: ${FIREBASE_SERVICE_ACCOUNT_JSON}
 
+      APPLE_TEAM_ID: ${APPLE_TEAM_ID}
+      APPLE_CLIENT_ID: ${APPLE_CLIENT_ID}
+      APPLE_KEY_ID: ${APPLE_KEY_ID}
+      APPLE_P8_KEY: ${APPLE_P8_KEY}
+
     restart: always
 
   # Redis 서비스

--- a/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
@@ -16,6 +16,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.MediaType;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
@@ -144,6 +145,7 @@ public class AuthController {
 	/**
 	 * 애플 로그인 테스트용 임시 리다이렉트 url
 	 */
+	@Profile("local")	// 로켈 테스트 환경에서만 작동 제한
 	@PostMapping("/login/apple/test")
 	@Operation(summary = "애플 로그인 테스트용 url")
 	public void appleTestCallback(jakarta.servlet.http.HttpServletRequest request) {

--- a/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
@@ -9,17 +9,21 @@ import com.hrr.backend.global.response.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 
 @Tag(name = "Auth", description = "인증 관련 API")
 @RestController
@@ -119,6 +123,8 @@ public class AuthController {
 	}
 
 	@PostMapping("/login/apple")
+	@Operation(summary = "애플 로그인",
+		description = "authorizationCode와 이름 정보를 받아 애플 로그인을 구현합니다. 이름은 애플 응답 그대로 first name과 last name을 넣어주시면 됩니다.")
 	public ApiResponse<AuthResponseDto.LoginResponse> appleLogin(
 		@RequestBody @Valid AuthRequestDto.AppleLoginRequest request) {
 
@@ -133,6 +139,31 @@ public class AuthController {
 		authService.logout(authorizationHeader);
 
 		return ApiResponse.onSuccess(SuccessCode.OK, "로그아웃에 성공했습니다.");
+	}
+
+	/**
+	 * 애플 로그인 테스트용 임시 리다이렉트 url
+	 */
+	@PostMapping("/login/apple/test")
+	@Operation(summary = "애플 로그인 테스트용 url")
+	public void appleTestCallback(jakarta.servlet.http.HttpServletRequest request) {
+		log.info("======= [DEBUG] APPLE CALLBACK START =======");
+
+		// 헤더 전체 출력
+		java.util.Enumeration<String> headerNames = request.getHeaderNames();
+		while (headerNames.hasMoreElements()) {
+			String name = headerNames.nextElement();
+			log.info("Header -> {}: {}", name, request.getHeader(name));
+		}
+
+		// 파라미터(Body) 전체 출력
+		java.util.Enumeration<String> params = request.getParameterNames();
+		while (params.hasMoreElements()) {
+			String name = params.nextElement();
+			log.info("Param -> {}: {}", name, request.getParameter(name));
+		}
+
+		log.info("======= [DEBUG] APPLE CALLBACK END =======");
 	}
 }
 

--- a/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/hrr/backend/domain/auth/controller/AuthController.java
@@ -118,6 +118,13 @@ public class AuthController {
 		return ApiResponse.onSuccess(SuccessCode.OK, loginResponse);
 	}
 
+	@PostMapping("/login/apple")
+	public ApiResponse<AuthResponseDto.LoginResponse> appleLogin(
+		@RequestBody @Valid AuthRequestDto.AppleLoginRequest request) {
+
+		return ApiResponse.onSuccess(SuccessCode.OK, authService.appleLogin(request));
+	}
+
 	@PostMapping("/logout")
 	@Operation(summary = "로그아웃",
 		description = "로그아웃 시 토큰을 무효화 시킵니다.")

--- a/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.auth.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class AuthRequestDto {
     public record SocialLoginRequest(
@@ -15,5 +16,24 @@ public class AuthRequestDto {
 		@Schema(description = "카카오 SDK에서 발급받은 Access Token", example = "string")
 		@NotBlank(message = "토큰은 필수값입니다.")
 		String accessToken;
+	}
+
+	@Getter
+	@NoArgsConstructor
+	public static class AppleLoginRequest {
+		@Schema(description = "식별 토큰", example = "string")
+		@NotBlank(message = "토큰은 필수값입니다.")
+		private String identityToken;
+
+		@Schema(description = "인가 코드(토큰 발급용)", example = "string")
+		@NotBlank(message = "코드는 필수값입니다.")
+		private String authorizationCode;
+
+		private String firstName;
+		private String lastName;
+
+		public String getName() {
+			return firstName + " " + lastName;
+		}
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
@@ -1,5 +1,7 @@
 package com.hrr.backend.domain.auth.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -21,10 +23,6 @@ public class AuthRequestDto {
 	@Getter
 	@NoArgsConstructor
 	public static class AppleLoginRequest {
-		@Schema(description = "식별 토큰", example = "string")
-		@NotBlank(message = "토큰은 필수값입니다.")
-		private String identityToken;
-
 		@Schema(description = "인가 코드(토큰 발급용)", example = "string")
 		@NotBlank(message = "코드는 필수값입니다.")
 		private String authorizationCode;
@@ -32,8 +30,10 @@ public class AuthRequestDto {
 		private String firstName;
 		private String lastName;
 
+		@JsonIgnore
+		@Schema(hidden = true)
 		public String getName() {
-			return firstName + " " + lastName;
+			return lastName + firstName;
 		}
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/auth/dto/AuthRequestDto.java
@@ -33,7 +33,11 @@ public class AuthRequestDto {
 		@JsonIgnore
 		@Schema(hidden = true)
 		public String getName() {
-			return lastName + firstName;
+			if (lastName == null && firstName == null) {
+				return null;
+			}
+
+			return (lastName != null ? lastName : "") + (firstName != null ? firstName : "");
 		}
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/auth/dto/AuthResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/auth/dto/AuthResponseDto.java
@@ -20,4 +20,6 @@ public class AuthResponseDto {
     public record TokenReissueResponse(
             String accessToken
     ) {}
+
+
 }

--- a/src/main/java/com/hrr/backend/domain/auth/entity/SocialAuth.java
+++ b/src/main/java/com/hrr/backend/domain/auth/entity/SocialAuth.java
@@ -1,0 +1,40 @@
+package com.hrr.backend.domain.auth.entity;
+
+import com.hrr.backend.domain.auth.entity.enums.SocialType;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.global.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "social_auth", indexes = {
+	@Index(name = "idx_social_id_type", columnList = "social_id, social_type")	// 문자열 검색의 최적화를 위해 인덱스 도입
+})
+public class SocialAuth extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@OneToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "user_id", nullable = false)
+	private User user;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "social_type", nullable = false)
+	private SocialType socialType;
+
+	@Column(name = "social_id", nullable = false)
+	private String socialId; // 애플 sub, 네이버 id, 카카오 id(String 변환)
+
+	/**
+	 * 애플이나 네이버처럼 탈퇴 시 RT 가 필요한 경우를 위해 필드 추가
+	 * TEXT 타입을 사용하여 긴 토큰 값도 저장 가능
+	 */
+	@Column(name = "social_refresh_token", columnDefinition = "TEXT")
+	private String socialRefreshToken;
+}

--- a/src/main/java/com/hrr/backend/domain/auth/entity/SocialAuth.java
+++ b/src/main/java/com/hrr/backend/domain/auth/entity/SocialAuth.java
@@ -21,7 +21,7 @@ public class SocialAuth extends BaseEntity {
 	private Long id;
 
 	@OneToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "user_id", nullable = false)
+	@JoinColumn(name = "user_id", nullable = false, unique = true)
 	private User user;
 
 	@Enumerated(EnumType.STRING)

--- a/src/main/java/com/hrr/backend/domain/auth/repository/SocialAuthRepository.java
+++ b/src/main/java/com/hrr/backend/domain/auth/repository/SocialAuthRepository.java
@@ -10,5 +10,5 @@ import com.hrr.backend.domain.auth.entity.enums.SocialType;
 public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
 
 	// Social ID와 SocialType으로 검색(겹칠 일 거의 없겠지만 혹시 모르니 같이 검색)
-	Optional<SocialAuth> findBySocialIdAndSocialType(String socialId, SocialType kakao);
+	Optional<SocialAuth> findBySocialIdAndSocialType(String socialId, SocialType socialType);
 }

--- a/src/main/java/com/hrr/backend/domain/auth/repository/SocialAuthRepository.java
+++ b/src/main/java/com/hrr/backend/domain/auth/repository/SocialAuthRepository.java
@@ -1,0 +1,14 @@
+package com.hrr.backend.domain.auth.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hrr.backend.domain.auth.entity.SocialAuth;
+import com.hrr.backend.domain.auth.entity.enums.SocialType;
+
+public interface SocialAuthRepository extends JpaRepository<SocialAuth, Long> {
+
+	// Social ID와 SocialType으로 검색(겹칠 일 거의 없겠지만 혹시 모르니 같이 검색)
+	Optional<SocialAuth> findBySocialIdAndSocialType(String socialId, SocialType kakao);
+}

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -18,6 +18,8 @@ import java.util.Base64;
 import java.util.Date;
 import java.util.Map;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 
@@ -38,20 +40,33 @@ public class AppleAuthService {
 	 */
 	public String getAppleAccountId(String identityToken) {
 		try {
+			// JWT: [header].[payload].[signature] 구조
 			String[] chunks = identityToken.split("\\.");
+			if (chunks.length < 2) {
+				throw new IllegalArgumentException("Invalid JWT token");
+			}
+
+			// Payload 디코딩; URL Safe Base64 디코더를 사용
 			Base64.Decoder decoder = Base64.getUrlDecoder();
 			String payload = new String(decoder.decode(chunks[1]));
 
-			return payload.substring(payload.indexOf("\"sub\":\"") + 7, payload.indexOf("\",\"auid\""));
+			// ObjectMapper를 사용하여 JSON에서 sub 필드만 추출
+			ObjectMapper objectMapper = new ObjectMapper();
+			JsonNode jsonNode = objectMapper.readTree(payload);
+
+			String sub = jsonNode.get("sub").asText();
+
+			return sub;
 		} catch (Exception e) {
+			log.error("애플 토큰으로부터 sub 획득 실패");
 			throw new GlobalException(ErrorCode.AUTH_APPLE_ID_TOKEN_INVALID);
 		}
 	}
 
 	/**
-	 * Authorization Code로 애플 Refresh Token 받아오기
+	 * Authorization Code로 애플 id_token과 Refresh Token 받아오기
 	 */
-	public String getAppleRefreshToken(String code) {
+	public Map<String, String> getAppleTokens(String code) {
 		String clientSecret = createClientSecret();
 		String tokenUrl = "https://appleid.apple.com/auth/token";
 
@@ -68,7 +83,13 @@ public class AppleAuthService {
 
 		try {
 			ResponseEntity<Map> response = restTemplate.postForEntity(tokenUrl, entity, Map.class);
-			return (String) response.getBody().get("refresh_token");
+			Map<String, Object> body = response.getBody();
+
+			// id_token과 refresh_token을 모두 맵에 담아 반환합니다.
+			return Map.of(
+				"id_token", (String) body.get("id_token"),
+				"refresh_token", (String) body.get("refresh_token")
+			);
 		} catch (Exception e) {
 			log.error("애플 RT 발급 실패");
 			throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -37,6 +37,7 @@ public class AppleAuthService {
 	@Value("${apple.p8-key}") private String P8_KEY; // .p8 파일의 텍스트 내용 전체
 
 	private final RestTemplate restTemplate;
+	private static final ObjectMapper objectMapper = new ObjectMapper();
 
 	/**
 	 * Identity Token에서 유저 식별자(sub) 추출 (단순 파싱 버전; 추후 검증 로직 추가 예정)
@@ -54,7 +55,6 @@ public class AppleAuthService {
 			String payload = new String(decoder.decode(chunks[1]));
 
 			// ObjectMapper를 사용하여 JSON에서 sub 필드만 추출
-			ObjectMapper objectMapper = new ObjectMapper();
 			JsonNode jsonNode = objectMapper.readTree(payload);
 
 			// "sub" 필드가 null 체크

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -1,0 +1,114 @@
+package com.hrr.backend.domain.auth.service;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
+import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.http.*;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+import java.security.PrivateKey;
+import java.util.Base64;
+import java.util.Date;
+import java.util.Map;
+
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AppleAuthService {
+
+	@Value("${apple.team-id}") private String TEAM_ID;
+	@Value("${apple.client-id}") private String CLIENT_ID;
+	@Value("${apple.key-id}") private String KEY_ID;
+	@Value("${apple.p8-key}") private String P8_KEY; // .p8 파일의 텍스트 내용 전체
+
+	private final RestTemplate restTemplate = new RestTemplate();
+
+	/**
+	 * Identity Token에서 유저 식별자(sub) 추출 (단순 파싱 버전; 추후 검증 로직 추가 예정)
+	 */
+	public String getAppleAccountId(String identityToken) {
+		try {
+			String[] chunks = identityToken.split("\\.");
+			Base64.Decoder decoder = Base64.getUrlDecoder();
+			String payload = new String(decoder.decode(chunks[1]));
+
+			return payload.substring(payload.indexOf("\"sub\":\"") + 7, payload.indexOf("\",\"auid\""));
+		} catch (Exception e) {
+			throw new GlobalException(ErrorCode.AUTH_APPLE_ID_TOKEN_INVALID);
+		}
+	}
+
+	/**
+	 * Authorization Code로 애플 Refresh Token 받아오기
+	 */
+	public String getAppleRefreshToken(String code) {
+		String clientSecret = createClientSecret();
+		String tokenUrl = "https://appleid.apple.com/auth/token";
+
+		HttpHeaders headers = new HttpHeaders();
+		headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+		MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+		params.add("client_id", CLIENT_ID);
+		params.add("client_secret", clientSecret);
+		params.add("code", code);
+		params.add("grant_type", "authorization_code");
+
+		HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
+
+		try {
+			ResponseEntity<Map> response = restTemplate.postForEntity(tokenUrl, entity, Map.class);
+			return (String) response.getBody().get("refresh_token");
+		} catch (Exception e) {
+			log.error("애플 RT 발급 실패");
+			throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
+		}
+	}
+
+	/**
+	 * 애플 서버 통신용 Client Secret(JWT) 생성
+	 */
+	private String createClientSecret() {
+		Date now = new Date();
+		Date expiration = new Date(now.getTime() + 3600000); // 1시간
+
+		return Jwts.builder()
+			.setHeaderParam("alg", "ES256")
+			.setHeaderParam("kid", KEY_ID)
+			.setIssuer(TEAM_ID)
+			.setIssuedAt(now)
+			.setExpiration(expiration)
+			.setAudience("https://appleid.apple.com")
+			.setSubject(CLIENT_ID)
+			.signWith(getPrivateKey(), SignatureAlgorithm.ES256)
+			.compact();
+	}
+
+	/**
+	 * .p8 문자열을 PrivateKey 객체로 변환
+	 */
+	private PrivateKey getPrivateKey() {
+		try {
+			String privateKeyPEM = P8_KEY
+				.replace("-----BEGIN PRIVATE KEY-----", "")
+				.replace("-----END PRIVATE KEY-----", "")
+				.replaceAll("\\s+", "");
+
+			byte[] encoded = Base64.getDecoder().decode(privateKeyPEM);
+			PrivateKeyInfo keyInfo = PrivateKeyInfo.getInstance(encoded);
+			return new JcaPEMKeyConverter().getPrivateKey(keyInfo);
+		} catch (Exception e) {
+			throw new GlobalException(ErrorCode.AUTH_APPLE_KEY_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -33,7 +33,7 @@ public class AppleAuthService {
 	@Value("${apple.key-id}") private String KEY_ID;
 	@Value("${apple.p8-key}") private String P8_KEY; // .p8 파일의 텍스트 내용 전체
 
-	private final RestTemplate restTemplate = new RestTemplate();
+	private final RestTemplate restTemplate;
 
 	/**
 	 * Identity Token에서 유저 식별자(sub) 추출 (단순 파싱 버전; 추후 검증 로직 추가 예정)

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -54,6 +54,12 @@ public class AppleAuthService {
 			ObjectMapper objectMapper = new ObjectMapper();
 			JsonNode jsonNode = objectMapper.readTree(payload);
 
+			// "sub" 필드가 null 체크
+			if (jsonNode.get("sub") == null || jsonNode.get("sub").isNull() || jsonNode.get("sub").asText().isBlank()) {
+				log.error("애플 토큰 내 sub 필드가 누락되었거나 비어있습니다. Payload: {}", payload);
+				throw new GlobalException(ErrorCode.AUTH_APPLE_ID_TOKEN_INVALID);
+			}
+
 			String sub = jsonNode.get("sub").asText();
 
 			return sub;

--- a/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AppleAuthService.java
@@ -7,7 +7,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.HttpClientErrorException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.http.*;
 import org.springframework.util.LinkedMultiValueMap;
@@ -88,16 +91,46 @@ public class AppleAuthService {
 		HttpEntity<MultiValueMap<String, String>> entity = new HttpEntity<>(params, headers);
 
 		try {
-			ResponseEntity<Map> response = restTemplate.postForEntity(tokenUrl, entity, Map.class);
+			ResponseEntity<Map<String, Object>> response = restTemplate.exchange(
+				tokenUrl,
+				HttpMethod.POST,
+				entity,
+				new ParameterizedTypeReference<Map<String, Object>>() {}
+			);
+
 			Map<String, Object> body = response.getBody();
 
-			// id_token과 refresh_token을 모두 맵에 담아 반환합니다.
-			return Map.of(
-				"id_token", (String) body.get("id_token"),
-				"refresh_token", (String) body.get("refresh_token")
-			);
+			// 응답 바디 전체가 null 인지 확인
+			if (body == null) {
+				log.error("애플 토큰 응답 바디가 비어있습니다.");
+				throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
+			}
+
+			// 애플 측에서 보낸 에러 메시지가 있는지 확인 (디버깅용)
+			if (body.containsKey("error")) {
+				log.error("애플 서버 인증 에러: {}, 상세: {}", body.get("error"), body.get("error_description"));
+				throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
+			}
+
+			String idToken = (String) body.get("id_token");
+			String refreshToken = (String) body.get("refresh_token");
+
+			// StringUtils 를 활용하여 null 및 빈 문자열 (""), 공백 (" ") 체크
+			if (!StringUtils.hasText(idToken) ||
+				!StringUtils.hasText(refreshToken)) {
+				log.error("애플 토큰 응답에 필수 필드 누락 또는 빈 값: id_token={}, refresh_token={}",
+					idToken != null, refreshToken != null);
+				throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
+			}
+
+			return Map.of("id_token", idToken, "refresh_token", refreshToken);
+
+		} catch (HttpClientErrorException e) {
+			// HTTP 에러 발생 시 애플이 보낸 상세 에러 바디를 로그로 남김
+			log.error("애플 토큰 요청 실패: ", e);
+			throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
 		} catch (Exception e) {
-			log.error("애플 RT 발급 실패");
+			log.error("애플 토큰 처리 중 알 수 없는 오류 발생: {}", e.getMessage());
 			throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
 		}
 	}

--- a/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
@@ -22,6 +22,7 @@ import org.springframework.stereotype.Service;
 public class AuthService {
 
     private final KakaoAuthService kakaoAuthService;
+	private final AppleAuthService appleAuthService;
     private final SocialUserService socialUserService;
     private final JwtService jwtService;
 
@@ -122,6 +123,46 @@ public class AuthService {
 			throw new GlobalException(ErrorCode.AUTH_EXTERNAL_API_ERROR);
 		}
 	}
+
+	/**
+	 * 애플 로그인 구현
+	 *
+	 * @param request 요청 Dto
+	 * @return 토큰, userId 등 필요 정보
+	 */
+	public AuthResponseDto.LoginResponse appleLogin(AuthRequestDto.AppleLoginRequest request) {
+
+		try {
+			String socialId = appleAuthService.getAppleAccountId(request.getIdentityToken());
+			String appleRefreshToken = appleAuthService.getAppleRefreshToken(request.getAuthorizationCode());
+
+			// DB 저장 (애플은 RT 함께 저장)
+			User user = socialUserService.upsertAppleUser(socialId, request.getName(), appleRefreshToken);
+
+			// JWT 생성
+			String accessToken = jwtService.generateAccessToken(user.getId());
+			String refreshToken = jwtService.generateRefreshToken(user.getId());
+
+			// 다음단계 게산
+			String nextStep = user.determineNextStep();
+
+			return new AuthResponseDto.LoginResponse(
+				user.getId(),
+				accessToken,
+				refreshToken,
+				user.getName(),
+				user.getNickname(),
+				user.getLoginStatus(),
+				nextStep
+			);
+		} catch (GlobalException e) {
+			throw e;
+		} catch (Exception e) {
+			// 애플 서버 통신 오류 처리
+			throw new GlobalException(ErrorCode.AUTH_EXTERNAL_API_ERROR);
+		}
+	}
+
 
 	public void logout(String tokenHeader) {
 

--- a/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
@@ -135,6 +135,13 @@ public class AuthService {
 
 		try {
 			Map<String, String> appleTokens = appleAuthService.getAppleTokens(request.getAuthorizationCode());
+
+			// id_token 자체가 오지 않은 경우 처리
+			if (appleTokens == null || appleTokens.get("id_token") == null) {
+				log.error("애플 id_token이 유효하지 않습니다.");
+				throw new GlobalException(ErrorCode.AUTH_APPLE_TOKEN_ERROR);
+			}
+
 			String socialId = appleAuthService.getAppleAccountId(appleTokens.get("id_token"));
 			String appleRefreshToken = appleTokens.get("refresh_token");
 

--- a/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.auth.service;
 
 import java.time.Duration;
+import java.util.Map;
 
 import com.hrr.backend.domain.auth.dto.AuthRequestDto;
 import com.hrr.backend.domain.auth.dto.AuthResponseDto;
@@ -133,11 +134,12 @@ public class AuthService {
 	public AuthResponseDto.LoginResponse appleLogin(AuthRequestDto.AppleLoginRequest request) {
 
 		try {
-			String socialId = appleAuthService.getAppleAccountId(request.getIdentityToken());
-			String appleRefreshToken = appleAuthService.getAppleRefreshToken(request.getAuthorizationCode());
+			Map<String, String> appleTokens = appleAuthService.getAppleTokens(request.getAuthorizationCode());
+			String socialId = appleAuthService.getAppleAccountId(appleTokens.get("id_token"));
+			String appleRefreshToken = appleTokens.get("refresh_token");
 
 			// DB 저장 (애플은 RT 함께 저장)
-			User user = socialUserService.upsertAppleUser(socialId, request.getName(), appleRefreshToken);
+			User user = socialUserService.upsertAppleUser(socialId, appleRefreshToken, request.getName());
 
 			// JWT 생성
 			String accessToken = jwtService.generateAccessToken(user.getId());
@@ -159,6 +161,7 @@ public class AuthService {
 			throw e;
 		} catch (Exception e) {
 			// 애플 서버 통신 오류 처리
+
 			throw new GlobalException(ErrorCode.AUTH_EXTERNAL_API_ERROR);
 		}
 	}

--- a/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
@@ -1,27 +1,28 @@
 package com.hrr.backend.domain.auth.service;
 
 import com.hrr.backend.domain.auth.dto.KakaoUserResponse;
+import com.hrr.backend.domain.auth.entity.SocialAuth;
 import com.hrr.backend.domain.auth.entity.enums.SocialType;
+import com.hrr.backend.domain.auth.repository.SocialAuthRepository;
 import com.hrr.backend.domain.user.entity.User;
-import com.hrr.backend.domain.user.entity.enums.LoginStatus;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class SocialUserService {
     private final UserRepository userRepository;
-
-    public SocialUserService(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
+	private final SocialAuthRepository socialAuthRepository;
 
     // 카카오 응답 → 우리 User db에 upsert(있으면 update하고 없으면 insert)
     @Transactional
     public User upsertKakaoUser(KakaoUserResponse kakao) {
-        Long kakaoId = kakao.getId();
+        String socialId = String.valueOf(kakao.getId());
         String name = Optional.ofNullable(kakao.getKakaoAccount())
                 .map(KakaoUserResponse.KakaoAccount::getProfile)
                 .map(KakaoUserResponse.KakaoAccount.Profile::getNickname)
@@ -32,35 +33,67 @@ public class SocialUserService {
                 .map(KakaoUserResponse.KakaoAccount.Profile::getProfile_image_url)
                 .orElse(null);
 
-        return userRepository.findBySocialId(String.valueOf(kakaoId))
-                .map(user -> {
-                    user.updateName(name);
-                    user.updateProfileImage(profileImage);
-                    return user;
-                })
-                .orElseGet(() -> {
-                    // 신규 유저는 NEW 상태로 생성되게 변경
-                    return userRepository.save(User.newKakao(kakaoId, name, profileImage));
-                });
+		return socialAuthRepository.findBySocialIdAndSocialType(socialId, SocialType.KAKAO)
+			.map(socialAuth -> {
+				// [기존 유저] 연관된 User 정보를 업데이트
+				User user = socialAuth.getUser();
+				user.updateName(name);
+				user.updateProfileImage(profileImage);
+				return user;
+			})
+			.orElseGet(() -> {
+				// [신규 유저] User 생성 후 SocialAuth와 연결하여 저장
+
+				// User 생성
+				User newUser = User.signUp(name, profileImage);
+				userRepository.save(newUser);
+
+				// SocialAuth 생성 및 연결
+				SocialAuth auth = SocialAuth.builder()
+					.user(newUser)
+					.socialId(socialId)
+					.socialType(SocialType.KAKAO)
+					.build();
+				socialAuthRepository.save(auth);
+
+				return newUser;
+			});
     }
 
 	@Transactional
 	public User upsertAppleUser(String appleSub, String appleRefreshToken, String name) {
 		// socialId(sub)로 기존 유저 확인
-		return userRepository.findBySocialId(appleSub)
-			.map(user -> {
-				// 기존 유저라면 애플 RT만 업데이트 (나중에 탈퇴 시 사용)
-				// Todo: RT 업데이트
+		return socialAuthRepository.findBySocialIdAndSocialType(appleSub, SocialType.APPLE)
+			.map(socialAuth -> {
+				// [기존 유저] 연관된 User 정보를 가져옴
+				User user = socialAuth.getUser();
+
+				// 애플은 이름이 첫 로그인 이후 null 로 올 수 있으므로 , 값이 있을 때만 업데이트
+				if (name != null) {
+					user.updateName(name);
+				}
+
+				// Todo: 애플 RT 업데이트 (나중에 탈퇴 시 사용)
+
 				return user;
 			})
 			.orElseGet(() -> {
-				// 신규 유저라면 회원가입 처리
-				User newUser = User.builder()
+				// [신규 유저] User 생성 후 SocialAuth 와 연결하여 저장
+
+				// User 생성 (애플은 프로필 이미지가 없으므로 null 전달 )
+				User newUser = User.signUp(name, null);
+				userRepository.save(newUser);
+
+				// SocialAuth 생성 및 애플 전용 RT 저장
+				SocialAuth auth = SocialAuth.builder()
+					.user(newUser)
 					.socialId(appleSub)
-					.name(name)
-					.loginStatus(LoginStatus.NEW)
+					.socialType(SocialType.APPLE)
+					.socialRefreshToken(appleRefreshToken)
 					.build();
-				return userRepository.save(newUser);
+				socialAuthRepository.save(auth);
+
+				return newUser;
 			});
 	}
 }

--- a/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.auth.service;
 
 import com.hrr.backend.domain.auth.dto.KakaoUserResponse;
+import com.hrr.backend.domain.auth.entity.enums.SocialType;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.enums.LoginStatus;
 import com.hrr.backend.domain.user.repository.UserRepository;
@@ -31,7 +32,7 @@ public class SocialUserService {
                 .map(KakaoUserResponse.KakaoAccount.Profile::getProfile_image_url)
                 .orElse(null);
 
-        return userRepository.findByKakaoId(kakaoId)
+        return userRepository.findBySocialId(String.valueOf(kakaoId))
                 .map(user -> {
                     user.updateName(name);
                     user.updateProfileImage(profileImage);
@@ -42,4 +43,24 @@ public class SocialUserService {
                     return userRepository.save(User.newKakao(kakaoId, name, profileImage));
                 });
     }
+
+	@Transactional
+	public User upsertAppleUser(String appleSub, String appleRefreshToken, String name) {
+		// socialId(sub)로 기존 유저 확인
+		return userRepository.findBySocialId(appleSub)
+			.map(user -> {
+				// 기존 유저라면 애플 RT만 업데이트 (나중에 탈퇴 시 사용)
+				// Todo: RT 업데이트
+				return user;
+			})
+			.orElseGet(() -> {
+				// 신규 유저라면 회원가입 처리
+				User newUser = User.builder()
+					.socialId(appleSub)
+					.name(name)
+					.loginStatus(LoginStatus.NEW)
+					.build();
+				return userRepository.save(newUser);
+			});
+	}
 }

--- a/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/SocialUserService.java
@@ -80,8 +80,10 @@ public class SocialUserService {
 			.orElseGet(() -> {
 				// [신규 유저] User 생성 후 SocialAuth 와 연결하여 저장
 
-				// User 생성 (애플은 프로필 이미지가 없으므로 null 전달 )
-				User newUser = User.signUp(name, null);
+				// User 생성 (애플은 프로필 이미지가 없으므로 null 전달)
+				String userName = (name != null) ? name : "애플 유저";	// 혹시 모를 이름 누락 대비
+				User newUser = User.signUp(userName, null);
+
 				userRepository.save(newUser);
 
 				// SocialAuth 생성 및 애플 전용 RT 저장

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.user.entity;
 
+import com.hrr.backend.domain.auth.entity.enums.SocialType;
 import com.hrr.backend.domain.notification.entity.NotificationSetting;
 import com.hrr.backend.domain.user.entity.enums.UserLevel;
 import com.hrr.backend.domain.user.entity.enums.UserRole;
@@ -90,9 +91,9 @@ public class User extends BaseEntity {
     private List<NotificationSetting> notificationSettings = new ArrayList<>();
 
     @Column(unique = true)
-    private Long kakaoId;
+    private String socialId;
 
-    @Enumerated(EnumType.STRING)
+	@Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
     private LoginStatus loginStatus = LoginStatus.NEW;
@@ -107,7 +108,7 @@ public class User extends BaseEntity {
     /** 카카오 로그인용 팩토리 메서드 */
     public static User newKakao(Long kakaoId, String name, String profileImage) {
         User user = new User();
-        user.kakaoId = kakaoId;
+		user.socialId = String.valueOf(kakaoId);
         user.name = name;
         user.profileImage = profileImage;
         // 초기 로그인 상태 명시적으로 설정 (nullable=false 대응)

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -1,7 +1,6 @@
 package com.hrr.backend.domain.user.entity;
 
 import com.hrr.backend.domain.auth.entity.SocialAuth;
-import com.hrr.backend.domain.auth.entity.enums.SocialType;
 import com.hrr.backend.domain.notification.entity.NotificationSetting;
 import com.hrr.backend.domain.user.entity.enums.UserLevel;
 import com.hrr.backend.domain.user.entity.enums.UserRole;

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.user.entity;
 
+import com.hrr.backend.domain.auth.entity.SocialAuth;
 import com.hrr.backend.domain.auth.entity.enums.SocialType;
 import com.hrr.backend.domain.notification.entity.NotificationSetting;
 import com.hrr.backend.domain.user.entity.enums.UserLevel;
@@ -90,13 +91,13 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<NotificationSetting> notificationSettings = new ArrayList<>();
 
-    @Column(unique = true)
-    private String socialId;
-
 	@Enumerated(EnumType.STRING)
     @Column(nullable = false)
     @Builder.Default
     private LoginStatus loginStatus = LoginStatus.NEW;
+
+	@OneToOne(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+	private SocialAuth socialAuth;
 
     @Builder.Default
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -105,16 +106,18 @@ public class User extends BaseEntity {
 	@OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
 	private List<UserMission> userMissions = new ArrayList<>();
 
-    /** 카카오 로그인용 팩토리 메서드 */
-    public static User newKakao(Long kakaoId, String name, String profileImage) {
-        User user = new User();
-		user.socialId = String.valueOf(kakaoId);
-        user.name = name;
-        user.profileImage = profileImage;
-        // 초기 로그인 상태 명시적으로 설정 (nullable=false 대응)
-        user.loginStatus = LoginStatus.NEW;
-        return user;
-    }
+	/**
+	 * 로그인/회원가입용 팩토리 메서드
+	 */
+	public static User signUp(String name, String profileImage) {
+		return User.builder()
+			.name(name)
+			.profileImage(profileImage)
+			.loginStatus(LoginStatus.NEW)
+			.userLevel(UserLevel.BRONZE)
+			.userRole(UserRole.USER)
+			.build();
+	}
 
     /** 닉네임 업데이트 */
     public void updateNickname(String nickname) {

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserRepository.java
@@ -11,8 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // ID로 유저 조회 (soft delete 미적용)
     Optional<User> findById(Long id);
-    // Kakao ID
-    Optional<User> findByKakaoId(Long kakaoId);
+
+	// Social ID(kakao, apple)
+    Optional<User> findBySocialId(String socialId);
 
     boolean existsByNickname(String nickname);
 
@@ -23,4 +24,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	 * @return Slice<User> - 데이터 목록과 다음 페이지 존재 여부(hasNext)를 포함
 	 */
 	Slice<User> findByNicknameContaining(String keyword, Pageable pageable);
+
+
 }

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserRepository.java
@@ -12,9 +12,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     // ID로 유저 조회 (soft delete 미적용)
     Optional<User> findById(Long id);
 
-	// Social ID(kakao, apple)
-    Optional<User> findBySocialId(String socialId);
-
     boolean existsByNickname(String nickname);
 
 	/**

--- a/src/main/java/com/hrr/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/hrr/backend/global/config/SecurityConfig.java
@@ -51,7 +51,8 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-resources/**",
-                        "/webjars/**"
+                        "/webjars/**",
+						"/api/v1/auth/login/apple/test"
                     ).permitAll()
                     // 그 외 요청은 JWT 인증 필요
                     .anyRequest().authenticated()
@@ -71,21 +72,15 @@ public class SecurityConfig {
         return authConfig.getAuthenticationManager();
     }
 
-/*	@Bean
-	public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
-		FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
-		bean.setFilter(new ForwardedHeaderFilter());
-		bean.setOrder(Ordered.HIGHEST_PRECEDENCE); // 가장 먼저 실행되도록 순위 조작
-		return bean;
-	}*/
-
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);
 		config.setAllowedOriginPatterns(List.of(
 			"https://*.hrr-umc7.store",  // 운영 환경 (www 포함 모든 서브도메인)
-			"http://localhost:*"));         // 로컬 개발 환경
+			"http://localhost:*",         // 로컬 개발 환경
+			"https://appleid.apple.com",
+			"https://semicapitalistic-shanell-irretraceable.ngrok-free.dev"));
         config.setAllowedOrigins(List.of(
                         "http://localhost:8080",
                         "http://localhost:5173",
@@ -104,118 +99,3 @@ public class SecurityConfig {
     }
 
 }
-
-/*package com.hrr.backend.global.config;
-
-import com.hrr.backend.global.config.jwt.JwtAuthenticationEntryPoint;
-import com.hrr.backend.global.config.jwt.JwtAuthenticationFilter;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.web.servlet.FilterRegistrationBean;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-import org.springframework.core.Ordered;
-import org.springframework.http.HttpMethod;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.web.SecurityFilterChain;
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-import org.springframework.web.cors.CorsConfiguration;
-import org.springframework.web.cors.CorsConfigurationSource;
-import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
-import org.springframework.web.filter.CorsFilter;
-import org.springframework.web.filter.ForwardedHeaderFilter;
-
-import java.util.List;
-
-@Configuration
-@EnableWebSecurity
-@RequiredArgsConstructor
-public class SecurityConfig {
-
-	private final JwtAuthenticationFilter jwtAuthenticationFilter;
-	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
-
-	@Bean
-	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-		http
-			// [수정] corsConfigurationSource() 메서드를 올바르게 호출
-			.cors(cors -> cors.configurationSource(corsConfigurationSource()))
-			.csrf(AbstractHttpConfigurer::disable)
-			.sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-			.formLogin(AbstractHttpConfigurer::disable)
-			.authorizeHttpRequests(auth -> auth
-				.requestMatchers(HttpMethod.GET, "/").permitAll()
-				.requestMatchers(
-					"/api/v1/auth/**",
-					"/swagger-ui/**",
-					"/v3/api-docs/**",
-					"/swagger-resources/**",
-					"/webjars/**"
-				).permitAll()
-				.anyRequest().authenticated()
-			)
-			.exceptionHandling(ex -> ex
-				.authenticationEntryPoint(jwtAuthenticationEntryPoint)
-			);
-
-		http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
-
-		return http.build();
-	}
-
-	@Bean
-	public AuthenticationManager authenticationManager(AuthenticationConfiguration authConfig) throws Exception {
-		return authConfig.getAuthenticationManager();
-	}
-
-	*//**
-	 * 1. CORS 설정의 핵심 (규칙 정의)
-	 * - 여기서 정의한 규칙을 Security와 Filter 양쪽에서 갖다 씁니다.
-	 *//*
-	@Bean
-	public CorsConfigurationSource corsConfigurationSource() {
-		CorsConfiguration config = new CorsConfiguration();
-
-		config.setAllowCredentials(true);
-		config.setAllowedOriginPatterns(List.of("*")); // 모든 출처 허용
-		config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
-		config.setAllowedHeaders(List.of("*")); // 모든 헤더 허용
-		config.setExposedHeaders(List.of("Authorization"));
-
-		UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
-		source.registerCorsConfiguration("/**", config);
-		return source;
-	}
-
-	*//**
-	 * 2. CORS 필터 강제 등록 (핵폭탄급 우선순위)
-	 * - 위에서 만든 corsConfigurationSource를 사용하여
-	 * - Spring Security 필터보다도 *먼저* 실행되게 만듭니다.
-	 *//*
-	@Bean
-	public FilterRegistrationBean<CorsFilter> corsFilter() {
-		// 위에서 만든 corsConfigurationSource()를 재사용합니다.
-		FilterRegistrationBean<CorsFilter> bean = new FilterRegistrationBean<>(
-			new CorsFilter(corsConfigurationSource())
-		);
-		// 가장 높은 우선순위 부여 (지구 끝까지 쫓아가서 CORS 허용함)
-		bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
-		return bean;
-	}
-
-	*//**
-	 * 3. HTTPS 프로토콜 감지 필터
-	 * - Nginx가 보내준 "나 HTTPS야!" 신호를 Spring이 알아먹게 함
-	 *//*
-	@Bean
-	public FilterRegistrationBean<ForwardedHeaderFilter> forwardedHeaderFilter() {
-		FilterRegistrationBean<ForwardedHeaderFilter> bean = new FilterRegistrationBean<>();
-		bean.setFilter(new ForwardedHeaderFilter());
-		bean.setOrder(Ordered.HIGHEST_PRECEDENCE);
-		return bean;
-	}
-}*/

--- a/src/main/java/com/hrr/backend/global/config/SecurityConfig.java
+++ b/src/main/java/com/hrr/backend/global/config/SecurityConfig.java
@@ -51,9 +51,8 @@ public class SecurityConfig {
                         "/swagger-ui/**",
                         "/v3/api-docs/**",
                         "/swagger-resources/**",
-                        "/webjars/**",
-						"/api/v1/auth/login/apple/test"
-                    ).permitAll()
+                        "/webjars/**"
+					).permitAll()
                     // 그 외 요청은 JWT 인증 필요
                     .anyRequest().authenticated()
             )
@@ -61,7 +60,7 @@ public class SecurityConfig {
                     .authenticationEntryPoint(jwtAuthenticationEntryPoint)
                     //.authenticationEntryPoint((req, res, ex1) -> res.sendError(HttpServletResponse.SC_UNAUTHORIZED))
                     //.accessDeniedHandler((req, res, ex1) -> res.sendError(HttpServletResponse.SC_FORBIDDEN))
-            );;
+            );
             //필터 등록 -> Spring Security 로그인 필터 전에 JwtAuthenticationFilter 실행하도록 등록함
         http.addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
@@ -80,7 +79,8 @@ public class SecurityConfig {
 			"https://*.hrr-umc7.store",  // 운영 환경 (www 포함 모든 서브도메인)
 			"http://localhost:*",         // 로컬 개발 환경
 			"https://appleid.apple.com",
-			"https://semicapitalistic-shanell-irretraceable.ngrok-free.dev"));
+			"https://semicapitalistic-shanell-irretraceable.ngrok-free.dev"	// 로컬 테스트용 임시
+		));
         config.setAllowedOrigins(List.of(
                         "http://localhost:8080",
                         "http://localhost:5173",

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -64,6 +64,11 @@ public enum ErrorCode implements BaseCode{
     AUTH_TOKEN_MISSING(HttpStatus.UNAUTHORIZED, "AUTH4019", "Authorization 헤더가 필요합니다."),
     AUTH_TOKEN_INVALIDATED(HttpStatus.UNAUTHORIZED, "AUTH4011", "로그아웃되어 만료된 토큰입니다."),
 
+	// apple auth
+	AUTH_APPLE_TOKEN_ERROR(HttpStatus.BAD_GATEWAY, "APPLE001", "애플 토큰 요청 중 오류가 발생했습니다."),
+	AUTH_APPLE_ID_TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "APPLE002", "유효하지 않은 애플 ID 토큰입니다."),
+	AUTH_APPLE_KEY_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "APPLE003", "애플 인증 키 생성 중 오류가 발생했습니다."),
+
     // round
     ROUND_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUND4041", "라운드를 찾을 수 없습니다."), // feat/90 & develop 공통
     ROUND_NOT_MATCH_CHALLENGE(HttpStatus.BAD_REQUEST, "ROUND4002", "라운드가 해당 챌린지에 속하지 않습니다."),
@@ -122,7 +127,7 @@ public enum ErrorCode implements BaseCode{
     // search
     MIGRATION_REDIS_TO_DB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH5001", "redis에서 DB로 로그를 저장하는 데 실패했습니다."),
     COUNTING_LOG_TABLE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH5002", "집계가 실패하였습니다."),
-    ;
+	;
 
     private final HttpStatus status;
     private final String code;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -55,8 +55,8 @@ model:
     embedding-url: http://localhost:8000/embedding
 
 apple:
-  team-id: {APPLE_TEAM_ID}
-  client-id: {APPLE_CLIENT_ID}
-  key-id: {APPLE_KEY_ID}
-  p8-key: {APPLE_P8_KEY}
+  team-id: ${APPLE_TEAM_ID}
+  client-id: ${APPLE_CLIENT_ID}
+  key-id: ${APPLE_KEY_ID}
+  p8-key: ${APPLE_P8_KEY}
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,3 +53,10 @@ model:
   api:
     url: http://localhost:8000/recommend
     embedding-url: http://localhost:8000/embedding
+
+apple:
+  team-id: {APPLE_TEAM_ID}
+  client-id: {APPLE_CLIENT_ID}
+  key-id: {APPLE_KEY_ID}
+  p8-key: {APPLE_P8_KEY}
+

--- a/src/main/resources/db/migration/V2.14.1__add_unique_constraint.sql
+++ b/src/main/resources/db/migration/V2.14.1__add_unique_constraint.sql
@@ -1,0 +1,25 @@
+-- user_id 에 대한 일대일 관계 유니크 제약 조건 추가 (멱등성 보장)
+DROP PROCEDURE IF EXISTS add_unique_constraint_if_not_exists;
+
+DELIMITER $$
+
+CREATE PROCEDURE add_unique_constraint_if_not_exists()
+BEGIN
+    -- 제약 조건이 존재하는지 확인
+    IF NOT EXISTS (
+        SELECT 1
+        FROM information_schema.TABLE_CONSTRAINTS
+        WHERE CONSTRAINT_SCHEMA = DATABASE()
+          AND TABLE_NAME = 'social_auth'
+          AND CONSTRAINT_NAME = 'uk_social_auth_user_id'
+    ) THEN
+        -- 존재하지 않을 때만 제약 조건을 추가
+        ALTER TABLE social_auth ADD CONSTRAINT uk_social_auth_user_id UNIQUE (user_id);
+    END IF;
+END $$
+
+DELIMITER ;
+
+-- 프로시저 실행 후 삭제
+CALL add_unique_constraint_if_not_exists();
+DROP PROCEDURE IF EXISTS add_unique_constraint_if_not_exists;

--- a/src/main/resources/db/migration/V2.14__add_social_auth.sql
+++ b/src/main/resources/db/migration/V2.14__add_social_auth.sql
@@ -1,0 +1,55 @@
+-- 1. social_auth 테이블 생성
+CREATE TABLE IF NOT EXISTS social_auth (
+                                           id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                                           user_id BIGINT NOT NULL,
+                                           social_type VARCHAR(20) NOT NULL,
+                                           social_id VARCHAR(255) NOT NULL,
+                                           social_refresh_token TEXT,
+                                           created_at DATETIME(6),
+                                           updated_at DATETIME(6),
+                                           CONSTRAINT fk_social_auth_user FOREIGN KEY (user_id) REFERENCES user (id),
+                                           UNIQUE KEY uq_social_id_type (social_id, social_type)
+) ENGINE=InnoDB;
+
+-- 2. 안전한 데이터 이전 및 컬럼 삭제를 위한 통합 프로시저
+DROP PROCEDURE IF EXISTS MigrateAndDropSocialColumns;
+
+DELIMITER //
+
+CREATE PROCEDURE MigrateAndDropSocialColumns()
+BEGIN
+    -- [A] 데이터 이전 : user 테이블에 social_id 컬럼이 아직 있을 때만 수행
+    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+               WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND COLUMN_NAME = 'social_id') THEN
+
+        -- social_auth가 비어있는 유저들만 이전 (중복 방지 )
+        INSERT INTO social_auth (user_id, social_id, social_type, created_at, updated_at)
+        SELECT id, CAST(social_id AS CHAR), social_type, NOW(), NOW()
+        FROM user
+        WHERE social_id IS NOT NULL
+          AND id NOT IN (SELECT user_id FROM social_auth);
+
+        -- 이전 완료 후 컬럼 삭제
+        ALTER TABLE user DROP COLUMN social_id;
+    END IF;
+
+    -- [B] social_type 컬럼 삭제 (남아있을 경우)
+    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+               WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND COLUMN_NAME = 'social_type') THEN
+        ALTER TABLE user DROP COLUMN social_type;
+    END IF;
+
+    -- [C] 만약 kakao_id 컬럼명이 남아있는 경우를 대비한 추가 처리
+    IF EXISTS (SELECT 1 FROM INFORMATION_SCHEMA.COLUMNS
+               WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'user' AND COLUMN_NAME = 'kakao_id') THEN
+        ALTER TABLE user DROP COLUMN kakao_id;
+    END IF;
+END //
+
+DELIMITER ;
+
+-- 프로시저 실행
+CALL MigrateAndDropSocialColumns();
+
+-- 프로시저 삭제
+DROP PROCEDURE IF EXISTS MigrateAndDropSocialColumns;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #140 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

애플 로그인을 구현했습니다.
SocialAuth 테이블 생성: 소셜 로그인 관련 데이터용으로 소셜 리프레시 토큰 등을 저장하기 위한 테이블을 분리했습니다. 
User의 kakaoId 삭제하고 SocialAuth의 socialId로 변경했습니다.

cf) 리프레시 토큰 저장 시 암호화 과정과, 회원 탈퇴 시의 추가 처리가 필요하지만 프론트와의 빠른 연동을 위해 다음 이슈에서 별도로 진행할 예정입니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

env 파일 업데이트 되었습니다.

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 스웨거
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 회원가입 완료 |
|---|
|<img width="384" height="266" alt="image" src="https://github.com/user-attachments/assets/acd13c8d-e69f-4a46-9cc4-e79199f0f207" />|

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple 계정 로그인(Apple OAuth) 및 관련 사용자 업서트 흐름이 추가되었습니다.
  * 소셜 인증 정보를 별도 엔티티로 관리하여 다수 제공자 연동이 개선되었습니다.

* **Security**
  * CORS 허용 범위가 확장되었고, Apple 로그인 관련 오류 코드가 추가되어 문제 진단이 쉬워졌습니다.
  * Apple 로그인용 테스트 엔드포인트가 추가되었습니다.

* **Chores / Deploy**
  * Apple 관련 런타임 환경변수(팀/클라이언트/키/P8)가 배포 설정에 추가되었습니다.

* **Database**
  * 소셜 인증 전용 테이블 및 안전한 마이그레이션과 고유 제약 추가 스크립트가 포함되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->