### PR TITLE
[Feat] 챌린지 중도 참여 로직 구현 및 테스트 코드 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -639,9 +639,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 			throw new GlobalException(ErrorCode.MAX_CHALLENGE_EXCEEDED);
 		}
 
-		// 모집 상태 검증 (UPCOMING 이거나 RECRUITING 상태여야 함)
-		if (challenge.getStatus() != ChallengeStatus.UPCOMING &&
-				challenge.getStatus() != ChallengeStatus.RECRUITING) {
+		// 상태 검증 (종료만 아니면 모두 참여 가능)
+		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
 			throw new GlobalException(ErrorCode.CHALLENGE_NOT_RECRUITING);
 		}
 
@@ -760,14 +759,8 @@ public class ChallengeServiceImpl implements ChallengeService {
             return ActionButtonStatus.WAITLIST;
         }
 
-        // 미참여자 + 모집 중 -> 참가하기
-        if (challenge.getStatus() == ChallengeStatus.UPCOMING
-                || challenge.getStatus() == ChallengeStatus.RECRUITING) {
-            return ActionButtonStatus.JOIN;
-        }
-
-        // 그 외 -> 비활성화
-        return ActionButtonStatus.DISABLED;
+        // 그 외 -> 참가하기
+		return ActionButtonStatus.JOIN;
     }
 
     /**

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -63,7 +63,7 @@ class ChallengeServiceInfoTest {
         // 조건: 상태는 UPCOMING
         setChallengeStatus(challenge, ChallengeStatus.UPCOMING, 10, 30);
         // 조건: 인증 시간대 내 (시간은 맞지만 날짜가 안 맞음)
-        setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
+        setVerificationTime(challenge, LocalTime.of(9, 0), LocalTime.of(18, 0));
 
         // Mocking
         mockFetchingChallenge(challengeId, challenge);
@@ -92,7 +92,7 @@ class ChallengeServiceInfoTest {
 
         // 조건: 라운드 시작됨, 시간 맞음
         setRoundDate(challenge, LocalDate.now().minusDays(1));
-        setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
+        setVerificationTime(challenge, LocalTime.of(9, 0), LocalTime.of(18, 0));
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
         // Mocking
@@ -117,8 +117,8 @@ class ChallengeServiceInfoTest {
 
         setRoundDate(challenge, LocalDate.now().minusDays(1));
 
-        // 조건: 인증 시간이 현재 시간보다 미래임 (아직 안 옴)
-        setVerificationTime(challenge, LocalTime.now().plusHours(1), LocalTime.now().plusHours(2));
+        // 현재 시간과 겹치지 않도록 이른 시간대 고정
+        setVerificationTime(challenge, LocalTime.of(0, 0), LocalTime.of(0, 1));
 
         // Mocking
         mockFetchingChallenge(challengeId, challenge);
@@ -142,7 +142,7 @@ class ChallengeServiceInfoTest {
 
         setRoundDate(challenge, LocalDate.now().minusDays(1));
         // 조건: 현재 시간이 인증 시간 내에 포함됨
-        setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
+        setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
         // Mocking
         mockFetchingChallenge(challengeId, challenge);
@@ -169,7 +169,7 @@ class ChallengeServiceInfoTest {
         Challenge challenge = createChallengeBase();
 
         setRoundDate(challenge, LocalDate.now().minusDays(1));
-        setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
+        setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
         // Mocking
         mockFetchingChallenge(challengeId, challenge);

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -272,6 +272,31 @@ class ChallengeServiceInfoTest {
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.DISABLED);
     }
 
+    @Test
+    @DisplayName("상황 9: 미참여자 + 진행중(ONGOING) + 자리 있음 -> JOIN (중도 참여 허용 확인)")
+    void guest_ongoing_hasSpace_returns_JOIN() {
+        // Given
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        // 조건: 진행 중(ONGOING), 인원 여유 있음
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 5, 10);
+        setRoundDate(challenge, LocalDate.now().minusDays(5)); // 이미 시작된지 5일 지남
+
+        // Mocking
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipant(user, challenge, false);
+
+        mockConverter(ActionButtonStatus.JOIN);
+
+        // When
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
+        // Then
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
+    }
+
     /**
      * Helper Methods (테스트 설정을 쉽게 하기 위한 도구들)
      */


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #174 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

챌린지의 중도 참여 로직을 도입하였습니다. 이때 챌린지 연장 알림이 보내진 후에 참여하는 챌린저들을 위해 라운드가 n일 남았다는 정보를 제공해야 하는데, 이는 챌린지 상단 정보 조회 API의 `remainDays`를 사용합니다.

또한 시간 의존성으로 인해 발생하던 테스트 버그(자정 전후로 테스트 실행 시 LocalTime 계산 오류로 빌드 실패)를 해결하여 빌드 안정성을 확보했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger, 단위 테스트(ChallengeServiceInfoTest)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)
* 중도 참여 검증 및 시간 버그 수정

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 챌린지 중도 참여 | 스크린샷 |
|---|------------------|
| 미참여자이며 진행중임을 확인 | <img width="1179" height="758" alt="image" src="https://github.com/user-attachments/assets/3749b768-9b6e-40b1-9fa0-bf935c698802" /> |
| 중도 참여 확인 | <img width="1178" height="378" alt="image" src="https://github.com/user-attachments/assets/329b0436-ab38-4031-9468-ef29de7df749" /> |
| 테스트 코드 결과 | <img width="600" height="253" alt="image" src="https://github.com/user-attachments/assets/02390243-9ae2-4f79-a23b-6c1360be3988" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

테스트 안정성: `LocalTime.MIN/MAX`를 사용해 시간 의존성을 제거한 방식

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 진행 중인 챌린지에서 게스트 사용자도 참가 가능하도록 확대

* **버그 수정**
  * 챌린지 참가 요청 검증 조건 완화 - 종료된 챌린지에서만 차단
  * 챌린지 참가 버튼 표시 로직 개선 - 공간 여부에 따라 동적으로 결정

* **테스트**
  * 시간 기반 테스트 안정성 개선으로 불필요한 실패 제거

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->