### PR TITLE
[FIX] 참가 중인 챌린지 조회 API 로직 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.hrr.backend.domain.round.entity.QRoundRecord;
 import com.hrr.backend.domain.user.dto.UserResponseDto;
 import com.hrr.backend.domain.user.entity.QUserChallenge;
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
 import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -49,7 +50,7 @@ public class UserChallengeRepositoryCustomImpl implements UserChallengeRepositor
                 )
                 .where(
                         qUserChallenge.user.eq(user),
-                        qChallenge.status.eq(ChallengeStatus.ONGOING)
+                        qUserChallenge.status.eq(ChallengeJoinStatus.JOINED)
                 )
                 .orderBy(qChallenge.startDate.desc())
                 .offset(pageable.getOffset())

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepositoryCustomImpl.java
@@ -38,7 +38,7 @@ public class UserChallengeRepositoryCustomImpl implements UserChallengeRepositor
                         qChallenge.title,
                         qChallenge.description,
                         qChallenge.imageKey.as("thumbnailUrl"),
-                        qRoundRecord.verificationCount.as("currentRound"),
+                        qRound.roundNumber.as("currentRound"),
                         qChallenge.startDate
                 ))
                 .from(qUserChallenge)

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -1,5 +1,7 @@
 package com.hrr.backend.domain.user.service;
 
+import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -89,7 +91,7 @@ public class UserServiceImpl implements UserService {
                 dto.setThumbnailUrl(s3UrlUtil.toFullUrl(dto.getThumbnailUrl()))
         );
 
-		// 인증 완료 여부 추가 - 오늘 포함 가장 최근 인증 요일에 완료 여부
+/*		// 인증 완료 여부 추가 - 오늘 포함 가장 최근 인증 요일에 완료 여부
 		slice.getContent().forEach(dto -> {
 			Long challengeId = dto.getChallengeId();
 			// 챌린지 요일/인증 시간 로딩
@@ -117,6 +119,49 @@ public class UserServiceImpl implements UserService {
 			}
 
 			// DTO 반영
+			dto.setVerified(verified);
+		});*/
+
+		// 인증 완료 여부 추가
+		slice.getContent().forEach(dto -> {
+			Long challengeId = dto.getChallengeId();
+
+			// 챌린지 요일/인증 시간 로딩
+			Challenge challenge = challengeRepository.findByIdWithDays(challengeId)
+					.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+			// java의 DayOfWeek를 ChallengeDays로 변환
+			DayOfWeek todayDayOfWeek = LocalDate.now().getDayOfWeek();
+			ChallengeDays todayChallengeDay = ChallengeDays.from(todayDayOfWeek);
+
+			// 오늘이 인증하는 날인지 체크
+			boolean isRegistrationDay = challenge.getChallengeDays().stream()
+				.anyMatch(day -> day.getDayOfWeek() == todayChallengeDay);
+
+			boolean verified = false;
+
+			if (isRegistrationDay) {
+				// 유저-챌린지 매핑 (userChallengeId 필요)
+				Long userChallengeId = userChallengeRepository
+					.findByUserIdAndChallengeId(userId, challengeId)
+					.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND))
+					.getId();
+
+				// 오늘 포함 가장 최근 인증 요일 계산
+				LocalDateTime today = LocalDateTime.now();
+				LocalDateTime startOfDay = LocalDate.now().atStartOfDay();	// 오늘 00:00 ~ 23:59 범위 설정
+				LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
+
+
+				verified = verificationRepository.existsTodayVerification(	// 오늘이 인증날이고, 인증을 완료했을 떄에만 true
+					userChallengeId,
+					VerificationStatus.COMPLETED,
+					startOfDay,
+					endOfDay
+				);
+			}
+
+			// 결과를 DTO 반영
 			dto.setVerified(verified);
 		});
 

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -91,37 +91,6 @@ public class UserServiceImpl implements UserService {
                 dto.setThumbnailUrl(s3UrlUtil.toFullUrl(dto.getThumbnailUrl()))
         );
 
