### PR TITLE
[FEAT] 팔로우/팔로우 취소 시 사용자 카운트 업데이트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,10 @@ dependencies {
 
     // S3
     implementation 'software.amazon.awssdk:s3:2.20.0'
+
+    //Spring-Retry
+    implementation 'org.springframework.retry:spring-retry'
+    implementation 'org.springframework:spring-aspects'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/hrr/backend/HrrBackendApiApplication.java
+++ b/src/main/java/com/hrr/backend/HrrBackendApiApplication.java
@@ -6,12 +6,14 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.retry.annotation.EnableRetry;
 
 import jakarta.annotation.PostConstruct;
 
 @SpringBootApplication
 @EnableJpaAuditing
 @EnableScheduling
+@EnableRetry
 public class HrrBackendApiApplication {
 
 	// 서버 실행 시 무조건 한국 시간으로 설정

--- a/src/main/java/com/hrr/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/hrr/backend/domain/follow/service/FollowService.java
@@ -12,6 +12,9 @@ import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.response.SliceResponseDto;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.OptimisticLockingFailureException;
+import org.springframework.retry.annotation.Backoff;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
@@ -32,6 +35,11 @@ public class FollowService {
      * @param followedUserId 팔로우할 사용자 ID
      * @return FollowResponseDto
      */
+    @Retryable(
+            value = {OptimisticLockingFailureException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
     @Transactional
     public FollowResponseDto followUser(Long currentUserId, Long followedUserId) {
         log.info("사용자 팔로우 요청 - followerId: {}, followingId: {}", currentUserId, followedUserId);
@@ -96,6 +104,11 @@ public class FollowService {
      * @param unfollowedUserId 팔로우 취소할 사용자 ID
      * @return FollowResponseDto
      */
+    @Retryable(
+            value = {OptimisticLockingFailureException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
     @Transactional
     public FollowResponseDto unfollowUser(Long currentUserId, Long unfollowedUserId) {
         log.info("사용자 팔로우 취소 요청 - followerId: {}, followingId: {}", currentUserId, unfollowedUserId);
@@ -137,6 +150,11 @@ public class FollowService {
      * @param requesterId 팔로우 요청한 사용자 ID
      * @return FollowResponseDto
      */
+    @Retryable(
+            value = {OptimisticLockingFailureException.class},
+            maxAttempts = 3,
+            backoff = @Backoff(delay = 100)
+    )
     @Transactional
     public FollowResponseDto approveFollowRequest(Long currentUserId, Long requesterId) {
         log.info("팔로우 요청 승인 - currentUserId: {}, requesterId: {}", currentUserId, requesterId);

--- a/src/main/java/com/hrr/backend/domain/follow/service/FollowService.java
+++ b/src/main/java/com/hrr/backend/domain/follow/service/FollowService.java
@@ -17,9 +17,6 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 @Slf4j
 @Service
 @RequiredArgsConstructor
@@ -77,6 +74,12 @@ public class FollowService {
 
         followRepository.save(follow);
 
+        // APPROVED 상태일 때만 카운트 증가 (공개 계정)
+        if (status == FollowStatus.APPROVED) {
+            currentUser.incrementFollowingCount();
+            followedUser.incrementFollowerCount();
+        }
+
         String message = status == FollowStatus.APPROVED
                 ? "User followed successfully"
                 : "Follow request sent successfully";
@@ -98,11 +101,15 @@ public class FollowService {
         log.info("사용자 팔로우 취소 요청 - followerId: {}, followingId: {}", currentUserId, unfollowedUserId);
 
         // 대상 사용자가 존재하는지 확인
-        userRepository.findById(unfollowedUserId)
+        User unfollowedUser = userRepository.findById(unfollowedUserId)
                 .orElseThrow(() -> {
                     log.warn("팔로우 취소할 사용자를 찾을 수 없습니다 - userId: {}", unfollowedUserId);
                     return new GlobalException(ErrorCode.USER_NOT_FOUND);
                 });
+
+        // 현재 사용자 조회
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
         // 팔로우 관계 조회 (상태 무관)
         Follow follow = followRepository.findByFollowerIdAndFollowingId(currentUserId, unfollowedUserId)
@@ -110,6 +117,12 @@ public class FollowService {
                     log.warn("팔로우 관계를 찾을 수 없습니다 - followerId: {}, followingId: {}", currentUserId, unfollowedUserId);
                     return new GlobalException(ErrorCode.FOLLOW_NOT_FOUND);
                 });
+
+        // APPROVED 상태였을 때만 카운트 감소
+        if (follow.getStatus() == FollowStatus.APPROVED) {
+            currentUser.decrementFollowingCount();
+            unfollowedUser.decrementFollowerCount();
+        }
 
         // 팔로우 관계 삭제
         followRepository.delete(follow);
@@ -129,11 +142,15 @@ public class FollowService {
         log.info("팔로우 요청 승인 - currentUserId: {}, requesterId: {}", currentUserId, requesterId);
 
         // 요청한 사용자 존재 여부 확인
-        userRepository.findById(requesterId)
+        User requester = userRepository.findById(requesterId)
                 .orElseThrow(() -> {
                     log.warn("요청한 사용자를 찾을 수 없습니다 - userId: {}", requesterId);
                     return new GlobalException(ErrorCode.USER_NOT_FOUND);
                 });
+
+        // 현재 사용자 조회
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
         // PENDING 상태의 팔로우 요청 조회
         Follow follow = followRepository
@@ -145,6 +162,11 @@ public class FollowService {
 
         // 승인 처리
         follow.approve();
+
+        // 승인 시점에 카운트 증가
+        requester.incrementFollowingCount();
+        currentUser.incrementFollowerCount();
+
         log.info("팔로우 요청 승인 완료 - requesterId: {}, currentUserId: {}", requesterId, currentUserId);
 
         return FollowResponseDto.of("Follow request approved successfully", requesterId, FollowStatus.APPROVED);

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -30,6 +30,9 @@ public class User extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Version
+    private Long version;
+
 	@Column(name = "name")	// 로그인 시 제공받는 이름. 중복이 가능하기에 unique 설정 x. 소셜 타입에 따라 이름 제공이 되지 않을 수 있어 nullable.
 	private String name;
 

--- a/src/main/java/com/hrr/backend/domain/user/entity/User.java
+++ b/src/main/java/com/hrr/backend/domain/user/entity/User.java
@@ -165,4 +165,28 @@ public class User extends BaseEntity {
 		this.userStatus = UserStatus.DELETED;
 		this.deletedAt = LocalDateTime.now();
 	}
+
+    //팔로워 카운트 증가
+    public void incrementFollowerCount() {
+        this.followerCount++;
+    }
+
+    //팔로워 카운트 감소
+    public void decrementFollowerCount() {
+        if (this.followerCount > 0) {
+            this.followerCount--;
+        }
+    }
+
+    // 팔로잉 카운트 증가
+    public void incrementFollowingCount() {
+        this.followingCount++;
+    }
+
+    // 팔로잉 카운트 감소
+    public void decrementFollowingCount() {
+        if (this.followingCount > 0) {
+            this.followingCount--;
+        }
+    }
 }

--- a/src/main/resources/db/migration/V2.20__add_version_to_user
+++ b/src/main/resources/db/migration/V2.20__add_version_to_user
@@ -1,0 +1,28 @@
+DROP PROCEDURE IF EXISTS `AddVersionColumnIfNotExist`;
+
+DELIMITER $$
+
+CREATE PROCEDURE `AddVersionColumnIfNotExist`()
+BEGIN
+    -- User 테이블에 version 컬럼 추가 (Optimistic Locking용)
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'user'
+        AND COLUMN_NAME = 'version'
+    ) THEN
+        ALTER TABLE user ADD COLUMN version BIGINT NOT NULL DEFAULT 0 AFTER id;
+    END IF;
+
+    -- 기존 데이터에 version 초기값 설정 (혹시 NULL인 경우 대비)
+    UPDATE user SET version = 0 WHERE version IS NULL;
+
+END $$
+
+DELIMITER ;
+
+-- 프로시저 실행
+CALL `AddVersionColumnIfNotExist`();
+
+-- 프로시저 삭제
+DROP PROCEDURE `AddVersionColumnIfNotExist`;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #130

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

팔로우/언팔로우 API 호출 시 User 엔티티의 `followerCount`와 `followingCount`가 업데이트되지 않는 버그가 있었습니다.
 1. User 엔티티에 카운트 증감 메서드 추가
 2. FollowService에 카운트 업데이트 로직 추가
---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 스웨거
* **결과 요약:** 두 개의 계정으로 테스트

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="659" height="295" alt="image" src="https://github.com/user-attachments/assets/7738fa90-e07f-43a9-a548-082038256337" />

followerCount, followingCount 증가

<img width="646" height="273" alt="image" src="https://github.com/user-attachments/assets/82af0895-71fb-41f6-8014-56a677550231" />

followerCount 감소
---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 동시성 상황에서 팔로우/언팔로우/승인 작업의 자동 재시도로 신뢰성 향상 (경합 시 동작 안정화)
  * 팔로우 상태에 따라 팔로워·팔로잉 수가 정확히 증감되도록 실시간 반영

* **Bug Fixes**
  * 언팔·승인 흐름에서 발생하던 카운트 불일치 및 음수 카운트 문제 해결

* **Chores**
  * 사용자 데이터 버전 관리 도입 및 기존 데이터 초기화 마이그레이션 적용

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->