### PR TITLE
[FEAT] 유틸 생성하여 유저 필터링 공통화

### DIFF
--- a/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -14,6 +14,7 @@ import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.global.util.UserFilterExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
+import jakarta.validation.constraints.NotNull;
 import lombok.RequiredArgsConstructor;
 
 @Repository
@@ -36,7 +37,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 	 * @return Slice<User> - 데이터 목록과 다음 페이지 존재 여부(hasNext)를 포함
 	 */
 	@Override
-	public Slice<User> findByNicknameContaining(String keyword, User me, Pageable pageable) {
+	public Slice<User> findByNicknameContaining(String keyword, @NotNull User me, Pageable pageable) {
 		// 실제 검색 쿼리
 		List<User> content = queryFactory
 			.selectFrom(qUser)

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -67,7 +67,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 	}
 
 	@Override
-	public Optional<User> findActiveUserExcludingBlocks(Long id, User me) {
+	public Optional<User> findActiveUserExcludingBlocks(Long id, @NotNull User me) {
 		return Optional.ofNullable(queryFactory
 			.selectFrom(qUser)
 			.where(

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserRepositoryCustomImpl.java
@@ -1,9 +1,7 @@
 package com.hrr.backend.domain.user.repository;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -13,8 +11,7 @@ import org.springframework.stereotype.Repository;
 import com.hrr.backend.domain.user.entity.QUser;
 import com.hrr.backend.domain.user.entity.QUserBlock;
 import com.hrr.backend.domain.user.entity.User;
-import com.hrr.backend.domain.user.entity.enums.UserStatus;
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.hrr.backend.global.util.UserFilterExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -45,8 +42,9 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.selectFrom(qUser)
 			.where(
 				qUser.nickname.contains(keyword),        // 닉네임 검색
-				isStatusActive(),						  // 탈퇴 유저 필터
-				notInBlockList(me),      // 차단 관계 유저 필터
+				UserFilterExpressions.isStatusActive(),	// 탈퇴 유저 필터
+				UserFilterExpressions.notBlockedByMe(me.getId()),      // 차단 관계 유저 필터(내가 차단한)
+				UserFilterExpressions.notBlockingMe(me.getId()),	   // 차단 관계 유저 필터(나를 차단한)
 				qUser.id.ne(me.getId())                 // 나 자신 제외
 			)
 			.offset(pageable.getOffset())
@@ -62,7 +60,7 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.selectFrom(qUser)
 			.where(
 				qUser.id.eq(id),
-				isStatusActive()
+				UserFilterExpressions.isStatusActive()
 			)
 			.fetchOne());
 	}
@@ -73,41 +71,11 @@ public class UserRepositoryCustomImpl implements UserRepositoryCustom {
 			.selectFrom(qUser)
 			.where(
 				qUser.id.eq(id),
-				isStatusActive(),
-				notInBlockList(me)
+				UserFilterExpressions.isStatusActive(),	// 탈퇴 유저 필터
+				UserFilterExpressions.notBlockedByMe(me.getId()),      // 차단 관계 유저 필터(내가 차단한)
+				UserFilterExpressions.notBlockingMe(me.getId())  	   // 차단 관계 유저 필터(나를 차단한)
 			)
 			.fetchOne());
-	}
-
-	// 활성 상태(비활성화, 탈퇴 x)인지
-	private BooleanExpression isStatusActive() {
-		return qUser.userStatus.eq(UserStatus.ACTIVE);
-	}
-
-	// 차단 관계에 있지 않은지
-	private BooleanExpression notInBlockList(User me) {
-		if (me == null) return null;
-
-		// 내가 차단한 + 나를 차단한 ID 수집 (서브쿼리보다 성능상 이점이 있도록 별도 조회 후 id.notIn 처리)
-		List<Long> blockedUserIds = queryFactory
-			.select(qUserBlock.blocked.id)
-			.from(qUserBlock)
-			.where(qUserBlock.blocker.eq(me))
-			.fetch();
-
-		List<Long> blockerUserIds = queryFactory
-			.select(qUserBlock.blocker.id)
-			.from(qUserBlock)
-			.where(qUserBlock.blocked.eq(me))
-			.fetch();
-
-		Set<Long> allBlockIds = new HashSet<>();
-		allBlockIds.addAll(blockedUserIds);
-		allBlockIds.addAll(blockerUserIds);
-
-		if (allBlockIds.isEmpty()) return null;
-
-		return qUser.id.notIn(allBlockIds);
 	}
 
 	// Slice 처리를 위한 공통 로직

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.validation.annotation.Validated;
 
 import com.hrr.backend.domain.follow.repository.FollowRepository;
 import com.hrr.backend.domain.user.entity.User;
@@ -43,6 +44,7 @@ import java.time.LocalDateTime;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true) // 기본적으로 읽기 전용 (조회 성능 최적화)
+@Validated
 public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/hrr/backend/global/util/UserFilterExpressions.java
+++ b/src/main/java/com/hrr/backend/global/util/UserFilterExpressions.java
@@ -1,0 +1,39 @@
+package com.hrr.backend.global.util;
+
+import com.hrr.backend.domain.user.entity.QUser;
+import com.hrr.backend.domain.user.entity.QUserBlock;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+
+public class UserFilterExpressions {
+	private static final QUser qUser = QUser.user;
+	private static final QUserBlock qUserBlock = QUserBlock.userBlock;
+
+	// 활성 유저 조건 (탈퇴/비활성화 제외)
+	public static BooleanExpression isStatusActive() {
+		return qUser.userStatus.eq(UserStatus.ACTIVE);
+	}
+
+	// 내가 차단한 유저 제외
+	public static BooleanExpression notBlockedByMe(Long myId) {
+		if (myId == null) return null;
+		return qUser.id.notIn(
+			JPAExpressions
+				.select(qUserBlock.blocked.id)
+				.from(qUserBlock)
+				.where(qUserBlock.blocker.id.eq(myId))
+		);
+	}
+
+	// 나를 차단한 유저 제외
+	public static BooleanExpression notBlockingMe(Long meId) {
+		if (meId == null) return null;
+		return qUser.id.notIn(
+			JPAExpressions
+				.select(qUserBlock.blocker.id)
+				.from(qUserBlock)
+				.where(qUserBlock.blocked.id.eq(meId))
+		);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #187 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

탈퇴 유저 및 차단 관계에 있는 유저 필터링 또는 마스킹이 필요해 기존 API를 수정해야하는 상황.
각 구현의 통일성을 위해 유틸 클래스로 분리

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

<img width="790" height="378" alt="image" src="https://github.com/user-attachments/assets/8fac0f4e-7347-4fef-96e3-691bb3c4bcc7" />

활성화된 유저인지(isStatusActive), 내가 차단한 유저는 제외(notBlockedByMe), 나를 차단한 유저는 제외(notBlockingMe)
이렇게 3개의 메소드를 구현해놨습니다.
각 로직에 따라 필터링 하는 조건이 다를 텐데요, 상황에 맞게 queryDSL의 where 절에 넣어주시면 됩니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 사용자 필터링 로직을 중앙화해 활성 상태 및 차단 관계 필터를 재사용 가능하게 통합했습니다.
* **Bug Fixes**
  * 닉네임 검색 및 사용자 조회 시 차단된 사용자와 비활성 사용자가 일관되게 제외되어 결과 정확도가 향상되었습니다.
* **Chores**
  * 서비스 계층에 메서드 수준 검증을 활성화해 입력 안정성을 보강했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->