### PR TITLE
[FEAT] 다른 사용자 인증 기록 조회 API

### DIFF
--- a/src/main/java/com/hrr/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/hrr/backend/domain/user/controller/UserController.java
@@ -20,6 +20,8 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Positive;
+import org.springframework.data.domain.Page;
 import org.springframework.validation.annotation.Validated;
 
 import jakarta.validation.constraints.NotBlank;
@@ -230,6 +232,31 @@ public class UserController {
         Long userId = customUserDetails.getUser().getId();
         SliceResponseDto<VerificationResponseDto.HistoryDto> response =
                 verificationService.getVerificationHistory(userId, page-1, size);
+
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
+    }
+
+    @GetMapping("/{userId}/verifications/history")
+    @Operation(
+            summary = "다른 사용자 인증 기록 조회",
+            description = "특정 사용자가 참여한 모든 챌린지의 인증 기록을 최신순으로 조회합니다. " +
+                    "비공개 프로필인 경우 isPublic=false와 빈 배열을 반환합니다."
+    )
+    public ApiResponse<VerificationResponseDto.OtherUserHistoryResponse> getOtherUserVerificationHistory(
+            @PathVariable
+            @Positive
+            @Parameter(description = "조회할 사용자 ID", example = "5") Long userId,
+
+            @RequestParam(name = "page", defaultValue = "1")
+            @Min(1)
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") int page,
+
+            @RequestParam(name = "size", defaultValue = "10")
+            @Min(1) @Max(100)
+            @Parameter(description = "페이지당 데이터 개수", example = "10") int size
+    ) {
+        VerificationResponseDto.OtherUserHistoryResponse response =
+                verificationService.getOtherUserVerificationHistory(userId, page - 1, size);
 
         return ApiResponse.onSuccess(SuccessCode.OK, response);
     }

--- a/src/main/java/com/hrr/backend/domain/verification/dto/VerificationResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/verification/dto/VerificationResponseDto.java
@@ -173,4 +173,21 @@ public class VerificationResponseDto {
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime verifiedAt;
     }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "다른 사용자 인증 기록 조회 응답 DTO")
+    public static class OtherUserHistoryResponse {
+
+        @Schema(description = "프로필 공개 여부", example = "true")
+        private Boolean isPublic;
+
+        @Schema(description = "사용자 닉네임", example = "testuser")
+        private String nickname;
+
+        @Schema(description = "인증 기록 리스트 (비공개시 빈 배열)")
+        private SliceResponseDto<HistoryDto> verifications;
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationService.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationService.java
@@ -66,9 +66,18 @@ public interface VerificationService {
     void deleteVerification(Long verificationId, Long currentUserId);
   
     /**
-     * 사용자 전체 챌린지 인증 기록 조회
+     * 사용자 인증 기록 조회
      */
     SliceResponseDto<VerificationResponseDto.HistoryDto> getVerificationHistory(
+            Long userId,
+            int page,
+            int size
+    );
+
+    /**
+     * 다른 사용자 전체 챌린지 인증 기록 조회
+     */
+    VerificationResponseDto.OtherUserHistoryResponse getOtherUserVerificationHistory(
             Long userId,
             int page,
             int size

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -479,4 +479,43 @@ public class VerificationServiceImpl implements VerificationService {
         // SliceResponseDto로 변환하여 반환
         return new SliceResponseDto<>(dtoSlice);
     }
+
+    @Override
+    public VerificationResponseDto.OtherUserHistoryResponse getOtherUserVerificationHistory(
+            Long userId,
+            int page,
+            int size
+    ) {
+        // 1. 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 2. 비공개 계정 체크
+        if (!user.getIsPublic()) {
+            log.info("User {} is private. Returning empty list.", userId);
+            return VerificationResponseDto.OtherUserHistoryResponse.builder()
+                    .isPublic(false)
+                    .nickname(user.getNickname())
+                    .verifications(new SliceResponseDto<>(Page.empty()))
+                    .build();
+        }
+
+        // 3. 공개 계정
+        Pageable pageable = PageRequest.of(page, size);
+
+        Slice<Verification> verificationSlice =
+                verificationRepository.findVerificationHistoryByUser(
+                        user,
+                        VerificationStatus.COMPLETED,
+                        pageable);
+
+        Slice<VerificationResponseDto.HistoryDto> dtoSlice =
+                verificationSlice.map(verificationConverter::toHistoryDto);
+
+        return VerificationResponseDto.OtherUserHistoryResponse.builder()
+                .isPublic(true)
+                .nickname(user.getNickname())
+                .verifications(new SliceResponseDto<>(dtoSlice))
+                .build();
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #183 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 특정 사용자의 ID를 통해 해당 사용자가 참여한 챌린지의 전체 인증 기록을 최신순으로 조회하는 기능을 추가했습니다.
- 조회 대상 유저의 설정이 **비공개(isPublic: false)**일 경우, 실제 데이터가 존재하더라도 빈 배열(content: [])과 함께 isPublic: false 상태를 반환합니다.
- VerificationServiceImpl에서 기존 '내 인증 기록 조회' 로직을 재사용하여 일관성을 유지했습니다.
---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 스웨거
* **결과 요약:** 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.


| 설명 | 사진 |
| ----------- | ------------ |
| 공개유저일 경우 | <img width="940" height="470" alt="image" src="https://github.com/user-attachments/assets/fa03cb42-8ce7-47ec-ac3b-108c6ecdad09" /> |
| 비공개유저일 경우 | <img width="642" height="348" alt="image" src="https://github.com/user-attachments/assets/272fb56d-ecfb-40f6-955d-e65dc30de8ff" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 다른 사용자의 검증 기록 조회 기능 추가: 공개 설정된 사용자의 인증 이력을 페이지네이션과 함께 확인할 수 있으며, 비공개 사용자의 경우 기록이 표시되지 않습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->