### PR TITLE
[FEAT] 다른 사용자 정보 조회 API 응답에 차단여부(isBlocked) 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/user/dto/UserResponseDto.java
@@ -17,7 +17,7 @@ public class UserResponseDto {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
-    @Schema(description = "사용자 프로필 정보 DTO")
+    @Schema(description = "다른 사용자 프로필 정보 DTO")
     public static class ProfileDto {
 
         @Schema(description = "사용자 아이디", example = "999")
@@ -41,8 +41,11 @@ public class UserResponseDto {
         @Schema(description = "팔로잉 여부", example = "false")
         private Boolean isFollowing;
 
+        @Schema(description = "차단 여부", example = "false")
+        private Boolean isBlocked;
+
         // Entity -> DTO 변환
-        public static ProfileDto from(User user, Boolean isFollowing) {
+        public static ProfileDto from(User user, Boolean isFollowing, Boolean isBlocked) {
             return ProfileDto.builder()
                     .userId(user.getId())
                     .nickname(user.getDisplayNickname())
@@ -51,6 +54,7 @@ public class UserResponseDto {
                     .followerCount(user.getFollowerCount())
                     .followingCount(user.getFollowingCount())
                     .isFollowing(isFollowing)
+                    .isBlocked(isBlocked)
                     .build();
         }
     }

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -73,9 +73,9 @@ public class UserServiceImpl implements UserService {
 
         // 차단 여부 확인 (양방향)
         boolean isBlockedByMe = userBlockRepository.existsByBlockerAndBlocked(currentUser, targetUser);
-        boolean iBlockedByOther = userBlockRepository.existsByBlockerAndBlocked(targetUser, currentUser);
+        boolean isBlockedByOther = userBlockRepository.existsByBlockerAndBlocked(targetUser, currentUser);
 
-        if (iBlockedByOther) {
+        if (isBlockedByOther) {
             throw new GlobalException(ErrorCode.USER_NOT_FOUND);
         }
 

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -4,12 +4,12 @@ import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.hrr.backend.domain.user.dto.*;
 import com.hrr.backend.domain.user.event.ProfileImageDeletedEvent;
+import com.hrr.backend.domain.user.repository.UserBlockRepository;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
@@ -50,6 +50,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final FollowRepository followRepository;
     private final UserChallengeRepository userChallengeRepository;
+    private final UserBlockRepository userBlockRepository;
 
     private final ChallengeRepository challengeRepository;
     private final VerificationRepository verificationRepository;
@@ -58,18 +59,30 @@ public class UserServiceImpl implements UserService {
     private final ApplicationEventPublisher eventPublisher;
 
 
-    // 프로필 조회 관련
-
+    // 다른 사용자 프로필 조회 관련
     @Override
     public UserResponseDto.ProfileDto getUserProfile(Long userId, User currentUser) {
-		// 탈퇴 & 차단 여부 조회
-        User user = userRepository.findActiveUserExcludingBlocks(userId, currentUser)
+        // 사용자 조회 (탈퇴자는 제외, 차단자는 허용)
+        User targetUser = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        // 탈퇴 또는 비활성 상태 체크
+        if (targetUser.isNotActive()) {
+            throw new GlobalException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        // 차단 여부 확인 (양방향)
+        boolean isBlockedByMe = userBlockRepository.existsByBlockerAndBlocked(currentUser, targetUser);
+        boolean iBlockedByOther = userBlockRepository.existsByBlockerAndBlocked(targetUser, currentUser);
+
+        if (iBlockedByOther) {
+            throw new GlobalException(ErrorCode.USER_NOT_FOUND);
+        }
 
         // 팔로잉 여부 확인
         Boolean isFollowing = checkIfFollowing(currentUser.getId(), userId);
 
-        return UserResponseDto.ProfileDto.from(user, isFollowing);
+        return UserResponseDto.ProfileDto.from(targetUser, isFollowing, isBlockedByMe);
     }
 
     @Override


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #193 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

이번 PR에서는 타 사용자 프로필 조회 시 차단 상태(isBlocked)를 반환하도록 로직을 개선했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:**  로컬
* **테스트 방법:** 스웨거
* **결과 요약:** 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 설명 | 사진 |
| ----- | ----- |
| 차단한 사용자 | <img width="940" height="396" alt="image" src="https://github.com/user-attachments/assets/0d4f507d-686d-4ac3-8ba6-f4e434d66835" /> |
| 일반 사용자 | <img width="940" height="441" alt="image" src="https://github.com/user-attachments/assets/061ea905-3b21-45bd-b23c-acf7edb163a4" /> |


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 사용자 프로필에 상대방 차단 여부 표시 추가
  * 프로필 조회 시 양방향 차단 상태를 확인해 차단된 경우 접근을 제한

* **Bug Fixes**
  * 비활성 사용자 처리 로직 개선 — 차단된 관계로 인한 잘못된 프로필 노출 방지

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->