### PR TITLE
[Feat] 챌린지 연장 여부 응답 알림 로직 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
@@ -1,5 +1,7 @@
 package com.hrr.backend.domain.notification.entity.enums;
 
 public enum NotificationTypeName {
-    CHALLENGE_EXTENSION // 챌린지 라운드 연장 안내
+    CHALLENGE_EXTENSION, // 챌린지 라운드 연장 안내
+    CHALLENGE_EXTENSION_SUCCESS,
+    CHALLENGE_EXTENSION_CANCEL
 }

--- a/src/main/java/com/hrr/backend/domain/notification/event/ChallengeExtensionResponseEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/event/ChallengeExtensionResponseEvent.java
@@ -1,0 +1,14 @@
+package com.hrr.backend.domain.notification.event;
+
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class ChallengeExtensionResponseEvent {
+    private final Long roundId;
+    private final User user;
+    private final NextRoundIntent intent; // "계속하기" 또는 "그만하기"
+}

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -9,6 +9,7 @@ import com.hrr.backend.domain.notification.repository.*;
 import com.hrr.backend.domain.round.entity.*;
 import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.round.repository.*;
+import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
@@ -94,6 +95,22 @@ public class NotificationEventListener {
     @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void handleChallengeExtensionResponseEvent(ChallengeExtensionResponseEvent event) {
+        Long roundId = event.getRoundId();
+        User user = event.getUser();
+
+        // 체크할 결과 타입 정의 (성공 또는 취소)
+        List<NotificationTypeName> resultTypes = List.of(
+                NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS,
+                NotificationTypeName.CHALLENGE_EXTENSION_CANCEL
+        );
+
+        // 멱등성 체크: 해당 리스트에 포함된 타입이 하나라도 존재하면 중단
+        if (notificationRepository.existsResponseNotification(
+                user, ResourceType.ROUND, roundId, resultTypes)) {
+            log.debug("이미 결과 알림(성공/취소)이 처리된 라운드입니다: User={}, Round={}", user.getNickname(), roundId);
+            return;
+        }
+
         Round round = roundRepository.findById(event.getRoundId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.ROUND_NOT_FOUND));
         Challenge challenge = round.getChallenge();
@@ -120,8 +137,8 @@ public class NotificationEventListener {
         NotificationEvent notificationEvent = NotificationEvent.builder()
                 .type(type)
                 .category(NotificationCategory.CHALLENGE)
-                .targetType(ResourceType.USER) // 응답한 유저 본인 대상
-                .targetId(event.getUser().getId())
+                .targetType(ResourceType.CHALLENGE)
+                .targetId(challenge.getId())
                 .contextType(ResourceType.ROUND)
                 .contextId(round.getId())
                 .title(title)

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -100,14 +100,17 @@ public class NotificationEventListener {
 
         // NextRoundIntent에 따른 알림 타입 및 메시지 결정
         NotificationTypeName typeName;
+        String title;
         String message;
 
         if (event.getIntent() == NextRoundIntent.CONTINUE) {
             typeName = NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS;
-            message = "연장 완료! 다음 라운드까지 함께 해요";
+            title = String.format("[%s] 챌린지가 연장되었어요", challenge.getTitle());
+            message = "다음 라운드에서도 루틴을 이어가요";
         } else {
             typeName = NotificationTypeName.CHALLENGE_EXTENSION_CANCEL;
-            message = "이번 라운드로 챌린지가 종료됩니다 그동안 수고하셨습니다!";
+            title = String.format("[%s] 챌린지를 마무리해요", challenge.getTitle());
+            message = "챌린지가 예정대로 종료돼요. 그동안 수고 많으셨어요";
         }
 
         NotificationType type = typeRepository.findByTypeName(typeName)
@@ -121,7 +124,7 @@ public class NotificationEventListener {
                 .targetId(event.getUser().getId())
                 .contextType(ResourceType.ROUND)
                 .contextId(round.getId())
-                .title(String.format("[%s] 연장 결과 안내", challenge.getTitle()))
+                .title(title)
                 .message(message)
                 .imageKey(challenge.getImageKey())
                 .build();

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -4,8 +4,10 @@ import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.notification.entity.*;
 import com.hrr.backend.domain.notification.entity.enums.*;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.repository.*;
 import com.hrr.backend.domain.round.entity.*;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.round.repository.*;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.global.exception.GlobalException;
@@ -86,5 +88,52 @@ public class NotificationEventListener {
 
             log.info("챌린지 연장 알림 DB 저장 완료: RoundId={}, 대상={}명", roundId, deliveries.size());
         }
+    }
+
+    @Async("getAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void handleChallengeExtensionResponseEvent(ChallengeExtensionResponseEvent event) {
+        Round round = roundRepository.findById(event.getRoundId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.ROUND_NOT_FOUND));
+        Challenge challenge = round.getChallenge();
+
+        // NextRoundIntent에 따른 알림 타입 및 메시지 결정
+        NotificationTypeName typeName;
+        String message;
+
+        if (event.getIntent() == NextRoundIntent.CONTINUE) {
+            typeName = NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS;
+            message = "연장 완료! 다음 라운드까지 함께 해요";
+        } else {
+            typeName = NotificationTypeName.CHALLENGE_EXTENSION_CANCEL;
+            message = "이번 라운드로 챌린지가 종료됩니다 그동안 수고하셨습니다!";
+        }
+
+        NotificationType type = typeRepository.findByTypeName(typeName)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+
+        // NotificationEvent 생성 및 저장
+        NotificationEvent notificationEvent = NotificationEvent.builder()
+                .type(type)
+                .category(NotificationCategory.CHALLENGE)
+                .targetType(ResourceType.USER) // 응답한 유저 본인 대상
+                .targetId(event.getUser().getId())
+                .contextType(ResourceType.ROUND)
+                .contextId(round.getId())
+                .title(String.format("[%s] 연장 결과 안내", challenge.getTitle()))
+                .message(message)
+                .imageKey(challenge.getImageKey())
+                .build();
+        eventRepository.save(notificationEvent);
+
+        // 해당 유저에게만 알림 내역(Delivery) 생성
+        notificationRepository.save(NotificationDelivery.builder()
+                .event(notificationEvent)
+                .receiver(event.getUser())
+                .isRead(false)
+                .build());
+
+        log.info("연장 응답 알림 생성 완료: User={}, Intent={}", event.getUser().getNickname(), event.getIntent());
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationRepository.java
@@ -2,6 +2,8 @@ package com.hrr.backend.domain.notification.repository;
 
 import com.hrr.backend.domain.notification.entity.NotificationDelivery;
 import com.hrr.backend.domain.notification.entity.enums.NotificationCategory;
+import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
+import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.user.entity.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
@@ -9,6 +11,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 @Repository
 public interface NotificationRepository extends JpaRepository<NotificationDelivery, Long> {
@@ -22,5 +27,18 @@ public interface NotificationRepository extends JpaRepository<NotificationDelive
             @Param("user") User user,
             @Param("category") NotificationCategory category,
             Pageable pageable
+    );
+
+    @Query("SELECT COUNT(nd) > 0 FROM NotificationDelivery nd " +
+            "JOIN nd.event e " +
+            "WHERE nd.receiver = :user " +
+            "AND e.contextType = :contextType " +
+            "AND e.contextId = :contextId " +
+            "AND e.type.typeName IN :typeNames")
+    boolean existsResponseNotification(
+            @Param("user") User user,
+            @Param("contextType") ResourceType contextType,
+            @Param("contextId") Long contextId,
+            @Param("typeNames") List<NotificationTypeName> typeNames
     );
 }

--- a/src/main/resources/db/migration/V2.26__add_extension_result_notification_types.sql
+++ b/src/main/resources/db/migration/V2.26__add_extension_result_notification_types.sql
@@ -1,0 +1,15 @@
+-- 1. 새로운 타입을 추가
+ALTER TABLE notification_type
+    MODIFY COLUMN type_name ENUM(
+    'CHALLENGE_EXTENSION',
+    'CHALLENGE_EXTENSION_SUCCESS',
+    'CHALLENGE_EXTENSION_CANCEL'
+    ) NOT NULL;
+
+-- 2. 데이터 삽입 (이미 존재하는 경우 무시하거나 업데이트)
+INSERT INTO notification_type (type_name, default_enabled, is_mandatory, created_at)
+VALUES
+    ('CHALLENGE_EXTENSION_SUCCESS', 1, 0, NOW()),
+    ('CHALLENGE_EXTENSION_CANCEL', 1, 0, NOW())
+    ON DUPLICATE KEY UPDATE
+                         updated_at = NOW();

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -13,6 +13,7 @@ import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
+import com.hrr.backend.global.s3.S3UrlUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,8 +48,10 @@ class ChallengeServiceProfileTest {
     @Mock private UserChallengeRepository userChallengeRepository;
     @Mock private VerificationRepository verificationRepository;
 
-    // Converter는 로직이 있으므로 실제 객체(Spy) 사용
-    @Spy private ChallengeConverter challengeConverter;
+    @Mock private S3UrlUtil s3UrlUtil;
+
+    @Spy
+    private ChallengeConverter challengeConverter = new ChallengeConverter(s3UrlUtil);
 
     @Test
     @DisplayName("1. [부분 인증] 인증 요일이 월/목인데 '월요일'만 인증한 경우 -> 리스트에 MONDAY 하나만 존재")

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -14,13 +14,11 @@ import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 import com.hrr.backend.global.s3.S3UrlUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -50,8 +48,15 @@ class ChallengeServiceProfileTest {
 
     @Mock private S3UrlUtil s3UrlUtil;
 
-    @Spy
-    private ChallengeConverter challengeConverter = new ChallengeConverter(s3UrlUtil);
+    @BeforeEach
+    void setUp() {
+        // Mock s3UrlUtil을 주입하여 객체를 생성한 후 Mockito.spy()로 감쌈
+        ChallengeConverter instance = new ChallengeConverter(s3UrlUtil);
+        ChallengeConverter challengeConverter = Mockito.spy(instance);
+
+        // @InjectMocks로 생성된 서비스 객체에 수동으로 주입
+        ReflectionTestUtils.setField(challengeService, "challengeConverter", challengeConverter);
+    }
 
     @Test
     @DisplayName("1. [부분 인증] 인증 요일이 월/목인데 '월요일'만 인증한 경우 -> 리스트에 MONDAY 하나만 존재")

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -198,6 +198,29 @@ class NotificationEventListenerTest {
         assertThat(savedEvent.getTargetId()).isEqualTo(user.getId());
     }
 
+    @Test
+    @DisplayName("이미 결과 알림(성공 혹은 취소)이 존재하면 추가로 생성하지 않는다")
+    void handleChallengeExtensionResponse_Idempotency() {
+        // given
+        User user = createTestUser(1L, "테스터");
+        Long roundId = 100L;
+        ChallengeExtensionResponseEvent event = new ChallengeExtensionResponseEvent(
+                roundId, user, NextRoundIntent.CONTINUE);
+
+        // 이미 알림이 존재한다고 가정
+        given(notificationRepository.existsResponseNotification(eq(user), eq(ResourceType.ROUND), eq(roundId), anyList()))
+                .willReturn(true);
+
+        // when
+        notificationEventListener.handleChallengeExtensionResponseEvent(event);
+
+        // then
+        // 멱등성 체크에서 걸러지므로 이후 로직이 실행되지 않아야 함
+        verify(roundRepository, never()).findById(anyLong());
+        verify(eventRepository, never()).save(any());
+        verify(notificationRepository, never()).save(any());
+    }
+
     // --- Helper Methods ---
     private User createTestUser(Long id, String nickname) {
         return User.builder().id(id).nickname(nickname).build();

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -195,7 +195,7 @@ class NotificationEventListenerTest {
 
         NotificationEvent savedEvent = eventCaptor.getValue();
         assertThat(savedEvent.getMessage()).contains("챌린지가 예정대로 종료돼요. 그동안 수고 많으셨어요");
-        assertThat(savedEvent.getTargetId()).isEqualTo(user.getId());
+        assertThat(savedEvent.getTargetId()).isEqualTo(challenge.getId());
     }
 
     @Test

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -160,7 +160,7 @@ class NotificationEventListenerTest {
         verify(eventRepository).save(eventCaptor.capture());
 
         NotificationEvent savedEvent = eventCaptor.getValue();
-        assertThat(savedEvent.getMessage()).contains("다음 라운드까지 함께 해요");
+        assertThat(savedEvent.getMessage()).contains("다음 라운드에서도 루틴을 이어가요");
         assertThat(savedEvent.getImageKey()).isEqualTo(challenge.getImageKey());
 
         // 2. NotificationDelivery 저장 확인 (수신자 검증)
@@ -194,7 +194,7 @@ class NotificationEventListenerTest {
         verify(eventRepository).save(eventCaptor.capture());
 
         NotificationEvent savedEvent = eventCaptor.getValue();
-        assertThat(savedEvent.getMessage()).contains("이번 라운드로 챌린지가 종료됩니다");
+        assertThat(savedEvent.getMessage()).contains("챌린지가 예정대로 종료돼요. 그동안 수고 많으셨어요");
         assertThat(savedEvent.getTargetId()).isEqualTo(user.getId());
     }
 

--- a/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/listener/NotificationEventListenerTest.java
@@ -1,17 +1,20 @@
 package com.hrr.backend.domain.notification.listener;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.notification.entity.NotificationDelivery;
 import com.hrr.backend.domain.notification.entity.NotificationEvent;
 import com.hrr.backend.domain.notification.entity.NotificationSetting;
 import com.hrr.backend.domain.notification.entity.NotificationType;
 import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
 import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.repository.NotificationEventRepository;
 import com.hrr.backend.domain.notification.repository.NotificationRepository;
 import com.hrr.backend.domain.notification.repository.NotificationTypeRepository;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.round.repository.RoundRepository;
 import com.hrr.backend.domain.user.entity.User;
@@ -20,6 +23,7 @@ import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,6 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import java.util.List;
 import java.util.Optional;
 
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.*;
@@ -125,5 +130,84 @@ class NotificationEventListenerTest {
         // then
         verify(roundRepository, never()).findById(anyLong());
         verify(notificationRepository, never()).saveAll(any());
+    }
+
+    @Test
+    @DisplayName("챌린지 연장 '계속하기' 응답 시 성공 알림이 생성된다")
+    void handleChallengeExtensionResponse_Continue() {
+        // given
+        User user = createTestUser(1L, "테스터"); //
+        Challenge challenge = createTestChallenge("운동 챌린지");
+        Round round = createTestRound(10L, challenge);
+
+        NotificationType successType = NotificationType.builder()
+                .typeName(NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS)
+                .build();
+
+        ChallengeExtensionResponseEvent event = new ChallengeExtensionResponseEvent(
+                round.getId(), user, NextRoundIntent.CONTINUE);
+
+        given(roundRepository.findById(anyLong())).willReturn(Optional.of(round));
+        given(typeRepository.findByTypeName(NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS))
+                .willReturn(Optional.of(successType));
+
+        // when
+        notificationEventListener.handleChallengeExtensionResponseEvent(event);
+
+        // then
+        // 1. NotificationEvent 저장 확인
+        ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventRepository).save(eventCaptor.capture());
+
+        NotificationEvent savedEvent = eventCaptor.getValue();
+        assertThat(savedEvent.getMessage()).contains("다음 라운드까지 함께 해요");
+        assertThat(savedEvent.getImageKey()).isEqualTo(challenge.getImageKey());
+
+        // 2. NotificationDelivery 저장 확인 (수신자 검증)
+        verify(notificationRepository).save(any(NotificationDelivery.class));
+    }
+
+    @Test
+    @DisplayName("챌린지 연장 '그만하기' 응답 시 종료 알림이 생성된다")
+    void handleChallengeExtensionResponse_Stop() {
+        // given
+        User user = createTestUser(1L, "테스터");
+        Challenge challenge = createTestChallenge("운동 챌린지");
+        Round round = createTestRound(10L, challenge);
+
+        NotificationType cancelType = NotificationType.builder()
+                .typeName(NotificationTypeName.CHALLENGE_EXTENSION_CANCEL)
+                .build();
+
+        ChallengeExtensionResponseEvent event = new ChallengeExtensionResponseEvent(
+                round.getId(), user, NextRoundIntent.STOP);
+
+        given(roundRepository.findById(anyLong())).willReturn(Optional.of(round));
+        given(typeRepository.findByTypeName(NotificationTypeName.CHALLENGE_EXTENSION_CANCEL))
+                .willReturn(Optional.of(cancelType));
+
+        // when
+        notificationEventListener.handleChallengeExtensionResponseEvent(event);
+
+        // then
+        ArgumentCaptor<NotificationEvent> eventCaptor = ArgumentCaptor.forClass(NotificationEvent.class);
+        verify(eventRepository).save(eventCaptor.capture());
+
+        NotificationEvent savedEvent = eventCaptor.getValue();
+        assertThat(savedEvent.getMessage()).contains("이번 라운드로 챌린지가 종료됩니다");
+        assertThat(savedEvent.getTargetId()).isEqualTo(user.getId());
+    }
+
+    // --- Helper Methods ---
+    private User createTestUser(Long id, String nickname) {
+        return User.builder().id(id).nickname(nickname).build();
+    }
+
+    private Challenge createTestChallenge(String title) {
+        return Challenge.builder().id(1L).title(title).imageKey("test-image-key").build();
+    }
+
+    private Round createTestRound(Long id, Challenge challenge) {
+        return Round.builder().id(id).challenge(challenge).build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #198  

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
- 이벤트 기반 처리: 사용자의 응답 시점에 `ChallengeExtensionResponseEvent`를 발행하고, 이를 비동기로 처리
- 알림 타입 확장: 연장 성공(`SUCCESS`)과 종료 안내(`CANCEL`)를 구분하기 위한 신규 알림 타입을 DB 및 코드에 추가
- 테스트 코드 작성 및 수정

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

|**ChallengeServiceProfileTest.java**|
|---|
|<img width="344" height="115" alt="image" src="https://github.com/user-attachments/assets/64df623e-ed02-4b73-b91c-ccaa80c2b10f" />|
|**NotificationEventListenerTest.java**|
|<img width="321" height="122" alt="image" src="https://github.com/user-attachments/assets/d6aaeb9b-3d90-458a-85db-88dfd8442ae5" />|



---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 챌린지 연장 응답 알림이 추가되었습니다. 연장 동의 시 성공 알림, 거절 시 취소 알림이 발송됩니다.
  * 알림에는 관련 라운드 정보와 챌린지 이미지가 포함되며, 응답자에게 미확인 상태의 전달 항목이 생성됩니다.
  * 알림 유형이 데이터베이스에 추가되어 기본 활성화됩니다.

* **테스트**
  * 계속/중단 처리와 중복 방지(idempotency)를 검증하는 단위 테스트가 추가되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->