### PR TITLE
[Feat] 챌린지 라운드 연장 알림 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/notification/entity/NotificationEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/NotificationEvent.java
@@ -59,5 +59,8 @@ public class NotificationEvent extends BaseEntity {
 
     @NotNull @Column(name = "message", length = 255, nullable = false)
     private String message;
+
+    @Column(name = "image_key", length = 255)
+    private String imageKey;
 }
 

--- a/src/main/java/com/hrr/backend/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/NotificationType.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.notification.entity;
 
+import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
 import com.hrr.backend.global.common.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotNull;
@@ -20,8 +21,9 @@ public class NotificationType extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Enumerated(EnumType.STRING)
     @Column(name = "type_name", length = 50, nullable = false, unique = true)
-    private String typeName;
+    private NotificationTypeName typeName;
 
     @NotNull
     @Column(name = "default_enabled", nullable = false)

--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
@@ -1,0 +1,5 @@
+package com.hrr.backend.domain.notification.entity.enums;
+
+public enum NotificationTypeName {
+    CHALLENGE_EXTENSION // 챌린지 라운드 연장 안내
+}

--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/ResourceType.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/ResourceType.java
@@ -5,5 +5,6 @@ public enum ResourceType {
     COMMENT,
     USER,
     CHALLENGE,
-    BADGE
+    BADGE,
+    ROUND
 }

