### PR TITLE
[Feat] 챌린지 참가 응답에 현재 참여 인원 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -141,4 +141,11 @@ public class ChallengeConverter {
                 .isCurrentRound(isCurrentRound)
                 .build();
     }
+
+    public ChallengeResponseDto.JoinChallengeDto toJoinResponseDto(Challenge challenge) {
+        return new ChallengeResponseDto.JoinChallengeDto(
+                challenge.getId(),
+                challenge.getCurrentParticipants()
+        );
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -88,6 +88,9 @@ public class ChallengeResponseDto {
 
 		@Schema(description = "참가한 챌린지 ID", example = "1")
 		private Long challengeId;
+
+		@Schema(description = "참가 후 현재 인원 수", example = "6") // 추가
+		private Integer currentParticipantCount;
 	}
 
 	@Getter

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -451,7 +451,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 현재 진행 중인 라운드의 RoundRecord 생성
 		createRoundRecordOrFail(challenge, userChallenge);
 
-		return new ChallengeResponseDto.JoinChallengeDto(challenge.getId());
+		// 현재 인원 포함한 응답
+		return challengeConverter.toJoinResponseDto(challenge);
 	}
 
 	private void createRoundRecordOrFail(Challenge challenge, UserChallenge userChallenge) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #145 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- JoinChallengeDto에 currentParticipantCount 필드 추가
- ChallengeConverter에 참가 응답 변환 메서드 추가
- 챌린지 참가 성공 시 최신 참여 인원을 반환하도록 로직 수정

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger
* **결과 요약:** 응답에 현재 인원 포함

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 기능 | 스크린샷 |
|------|-----------|
| 챌린지 참가 응답 | <img width="1172" height="389" alt="image" src="https://github.com/user-attachments/assets/e35ca198-a98f-42b6-b28c-800e3a5cad00" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
  * 챌린지 참가 후 참가자 수 정보 표시 - 챌린지 참가 완료 시 현재 참가 중인 전체 인원 수를 함께 제공하여 챌린지의 참여 현황을 즉시 확인할 수 있습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->