-/*		// 인증 완료 여부 추가 - 오늘 포함 가장 최근 인증 요일에 완료 여부
-		slice.getContent().forEach(dto -> {
-			Long challengeId = dto.getChallengeId();
-			// 챌린지 요일/인증 시간 로딩
-			Challenge challenge = challengeRepository.findByIdWithDays(challengeId)
-					.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
-
-			// 유저-챌린지 매핑 (userChallengeId 필요)
-			Long userChallengeId = userChallengeRepository
-					.findByUserIdAndChallengeId(userId, challengeId)
-					.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND))
-					.getId();
-
-			// 오늘 포함 가장 최근 인증 요일 계산
-			LocalDate targetDate = findLastestDateIncludingToday(challenge);
-			boolean verified = false;
-			if (targetDate != null) {
-				LocalDateTime start = LocalDateTime.of(targetDate, challenge.getVerifyStartTime());
-				LocalDateTime end = LocalDateTime.of(targetDate, challenge.getVerifyEndTime());
-				verified = verificationRepository.existsTodayVerification(	// 오늘 완료 여부를 확인하기 위한 메소드지만 파라미터 조정으로 활용
-						userChallengeId,
-						VerificationStatus.COMPLETED,
-						start,
-						end
-				);
-			}
-
-			// DTO 반영
-			dto.setVerified(verified);
-		});*/
-
 		// 인증 완료 여부 추가
 		slice.getContent().forEach(dto -> {
 			Long challengeId = dto.getChallengeId();

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -147,9 +147,8 @@ public class UserServiceImpl implements UserService {
 					.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND))
 					.getId();
 
-				// 오늘 포함 가장 최근 인증 요일 계산
-				LocalDateTime today = LocalDateTime.now();
-				LocalDateTime startOfDay = LocalDate.now().atStartOfDay();	// 오늘 00:00 ~ 23:59 범위 설정
+				// 오늘 00:00 ~ 23:59 범위 설정
+				LocalDateTime startOfDay = LocalDate.now().atStartOfDay();
 				LocalDateTime endOfDay = LocalDate.now().atTime(LocalTime.MAX);
 
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #153 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

참가 중인 챌린지 조회 API에서 '인증 완료 여부(isVerified)', '현재 라운드(currentRound)', 참가 중 판단 여부 로직 변경

- 인증 완료 여부(isVerified) : (기존) 오늘 포함 가장 최근 인증 요일에 완료 여부  -> (변경) 오늘이 인증날이면서, 인증을 완료했는지
- 현재 라운드(currentRound) : (기존) 인증 횟수 -> (변경) roundNumber 
- 참가 중 판단 여부 : (기존) 내가 참가 중인 챌린지가 ONGOING인지 -> (변경) UserChallenge에 JOINED 상태인지

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 스웨거
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 

인증 요일 아니면서 인증 x, 인증 요일 아니면서 인증 o, 인증 요일이면서 인증 x, 인증 요일이면서 인증 o 
-> 모두 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 내용 | 스크린샷 |
|---|---|
| DB 상황(1은 인증날 x, 2는 인증날 o) |<img width="4064" height="2334" alt="DB 상황" src="https://github.com/user-attachments/assets/12aef633-223a-4076-b9a8-1d0573e22c4a" />|
| 기존 조회 |<img width="827" height="541" alt="기존 조회" src="https://github.com/user-attachments/assets/7a8ebe5f-7ccf-49f7-a0b8-d57f7e6e9952" />|
| 금요일 인증 후 | <img width="894" height="566" alt="금요일 인증 후" src="https://github.com/user-attachments/assets/10b915fd-405a-4364-9c2a-cfdae81b0c8e" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 버그 수정
* 일일 과제 검증 로직 개선 — 오늘이 과제 등록일인지 확인하고 해당 일자(00:00–23:59) 범위 내 완료 여부를 정확히 판별하도록 검증 흐름 활성화
* 진행 중인 과제 조회 정확도 향상 — 라운드 기반 판별과 참가(가입) 상태 필터 적용으로 과제 현황 조회 정밀도 개선

<sub>✏️ Tip: 리뷰 설정에서 이 요약을 수정할 수 있습니다.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->