--- a/src/main/java/com/hrr/backend/domain/notification/event/ChallengeExtensionEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/event/ChallengeExtensionEvent.java
@@ -1,0 +1,10 @@
+package com.hrr.backend.domain.notification.event;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChallengeExtensionEvent {
+    private final Long roundId;
+}

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -61,6 +61,7 @@ public class NotificationEventListener {
                 .contextId(roundId)
                 .title(String.format("%s 챌린지 종료 3일 전입니다.", challenge.getTitle()))
                 .message("다음 라운드에도 참여하시겠어요?\n내일까지 연장 여부를 알려주세요!")
+                .imageKey(challenge.getImageKey())
                 .build();
         eventRepository.save(notificationEvent);
 

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -1,0 +1,85 @@
+package com.hrr.backend.domain.notification.listener;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.notification.entity.*;
+import com.hrr.backend.domain.notification.entity.enums.*;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.notification.repository.*;
+import com.hrr.backend.domain.round.entity.*;
+import com.hrr.backend.domain.round.repository.*;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationEventListener {
+
+    private final RoundRepository roundRepository;
+    private final RoundRecordRepository roundRecordRepository;
+    private final NotificationTypeRepository typeRepository;
+    private final NotificationEventRepository eventRepository;
+    private final NotificationRepository notificationRepository;
+
+    @Async("getAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleChallengeExtensionEvent(ChallengeExtensionEvent event) {
+        Long roundId = event.getRoundId();
+
+        // 멱등성 체크 (중복 알림 방지)
+        if (eventRepository.existsByContextTypeAndContextIdAndCreatedAtAfter(
+                ResourceType.ROUND, roundId, LocalDate.now().atStartOfDay())) {
+            return;
+        }
+
+        // 데이터 조회
+        Round round = roundRepository.findById(roundId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.ROUND_NOT_FOUND));
+        Challenge challenge = round.getChallenge();
+
+        NotificationType type = typeRepository.findByTypeName(NotificationTypeName.CHALLENGE_EXTENSION)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+
+        NotificationEvent notificationEvent = NotificationEvent.builder()
+                .type(type)
+                .category(NotificationCategory.CHALLENGE)
+                .targetType(ResourceType.CHALLENGE)
+                .targetId(challenge.getId())
+                .contextType(ResourceType.ROUND)
+                .contextId(roundId)
+                .title(String.format("%s 챌린지 종료 3일 전입니다.", challenge.getTitle()))
+                .message("다음 라운드에도 참여하시겠어요?\n내일까지 연장 여부를 알려주세요!")
+                .build();
+        eventRepository.save(notificationEvent);
+
+        // 수신자 전체에 대해 Delivery 생성 (목록에 표시를 위함)
+        List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(round);
+
+        List<NotificationDelivery> deliveries = records.stream()
+                .map(record -> NotificationDelivery.builder()
+                        .event(notificationEvent)
+                        .receiver(record.getUserChallenge().getUser())
+                        .isRead(false)
+                        .build())
+                .toList();
+
+        // DB 저장 (전원 저장되므로 알림 목록에서 확인 가능)
+        if (!deliveries.isEmpty()) {
+            notificationRepository.saveAll(deliveries);
+
+            log.info("챌린지 연장 알림 DB 저장 완료: RoundId={}, 대상={}명", roundId, deliveries.size());
+        }
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -7,6 +7,7 @@ import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.repository.*;
 import com.hrr.backend.domain.round.entity.*;
 import com.hrr.backend.domain.round.repository.*;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -66,7 +67,10 @@ public class NotificationEventListener {
         eventRepository.save(notificationEvent);
 
         // 수신자 전체에 대해 Delivery 생성 (목록에 표시를 위함)
-        List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(round);
+        List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
+                round,
+                ChallengeJoinStatus.JOINED
+        );
 
         List<NotificationDelivery> deliveries = records.stream()
                 .map(record -> NotificationDelivery.builder()

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventRepository.java
@@ -1,0 +1,16 @@
+package com.hrr.backend.domain.notification.repository;
+
+import com.hrr.backend.domain.notification.entity.NotificationEvent;
+import com.hrr.backend.domain.notification.entity.enums.ResourceType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.time.LocalDateTime;
+
+public interface NotificationEventRepository extends JpaRepository<NotificationEvent, Long> {
+
+    // 특정 리소스에 대해 지정된 시간 이후 알림이 이미 생성되었는지 확인
+    boolean existsByContextTypeAndContextIdAndCreatedAtAfter(
+            ResourceType contextType,
+            Long contextId,
+            LocalDateTime dateTime
+    );
+}

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationTypeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationTypeRepository.java
@@ -1,0 +1,14 @@
+package com.hrr.backend.domain.notification.repository;
+
+import com.hrr.backend.domain.notification.entity.NotificationType;
+import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface NotificationTypeRepository extends JpaRepository<NotificationType, Long> {
+
+    Optional<NotificationType> findByTypeName(NotificationTypeName typeName);
+}

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.round.repository;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
 import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -60,7 +61,9 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
             "JOIN FETCH uc.user u " +
             "JOIN FETCH u.notificationSetting " +
             "WHERE rr.round = :round " +
-            "AND uc.status = 'JOINED'")
-    List<RoundRecord> findAllByRoundWithUserAndSetting(@Param("round") Round round);
-
+            "AND uc.status = :status") // 수정됨
+    List<RoundRecord> findAllByRoundWithUserAndSetting(
+            @Param("round") Round round,
+            @Param("status") ChallengeJoinStatus status
+    );
 }

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.round.repository;
 
+import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -50,4 +51,16 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
     // 내 총 인증 횟수 합계
     @Query("SELECT COALESCE(SUM(r.verificationCount), 0) FROM RoundRecord r WHERE r.userChallenge.id = :userChallengeId")
     Long sumVerificationCountByUserChallengeId(@Param("userChallengeId") Long userChallengeId);
+
+    /**
+     * 알림 발송 대상자 및 설정 정보 일괄 조회
+     */
+    @Query("SELECT rr FROM RoundRecord rr " +
+            "JOIN FETCH rr.userChallenge uc " +
+            "JOIN FETCH uc.user u " +
+            "JOIN FETCH u.notificationSetting " +
+            "WHERE rr.round = :round " +
+            "AND uc.status = 'JOINED'")
+    List<RoundRecord> findAllByRoundWithUserAndSetting(@Param("round") Round round);
+
 }

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -152,6 +152,7 @@ public enum ErrorCode implements BaseCode{
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4041", "존재하지 않는 알림입니다."),
     NOTIFICATION_SETTING_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4042", "알림 설정 정보를 찾을 수 없습니다."),
     NOTIFICATION_ACCESS_DENIED(HttpStatus.FORBIDDEN, "NOTIFICATION4032", "해당 알림에 대한 접근 권한이 없습니다."),
+    NOTIFICATION_TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4043", "존재하지 않는 알림 타입입니다."),
 
     // search
     MIGRATION_REDIS_TO_DB_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "SEARCH5001", "redis에서 DB로 로그를 저장하는 데 실패했습니다."),

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -5,6 +5,7 @@ import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.repository.RoundRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j; // [추가] 로깅 라이브러리
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -13,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.time.LocalDate;
 import java.util.List;
 
