### PR TITLE
[Feat] 알림 읽음 처리 API 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/hrr/backend/domain/notification/controller/NotificationController.java
@@ -47,7 +47,7 @@ public class NotificationController {
     @PatchMapping("/{notificationId}/read")
     @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
     public ApiResponse<NotificationResponseDto.ReadResultDto> markAsRead(
-            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails,
             @PathVariable Long notificationId
     ) {
         NotificationResponseDto.ReadResultDto response =

--- a/src/main/java/com/hrr/backend/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/hrr/backend/domain/notification/controller/NotificationController.java
@@ -44,4 +44,17 @@ public class NotificationController {
         return ApiResponse.onSuccess(SuccessCode.OK, response);
     }
 
+    @PatchMapping("/{notificationId}/read")
+    @Operation(summary = "알림 읽음 처리", description = "특정 알림을 읽음 상태로 변경합니다.")
+    public ApiResponse<NotificationResponseDto.ReadResultDto> markAsRead(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long notificationId
+    ) {
+        NotificationResponseDto.ReadResultDto response =
+                notificationService.markAsRead(userDetails.getUser(), notificationId);
+
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
+    }
+
+
 }

--- a/src/main/java/com/hrr/backend/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/notification/dto/NotificationResponseDto.java
@@ -54,4 +54,25 @@ public class NotificationResponseDto {
                     .build();
         }
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "알림 읽음 처리 결과 DTO")
+    public static class ReadResultDto {
+
+        @Schema(description = "알림 배달 ID", example = "1")
+        private Long notificationId;
+
+        @Schema(description = "읽음 여부", example = "true")
+        private Boolean isRead;
+
+        public static ReadResultDto from(NotificationDelivery delivery) {
+            return ReadResultDto.builder()
+                    .notificationId(delivery.getId())
+                    .isRead(delivery.getIsRead())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/entity/NotificationDelivery.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/NotificationDelivery.java
@@ -46,4 +46,11 @@ public class NotificationDelivery extends BaseEntity {
 
     @Column(name = "read_at")
     private LocalDateTime readAt;
+
+    public void markAsRead() {
+        if (this.isRead == null || !this.isRead) { // 아직 읽지 않은 경우에만 업데이트
+            this.isRead = true;
+            this.readAt = LocalDateTime.now();
+        }
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationService.java
@@ -6,6 +6,12 @@ import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.global.response.SliceResponseDto;
 
 public interface NotificationService {
+
+    // 알림 목록 조회
     SliceResponseDto<NotificationResponseDto.InfoDto> getNotificationList(
             User user, NotificationCategory category, int page, int size);
+
+    // 단일 알림 읽음 처리
+    NotificationResponseDto.ReadResultDto markAsRead(User user, Long notificationId);
+
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationServiceImpl.java
@@ -5,6 +5,8 @@ import com.hrr.backend.domain.notification.entity.NotificationDelivery;
 import com.hrr.backend.domain.notification.entity.enums.NotificationCategory;
 import com.hrr.backend.domain.notification.repository.NotificationRepository;
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.response.SliceResponseDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
@@ -37,4 +39,20 @@ public class NotificationServiceImpl implements NotificationService {
 
         return new SliceResponseDto<>(dtoSlice);
     }
+
+    @Override
+    @Transactional
+    public NotificationResponseDto.ReadResultDto markAsRead(User user, Long notificationId) {
+        NotificationDelivery delivery = notificationRepository.findById(notificationId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_NOT_FOUND));
+
+        if (!delivery.getReceiver().getId().equals(user.getId())) {
+            throw new GlobalException(ErrorCode.NOTIFICATION_ACCESS_DENIED);
+        }
+
+        delivery.markAsRead();
+
+        return NotificationResponseDto.ReadResultDto.from(delivery);
+    }
+
 }

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -130,6 +130,10 @@ public enum ErrorCode implements BaseCode{
     ALREADY_FOLLOWING(HttpStatus.CONFLICT, "FOLLOW4091", "이미 팔로우 중인 사용자입니다."),
     FOLLOW_NOT_FOUND(HttpStatus.NOT_FOUND, "FOLLOW4041", "팔로우 관계를 찾을 수 없습니다."),
 
+    // notification
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4041", "존재하지 않는 알림입니다."),
+    NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "NOTIFICATION4032", "해당 알림에 대한 접근 권한이 없습니다."),
+
     // search
     MIGRATION_REDIS_TO_DB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH5001", "redis에서 DB로 로그를 저장하는 데 실패했습니다."),
     COUNTING_LOG_TABLE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH5002", "집계가 실패하였습니다."),


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #154 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

알림 목록에서 특정 알림을 클릭했을 때의 읽음 상태 업데이트 API를 구현했습니다.
- 단일 알림 읽음 처리 (PATCH): 특정 알림을 읽음 상태(is_read = true)로 변경하고 읽은 시간(read_at)을 기록합니다.
- 보안 검증 로직: 요청을 보낸 사용자가 해당 알림의 실제 수신자인지 확인하여 타인의 알림 접근을 차단합니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger
* **결과 요약:** 
* 성공: 본인의 알림으로 요청 시 is_read가 true로 변경되고 현재 시간이 read_at에 저장됨
* 실패: 유저2가 유저1의 알림으로 요청시 403 에러 발생
* 실패: 존재히지 않는 알림으로 요청시 404 에러 발생

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 기능 | 스크린샷 |
|---|-----------|
| 알림 읽음 처리 응답 | <img width="1177" height="385" alt="image" src="https://github.com/user-attachments/assets/4d9e7211-7ccb-491f-bf5e-e155feabe132" /> |
| 알림 목록 조회시 true로 변경 | <img width="1178" height="760" alt="image" src="https://github.com/user-attachments/assets/a1382653-0353-4f02-b735-71834ea7a69a" /> |
| 다른 사람의 알림 | <img width="1173" height="325" alt="image" src="https://github.com/user-attachments/assets/ad9fa140-1376-4559-9e5c-a110e6799d70" /> |
| 존재하지 않는 알림 | <img width="1176" height="331" alt="image" src="https://github.com/user-attachments/assets/836a7739-931e-49e1-9d9f-cddabbe05ea0" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 개별 알림을 선택하여 읽음으로 표시할 수 있는 API가 추가되었습니다.
  * 알림을 읽음 처리하면 시스템이 읽음 시각을 자동으로 기록합니다.

* **오류 처리 개선**
  * 존재하지 않거나 접근 권한이 없는 알림에 대해 적절한 오류 응답이 반환되도록 개선되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->