+@Slf4j // [추가]
 @Component
 @RequiredArgsConstructor
 public class NotificationScheduler {
@@ -23,11 +25,39 @@ public class NotificationScheduler {
     @Transactional(readOnly = true)
     @Scheduled(cron = "0 0 9 * * *") // 매일 오전 9시
     public void scheduleChallengeExtensionNotifications() {
+        // 대상 날짜 계산
         LocalDate targetDate = LocalDate.now().plusDays(Challenge.CHALLENGER_DECISION_DAYS);
-        List<Round> targetRounds = roundRepository.findAllByEndDate(targetDate);
 
-        for (Round round : targetRounds) {
-            eventPublisher.publishEvent(new ChallengeExtensionEvent(round.getId()));
+        try {
+            // 스케줄러 시작 및 대상 날짜 로깅
+            log.info("[ChallengeExtensionScheduler] 챌린지 연장 알림 스케줄러 시작 (대상 날짜: {})", targetDate);
+
+            List<Round> targetRounds = roundRepository.findAllByEndDate(targetDate);
+
+            // 발견된 라운드 수 로깅
+            log.info("[ChallengeExtensionScheduler] 대상 날짜({})에 종료되는 라운드 총 {}건 발견", targetDate, targetRounds.size());
+
+            if (targetRounds.isEmpty()) {
+                log.info("[ChallengeExtensionScheduler] 알림을 보낼 대상 라운드가 없습니다.");
+                return;
+            }
+
+            for (Round round : targetRounds) {
+                try {
+                    // 각 라운드별 이벤트 발행 시도 로깅
+                    eventPublisher.publishEvent(new ChallengeExtensionEvent(round.getId()));
+                    log.info("[ChallengeExtensionScheduler] 이벤트 발행 완료 - RoundId: {}", round.getId());
+                } catch (Exception e) {
+                    // 개별 라운드 처리 중 예외 발생 시 에러 로깅
+                    log.error("[ChallengeExtensionScheduler] 이벤트 발행 실패 - RoundId: {}, 사유: {}", round.getId(), e.getMessage());
+                }
+            }
+
+            log.info("[ChallengeExtensionScheduler] 스케줄러 작업 정상 종료");
+
+        } catch (Exception e) {
+            // 전체 프로세스 중 예외 발생 시 에러 로깅
+            log.error("[ChallengeExtensionScheduler] 스케줄러 실행 중 심각한 오류 발생 (대상 날짜: {}), 에러: ", targetDate, e);
         }
     }
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -1,0 +1,33 @@
+package com.hrr.backend.domain.notification.scheduler;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class NotificationScheduler {
+
+    private final RoundRepository roundRepository;
+    private final ApplicationEventPublisher eventPublisher;
+
+    @Transactional(readOnly = true)
+    @Scheduled(cron = "0 0 9 * * *") // 매일 오전 9시
+    public void scheduleChallengeExtensionNotifications() {
+        LocalDate targetDate = LocalDate.now().plusDays(Challenge.CHALLENGER_DECISION_DAYS);
+        List<Round> targetRounds = roundRepository.findAllByEndDate(targetDate);
+
+        for (Round round : targetRounds) {
+            eventPublisher.publishEvent(new ChallengeExtensionEvent(round.getId()));
+        }
+    }
+}

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -1,4 +1,4 @@
-package com.hrr.backend.domain.notification.scheduler;
+package com.hrr.backend.global.scheduler;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;

--- a/src/main/resources/db/migration/V2.24__update_notification_entities_and_types.sql
+++ b/src/main/resources/db/migration/V2.24__update_notification_entities_and_types.sql
@@ -1,0 +1,38 @@
+DELIMITER $$
+
+-- 1. 기존 프로시저 삭제 (구분자 $$ 사용)
+DROP PROCEDURE IF EXISTS MigrateNotificationEntities $$
+
+-- 2. 프로시저 정의
+CREATE PROCEDURE MigrateNotificationEntities()
+BEGIN
+    -- 1. notification_event 테이블: image_key 컬럼 추가
+    IF NOT EXISTS (
+        SELECT * FROM information_schema.COLUMNS
+        WHERE TABLE_SCHEMA = DATABASE()
+        AND TABLE_NAME = 'notification_event'
+        AND COLUMN_NAME = 'image_key'
+    ) THEN
+ALTER TABLE notification_event ADD COLUMN image_key VARCHAR(255) AFTER message;
+END IF;
+
+    -- 2. notification_event 테이블: Enum 타입 확장
+ALTER TABLE notification_event
+    MODIFY COLUMN context_type ENUM('BADGE', 'CHALLENGE', 'COMMENT', 'USER', 'VERIFICATION', 'ROUND');
+ALTER TABLE notification_event
+    MODIFY COLUMN target_type ENUM('BADGE', 'CHALLENGE', 'COMMENT', 'USER', 'VERIFICATION', 'ROUND') NOT NULL;
+
+-- 3. notification_type 테이블: 데이터 보정 및 타입 변경
+UPDATE notification_type SET type_name = 'CHALLENGE_EXTENSION' WHERE type_name IS NOT NULL;
+
+ALTER TABLE notification_type
+    MODIFY COLUMN type_name ENUM('CHALLENGE_EXTENSION') NOT NULL;
+
+END $$
+
+-- 3. 구분자 원복
+DELIMITER ;
+
+-- 4. 프로시저 실행 및 삭제
+CALL MigrateNotificationEntities();
+DROP PROCEDURE MigrateNotificationEntities;

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -16,6 +16,7 @@ import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.round.repository.RoundRepository;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -87,7 +88,10 @@ class NotificationEventListenerTest {
         given(uc1.getUser()).willReturn(userEnabled);
         given(uc2.getUser()).willReturn(userDisabled);
 
-        given(roundRecordRepository.findAllByRoundWithUserAndSetting(round))
+        given(roundRecordRepository.findAllByRoundWithUserAndSetting(
+                round,
+                ChallengeJoinStatus.JOINED
+        ))
                 .willReturn(List.of(record1, record2));
 
         // when

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -1,0 +1,118 @@
+package com.hrr.backend.domain.notification.listener;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.notification.entity.NotificationEvent;
+import com.hrr.backend.domain.notification.entity.NotificationSetting;
+import com.hrr.backend.domain.notification.entity.NotificationType;
+import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
+import com.hrr.backend.domain.notification.entity.enums.ResourceType;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.notification.repository.NotificationEventRepository;
+import com.hrr.backend.domain.notification.repository.NotificationRepository;
+import com.hrr.backend.domain.notification.repository.NotificationTypeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationEventListenerTest {
+
+    @InjectMocks
+    private NotificationEventListener notificationEventListener;
+
+    @Mock private RoundRepository roundRepository;
+    @Mock private RoundRecordRepository roundRecordRepository;
+    @Mock private NotificationTypeRepository typeRepository;
+    @Mock private NotificationEventRepository eventRepository;
+    @Mock private NotificationRepository notificationRepository;
+
+    @Test
+    @DisplayName("알림 설정 여부와 상관없이 모든 참여자에게 알림 목록 데이터가 생성되어야 한다")
+    void handleChallengeExtensionEvent_Success() {
+        // given
+        Long roundId = 1L;
+        ChallengeExtensionEvent event = new ChallengeExtensionEvent(roundId);
+
+        // 1. 멱등성 체크 통과
+        given(eventRepository.existsByContextTypeAndContextIdAndCreatedAtAfter(any(), any(), any()))
+                .willReturn(false);
+
+        // 2. 라운드 및 챌린지 모킹 (이미지 제외)
+        Round round = mock(Round.class);
+        Challenge challenge = Challenge.builder().id(10L).title("테스트 챌린지").build();
+        given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
+        given(round.getChallenge()).willReturn(challenge);
+
+        // 3. 알림 타입 설정
+        NotificationType type = NotificationType.builder()
+                .typeName(NotificationTypeName.CHALLENGE_EXTENSION)
+                .build();
+        given(typeRepository.findByTypeName(NotificationTypeName.CHALLENGE_EXTENSION))
+                .willReturn(Optional.of(type));
+
+        // 4. 참여자 설정 (설정 ON 유저와 OFF 유저 각각 1명씩)
+        User userEnabled = User.builder().id(1L).notificationSetting(
+                NotificationSetting.builder().isChallengeEnabled(true).build()).build();
+        User userDisabled = User.builder().id(2L).notificationSetting(
+                NotificationSetting.builder().isChallengeEnabled(false).build()).build();
+
+        RoundRecord record1 = mock(RoundRecord.class);
+        RoundRecord record2 = mock(RoundRecord.class);
+        UserChallenge uc1 = mock(UserChallenge.class);
+        UserChallenge uc2 = mock(UserChallenge.class);
+
+        given(record1.getUserChallenge()).willReturn(uc1);
+        given(record2.getUserChallenge()).willReturn(uc2);
+        given(uc1.getUser()).willReturn(userEnabled);
+        given(uc2.getUser()).willReturn(userDisabled);
+
+        // 전원 조회 쿼리 모킹
+        given(roundRecordRepository.findAllByRoundWithUserAndSetting(round))
+                .willReturn(List.of(record1, record2));
+
+        // when
+        notificationEventListener.handleChallengeExtensionEvent(event);
+
+        // then
+        // 알림 이벤트는 1번 생성됨
+        verify(eventRepository, times(1)).save(any(NotificationEvent.class));
+
+        // 중요: 설정과 관계없이 참여자 전원(2명)에게 알림 데이터가 저장되어야 함
+        verify(notificationRepository).saveAll(argThat(deliveries -> ((List<?>)deliveries).size() == 2));
+    }
+
+    @Test
+    @DisplayName("오늘 이미 알림이 생성되었다면 로직을 수행하지 않는다")
+    void handleChallengeExtensionEvent_Idempotency() {
+        // given
+        Long roundId = 1L;
+        ChallengeExtensionEvent event = new ChallengeExtensionEvent(roundId);
+
+        given(eventRepository.existsByContextTypeAndContextIdAndCreatedAtAfter(
+                eq(ResourceType.ROUND), eq(roundId), any()))
+                .willReturn(true);
+
+        // when
+        notificationEventListener.handleChallengeExtensionEvent(event);
+
+        // then
+        verify(roundRepository, never()).findById(anyLong());
+        verify(notificationRepository, never()).saveAll(any());
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -47,26 +47,31 @@ class NotificationEventListenerTest {
     void handleChallengeExtensionEvent_Success() {
         // given
         Long roundId = 1L;
+        String testImageKey = "challenges/thumbnail_01.png"; // 테스트용 키
         ChallengeExtensionEvent event = new ChallengeExtensionEvent(roundId);
 
         // 1. 멱등성 체크 통과
         given(eventRepository.existsByContextTypeAndContextIdAndCreatedAtAfter(any(), any(), any()))
                 .willReturn(false);
 
-        // 2. 라운드 및 챌린지 모킹 (이미지 제외)
+        // 2. 라운드 및 챌린지 모킹 (imageKey 포함)
         Round round = mock(Round.class);
-        Challenge challenge = Challenge.builder().id(10L).title("테스트 챌린지").build();
+        Challenge challenge = Challenge.builder()
+                .id(10L)
+                .title("테스트 챌린지")
+                .imageKey(testImageKey) // 이미지 키 설정
+                .build();
         given(roundRepository.findById(roundId)).willReturn(Optional.of(round));
         given(round.getChallenge()).willReturn(challenge);
 
-        // 3. 알림 타입 설정
+        // 3. 알림 타입 설정 (Enum 직접 사용)
         NotificationType type = NotificationType.builder()
                 .typeName(NotificationTypeName.CHALLENGE_EXTENSION)
                 .build();
         given(typeRepository.findByTypeName(NotificationTypeName.CHALLENGE_EXTENSION))
                 .willReturn(Optional.of(type));
 
-        // 4. 참여자 설정 (설정 ON 유저와 OFF 유저 각각 1명씩)
+        // 4. 참여자 설정 (설정 ON/OFF 유저 각 1명)
         User userEnabled = User.builder().id(1L).notificationSetting(
                 NotificationSetting.builder().isChallengeEnabled(true).build()).build();
         User userDisabled = User.builder().id(2L).notificationSetting(
@@ -82,7 +87,6 @@ class NotificationEventListenerTest {
         given(uc1.getUser()).willReturn(userEnabled);
         given(uc2.getUser()).willReturn(userDisabled);
 
-        // 전원 조회 쿼리 모킹
         given(roundRecordRepository.findAllByRoundWithUserAndSetting(round))
                 .willReturn(List.of(record1, record2));
 
@@ -90,8 +94,11 @@ class NotificationEventListenerTest {
         notificationEventListener.handleChallengeExtensionEvent(event);
 
         // then
-        // 알림 이벤트는 1번 생성됨
-        verify(eventRepository, times(1)).save(any(NotificationEvent.class));
+        // 1. NotificationEvent 저장 시 imageKey가 정확히 포함되었는지 확인
+        verify(eventRepository).save(argThat(savedEvent ->
+                savedEvent.getImageKey().equals(testImageKey) &&
+                        savedEvent.getTitle().contains("테스트 챌린지")
+        ));
 
         // 중요: 설정과 관계없이 참여자 전원(2명)에게 알림 데이터가 저장되어야 함
         verify(notificationRepository).saveAll(argThat(deliveries -> ((List<?>)deliveries).size() == 2));


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #186

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

챌린지 종료 3일 전 챌린저들에게 라운드 연장 여부를 안내하는 알림 생성 로직 구현
- 알림 이벤트 처리: ChallengeExtensionEvent 발생 시 비동기(@Async)로 알림 데이터를 생성하는 리스너를 구현
- 이미지 지원: 알림 목록에서 챌린지 썸네일을 노출하기 위해 NotificationEvent 엔티티에 imageKey 필드를 추가
- 도메인 강화: NotificationType의 타입을 Enum으로 변경하여 타입 안정성을 확보하고, ResourceType에 ROUND를 추가
- 비즈니스 로직: 유저의 푸시 알림 설정 여부와 관계 없이 모든 참여자에게 NotificationDelivery 레코드 생성 (알림 목록에서 보여주기 위함_

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="392" height="102" alt="image" src="https://github.com/user-attachments/assets/4117dcea-7c32-4144-a38b-45f8a406ee43" />

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- 이미지 처리는 DB에는 이미지 키만 저장하고, 조회 시점에 전체 URL로 반환 -> 알림 목록 조회 API 수정 예정

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 라운드 연장 알림 자동 배송 추가 — 매일 09:00에 연장 대상 라운드에 대해 연장 알림 이벤트 생성 및 전송

* **개선사항**
  * 알림에 선택적 이미지 키(imageKey) 지원 추가
  * 알림 타입을 열거형으로 전환하고 라운드(ROUND) 리소스 지원 추가로 타입 안정성 향상

* **테스트**
  * 연장 알림 처리 로직에 대한 단위 테스트 추가

* **데이터베이스**
  * 알림 관련 스키마 및 마이그레이션 스크립트 추가

* **오류 처리**
  * 미등록 알림 타입에 대한 신규 오류 코드 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->