### PR TITLE
[FEAT] 챌린지 라운드 연장 과 챌린지 시작, 종료를 진행하는 API

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
@@ -115,4 +115,10 @@ public class Challenge extends BaseEntity {
 	public void changeCurrentRound(Round round) {
 		this.currentRound = round;
 	}
+
+    //상태 변경 메서드 추가
+    public void updateStatus(ChallengeStatus status) {
+        this.status = status;
+    }
+
 }

--- a/src/main/java/com/hrr/backend/domain/round/controller/RoundController.java
+++ b/src/main/java/com/hrr/backend/domain/round/controller/RoundController.java
@@ -1,0 +1,34 @@
+package com.hrr.backend.domain.round.controller;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+import com.hrr.backend.domain.round.dto.RoundDecisionRequestDto;
+import com.hrr.backend.domain.round.service.RoundDecisionService;
+import com.hrr.backend.global.config.CustomUserDetails;
+import com.hrr.backend.global.response.ApiResponse;
+import com.hrr.backend.global.response.SuccessCode;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/challenges")
+@Validated
+public class RoundController {
+
+    private final RoundDecisionService roundDecisionService;
+
+    // POST /api/v1/challenges/{challengeId}/rounds/decision
+    @PostMapping("/{challengeId}/rounds/decision")
+    public ApiResponse<Void> decideNextRound(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long challengeId,
+            @RequestBody @Valid RoundDecisionRequestDto request
+    ) {
+        roundDecisionService.decideNextRound(userDetails.getUser().getId(), challengeId, request);
+        return ApiResponse.onSuccess(SuccessCode.OK, null);
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/converter/RoundConverter.java
+++ b/src/main/java/com/hrr/backend/domain/round/converter/RoundConverter.java
@@ -35,4 +35,16 @@ public class RoundConverter {
                 .nextRoundIntent(NextRoundIntent.UNDECIDED)
                 .build();
     }
+
+    /** next round 생성 메서드(다음 라운드를 호출할 수 있게) */
+    public Round toNextRoundEntity(Challenge challenge, Round prevRound) {
+        LocalDate nextStart = prevRound.getEndDate().plusDays(1);
+        return Round.builder()
+                .challenge(challenge)
+                .roundNumber(prevRound.getRoundNumber() + 1)
+                .startDate(nextStart)
+                .endDate(nextStart.plusWeeks(Challenge.ROUND_WEEKS).minusDays(1))
+                .build();
+    }
+
 }

--- a/src/main/java/com/hrr/backend/domain/round/dto/RoundDecisionRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/round/dto/RoundDecisionRequestDto.java
@@ -1,0 +1,8 @@
+package com.hrr.backend.domain.round.dto;
+
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import jakarta.validation.constraints.NotNull;
+
+public record RoundDecisionRequestDto(
+        @NotNull NextRoundIntent intent
+) {}

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -66,4 +66,9 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
             @Param("round") Round round,
             @Param("status") ChallengeJoinStatus status
     );
+
+    /**멱등성 위한 exists 메서드 추가-> 스케줄러 장애 또는 재시작으로 재실행돼도 중복 생성 방지하게*/
+    boolean existsByUserChallengeAndRound(UserChallenge userChallenge, Round round);
+
+
 }

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRepository.java
@@ -43,10 +43,23 @@ public interface RoundRepository extends JpaRepository<Round, Long> {
 
     /**
      * 특정 날짜에 종료되는 라운드 목록 조회
+     * - Round.challenge는 LAZY일 수 있으므로 JOIN FETCH로 미리 로딩
+     * - challenge.currentRound도 접근될 가능성이 있어 LEFT JOIN FETCH로 함께 로딩
      */
     @Query("SELECT r FROM Round r " +
+            "JOIN FETCH r.challenge c " +
+            "LEFT JOIN FETCH c.currentRound " +
             "WHERE r.endDate = :endDate")
     List<Round> findAllByEndDate(@Param("endDate") LocalDate endDate);
+
+    /**
+     * 종료 처리 트랜잭션 내부에서 사용할 Round 재조회용 (detached 방지)
+     */
+    @Query("SELECT r FROM Round r " +
+            "JOIN FETCH r.challenge c " +
+            "LEFT JOIN FETCH c.currentRound " +
+            "WHERE r.id = :roundId")
+    Optional<Round> findByIdWithChallengeAndCurrentRound(@Param("roundId") Long roundId);
 
     // 챌린지 ID로 모든 라운드를 회차 오름차순(1R, 2R, ...)으로 조회
     List<Round> findAllByChallengeIdOrderByRoundNumberAsc(Long challengeId);

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionService.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionService.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.round.service;
+
+import com.hrr.backend.domain.round.dto.RoundDecisionRequestDto;
+
+public interface RoundDecisionService {
+    void decideNextRound(Long userId, Long challengeId, RoundDecisionRequestDto request);
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
@@ -1,0 +1,79 @@
+package com.hrr.backend.domain.round.service;
+
+import java.time.LocalDate;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.dto.RoundDecisionRequestDto;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class RoundDecisionServiceImpl implements RoundDecisionService {
+
+    private final ChallengeRepository challengeRepository;
+    private final UserChallengeRepository userChallengeRepository;
+    private final RoundRecordRepository roundRecordRepository;
+
+    @Override
+    @Transactional
+    public void decideNextRound(Long userId, Long challengeId, RoundDecisionRequestDto request) {
+
+        Challenge challenge = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
+
+        UserChallenge uc = userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_CHALLENGE_NOT_FOUND));
+
+        if (uc.getStatus() != ChallengeJoinStatus.JOINED) {
+            throw new GlobalException(ErrorCode.USER_CHALLENGE_NOT_FOUND);
+        }
+
+        Round currentRound = challenge.getCurrentRound();
+        if (currentRound == null) {
+            throw new GlobalException(ErrorCode.ROUND_NOT_FOUND);
+        }
+
+        LocalDate today = LocalDate.now();
+
+        // 라운드 기간 체크
+        if (today.isBefore(currentRound.getStartDate())) {
+            throw new GlobalException(ErrorCode.ROUND_NOT_STARTED);
+        }
+        if (today.isAfter(currentRound.getEndDate())) {
+            throw new GlobalException(ErrorCode.ROUND_ALREADY_ENDED);
+        }
+
+        // 결정 기간 체크: 종료 3일 전(포함)부터 가능
+        LocalDate decisionOpenDate = currentRound.getEndDate().minusDays(Challenge.CHALLENGER_DECISION_DAYS);
+        if (today.isBefore(decisionOpenDate)) {
+            throw new GlobalException(ErrorCode.ROUND_DECISION_PERIOD_NOT_OPEN);
+        }
+
+        // intent 유효성 (UNDECIDED로 요청하는 것 방지)
+        NextRoundIntent intent = request.intent();
+        if (intent == null || intent == NextRoundIntent.UNDECIDED) {
+            throw new GlobalException(ErrorCode.ROUND_DECISION_INTENT_INVALID);
+        }
+
+        RoundRecord rr = roundRecordRepository.findByUserChallengeAndRoundId(uc, currentRound.getId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.ROUND_RECORD_NOT_FOUND));
+
+        rr.updateNextRoundIntent(intent);
+        // rr은 영속 상태라 save 없어도 되지만, 명시적으로 해도 OK
+        // roundRecordRepository.save(rr);
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
@@ -1,7 +1,7 @@
 package com.hrr.backend.domain.round.service;
 
 import java.time.LocalDate;
-
+import java.time.ZoneId;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +47,7 @@ public class RoundDecisionServiceImpl implements RoundDecisionService {
             throw new GlobalException(ErrorCode.ROUND_NOT_FOUND);
         }
 
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         // 라운드 기간 체크
         if (today.isBefore(currentRound.getStartDate())) {

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
@@ -57,9 +57,15 @@ public class RoundDecisionServiceImpl implements RoundDecisionService {
             throw new GlobalException(ErrorCode.ROUND_ALREADY_ENDED);
         }
 
-        // 결정 기간 체크: 종료 3일 전(포함)부터 가능
-        LocalDate decisionOpenDate = currentRound.getEndDate().minusDays(Challenge.CHALLENGER_DECISION_DAYS);
-        if (today.isBefore(decisionOpenDate)) {
+        // 결정 기간 체크: (다음 라운드 시작 3일 전 ~ 2일 전) => 딱 하루만
+        // nextStart = endDate + 1
+        // open = nextStart - 3 = endDate - 2
+        // close = nextStart - 2 = endDate - 1
+        LocalDate decisionOpenDate = currentRound.getEndDate().minusDays(2);
+        LocalDate decisionCloseDate = currentRound.getEndDate().minusDays(1); // open + 1일
+
+// [openDate, closeDate) 만 허용 (즉, openDate 당일만 허용)
+        if (today.isBefore(decisionOpenDate) || !today.isBefore(decisionCloseDate)) {
             throw new GlobalException(ErrorCode.ROUND_DECISION_PERIOD_NOT_OPEN);
         }
 

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDropService.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDropService.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.round.service;
+
+import java.time.LocalDate;
+
+public interface RoundDropService {
+    void dropNonContinuersAt(LocalDate endDate);
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDropServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDropServiceImpl.java
@@ -1,0 +1,72 @@
+package com.hrr.backend.domain.round.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoundDropServiceImpl implements RoundDropService {
+
+    private final RoundRepository roundRepository;
+    private final RoundRecordRepository roundRecordRepository;
+    private final ChallengeRepository challengeRepository;
+
+    @Override
+    @Transactional
+    public void dropNonContinuersAt(LocalDate endDate) {
+
+        // 오늘이 endDate인 라운드들 => 오늘 23:59에 드랍 처리 대상
+        List<Round> rounds = roundRepository.findAllByEndDate(endDate);
+
+        for (Round round : rounds) {
+            try {
+                Challenge challenge = round.getChallenge();
+
+                // 진행중 챌린지만 처리
+                if (challenge.getStatus() != ChallengeStatus.ONGOING) continue;
+
+                // 멱등성: 이미 currentRound가 바뀌었으면 스킵
+                if (challenge.getCurrentRound() == null || !challenge.getCurrentRound().getId().equals(round.getId())) {
+                    continue;
+                }
+
+                // JOINED만 조회
+                List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
+                        round,
+                        ChallengeJoinStatus.JOINED
+                );
+
+                for (RoundRecord rr : records) {
+                    if (rr.getNextRoundIntent() == NextRoundIntent.CONTINUE) continue;
+
+                    UserChallenge uc = rr.getUserChallenge();
+                    if (uc.getStatus() != ChallengeJoinStatus.JOINED) continue;
+
+                    uc.updateStatus(ChallengeJoinStatus.DROPPED);
+                    challengeRepository.decreaseCurrentParticipantCount(challenge.getId());
+                }
+
+            } catch (Exception e) {
+                log.error("[RoundDrop] 드랍 처리 실패. roundId={}", round.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleService.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleService.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.round.service;
+
+import java.time.LocalDate;
+
+public interface RoundLifecycleService {
+    void processRoundsEndedAt(LocalDate endDate);
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -1,0 +1,131 @@
+package com.hrr.backend.domain.round.service;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.converter.RoundConverter;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RoundLifecycleServiceImpl implements RoundLifecycleService {
+
+    private final RoundRepository roundRepository;
+    private final RoundRecordRepository roundRecordRepository;
+    private final ChallengeRepository challengeRepository;
+    private final RoundConverter roundConverter;
+
+    @Override
+    @Transactional
+    public void processRoundsEndedAt(LocalDate endDate) {
+
+        List<Round> endedRounds = roundRepository.findAllByEndDate(endDate);
+
+        for (Round endedRound : endedRounds) {
+            try {
+                processSingleEndedRound(endedRound);
+            } catch (Exception e) {
+                log.error("[RoundLifecycle] 라운드 종료 처리 실패. roundId={}", endedRound.getId(), e);
+            }
+        }
+    }
+
+    private void processSingleEndedRound(Round endedRound) {
+
+        Challenge challenge = endedRound.getChallenge();
+
+        // 1. 멱등성: 현재 라운드가 이미 교체됐으면 스킵
+        Round currentRound = challenge.getCurrentRound();
+        if (currentRound == null || !currentRound.getId().equals(endedRound.getId())) {
+            return;
+        }
+
+        //2. 진행중인 챌린지만 라운드 자동 전환
+        if (challenge.getStatus() != ChallengeStatus.ONGOING) {
+            return;
+        }
+
+        // 3. 현재 라운드의 참가자 기록 조회 (JOINED만)
+        List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
+                endedRound,
+                ChallengeJoinStatus.JOINED
+        );
+
+        // 4. CONTINUE가 1명이라도 있으면 챌린지는 계속 (방장 STOP이어도 상관없개)
+        List<RoundRecord> continuers = records.stream()
+                .filter(rr -> rr.getNextRoundIntent() == NextRoundIntent.CONTINUE)
+                .toList();
+
+        if (continuers.isEmpty()) {
+            // 아무도 연장 안 함(UNDECIDED 포함 자동 하차) => 챌린지 종료
+            finishChallengeAndDropAll(challenge, records);
+            return;
+        }
+
+        // 5. 다음 라운드 생성(이미 존재하면 재사용)
+        Round nextRound = roundRepository
+                .findByChallengeIdAndRoundNumber(challenge.getId(), endedRound.getRoundNumber() + 1)
+                .orElseGet(() -> roundRepository.save(roundConverter.toNextRoundEntity(challenge, endedRound)));
+
+        // 6. CONTINUE는 nextRound로 RoundRecord 생성
+        for (RoundRecord rr : continuers) {
+            UserChallenge uc = rr.getUserChallenge();
+
+            // 멱등성- 이미 다음 라운드 기록이 있으면 스킵
+            if (roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)) {
+                continue;
+            }
+            RoundRecord nextRR = roundConverter.toRoundRecordEntity(nextRound, uc);
+            roundRecordRepository.save(nextRR);
+        }
+
+        // 7. STOP/UNDECIDED 는 하차 처리
+        for (RoundRecord rr : records) {
+            if (rr.getNextRoundIntent() == NextRoundIntent.CONTINUE) continue;
+
+            UserChallenge uc = rr.getUserChallenge();
+            uc.updateStatus(ChallengeJoinStatus.DROPPED);
+            challengeRepository.decreaseCurrentParticipantCount(challenge.getId());
+        }
+
+        // 8. 챌린지 currentRound 교체
+        challenge.changeCurrentRound(nextRound);
+
+        log.info("[RoundLifecycle] 라운드 전환 완료. challengeId={}, {}R -> {}R",
+                challenge.getId(), endedRound.getRoundNumber(), nextRound.getRoundNumber());
+    }
+
+    private void finishChallengeAndDropAll(Challenge challenge, List<RoundRecord> records) {
+
+        // 전원 하차 처리
+        for (RoundRecord rr : records) {
+            UserChallenge uc = rr.getUserChallenge();
+            if (uc.getStatus() == ChallengeJoinStatus.JOINED) {
+                uc.updateStatus(ChallengeJoinStatus.DROPPED);
+                challengeRepository.decreaseCurrentParticipantCount(challenge.getId());
+            }
+        }
+
+        // 챌린지 종료(상태 변경)
+        // 엔티티 메서드가 없다면 repository update 쿼리 추가해서 처리해도 됨.
+        challenge.updateStatus(ChallengeStatus.FINISHED);
+
+        log.info("[RoundLifecycle] 챌린지 종료 처리. challengeId={}", challenge.getId());
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.round.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -19,6 +20,7 @@ import com.hrr.backend.global.common.enums.ChallengeStatus;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @RequiredArgsConstructor
@@ -28,16 +30,20 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
     private final RoundRepository roundRepository;
     private final RoundRecordRepository roundRecordRepository;
     private final RoundConverter roundConverter;
+    private final DataSourceTransactionManager transactionManager;
 
     @Override
-    @Transactional
     public void processRoundsEndedAt(LocalDate endDate) {
 
         List<Round> endedRounds = roundRepository.findAllByEndDate(endDate);
 
+        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
+
         for (Round endedRound : endedRounds) {
             try {
-                processSingleEndedRound(endedRound);
+                transactionTemplate.executeWithoutResult(status -> {
+                    processSingleEndedRound(endedRound);
+                });
             } catch (Exception e) {
                 log.error("[RoundLifecycle] 라운드 종료 처리 실패. roundId={}", endedRound.getId(), e);
             }

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -7,7 +7,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
-import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.round.converter.RoundConverter;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
@@ -28,7 +27,6 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
 
     private final RoundRepository roundRepository;
     private final RoundRecordRepository roundRecordRepository;
-    private final ChallengeRepository challengeRepository;
     private final RoundConverter roundConverter;
 
     @Override
@@ -56,29 +54,30 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
             return;
         }
 
-        //2. 진행중인 챌린지만 라운드 자동 전환
+        // 2. 진행중인 챌린지만 라운드 자동 전환
         if (challenge.getStatus() != ChallengeStatus.ONGOING) {
             return;
         }
 
         // 3. 현재 라운드의 참가자 기록 조회 (JOINED만)
+        //STOP/UNDECIDED는 S-1일 23:59 드랍 스케줄러가 먼저 DROPPED 처리해야 함
         List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
                 endedRound,
                 ChallengeJoinStatus.JOINED
         );
 
-        // 4. CONTINUE가 1명이라도 있으면 챌린지는 계속 (방장 STOP이어도 상관없개)
+        // 4. 다음 라운드로 넘어갈 사람 = (드랍 이후 JOINED 중) CONTINUE인 사람
         List<RoundRecord> continuers = records.stream()
                 .filter(rr -> rr.getNextRoundIntent() == NextRoundIntent.CONTINUE)
                 .toList();
 
         if (continuers.isEmpty()) {
-            // 아무도 연장 안 함(UNDECIDED 포함 자동 하차) => 챌린지 종료
-            finishChallengeAndDropAll(challenge, records);
+            // 남아있는 연장자가 없으면 챌린지 종료(드랍은 별도 23:59 배치가 담당)
+            finishChallengeOnly(challenge);
             return;
         }
 
-        // 5. 다음 라운드 생성(이미 존재하면 재사용)
+        // 5. 다음 라운드 생성
         Round nextRound = roundRepository
                 .findByChallengeIdAndRoundNumber(challenge.getId(), endedRound.getRoundNumber() + 1)
                 .orElseGet(() -> roundRepository.save(roundConverter.toNextRoundEntity(challenge, endedRound)));
@@ -87,45 +86,24 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
         for (RoundRecord rr : continuers) {
             UserChallenge uc = rr.getUserChallenge();
 
-            // 멱등성- 이미 다음 라운드 기록이 있으면 스킵
+            // 멱등성: 이미 다음 라운드 기록이 있으면 스킵
             if (roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)) {
                 continue;
             }
+
             RoundRecord nextRR = roundConverter.toRoundRecordEntity(nextRound, uc);
             roundRecordRepository.save(nextRR);
         }
 
-        // 7. STOP/UNDECIDED 는 하차 처리
-        for (RoundRecord rr : records) {
-            if (rr.getNextRoundIntent() == NextRoundIntent.CONTINUE) continue;
-
-            UserChallenge uc = rr.getUserChallenge();
-            uc.updateStatus(ChallengeJoinStatus.DROPPED);
-            challengeRepository.decreaseCurrentParticipantCount(challenge.getId());
-        }
-
-        // 8. 챌린지 currentRound 교체
+        // 7. 챌린지 currentRound 교체
         challenge.changeCurrentRound(nextRound);
 
         log.info("[RoundLifecycle] 라운드 전환 완료. challengeId={}, {}R -> {}R",
                 challenge.getId(), endedRound.getRoundNumber(), nextRound.getRoundNumber());
     }
 
-    private void finishChallengeAndDropAll(Challenge challenge, List<RoundRecord> records) {
-
-        // 전원 하차 처리
-        for (RoundRecord rr : records) {
-            UserChallenge uc = rr.getUserChallenge();
-            if (uc.getStatus() == ChallengeJoinStatus.JOINED) {
-                uc.updateStatus(ChallengeJoinStatus.DROPPED);
-                challengeRepository.decreaseCurrentParticipantCount(challenge.getId());
-            }
-        }
-
-        // 챌린지 종료(상태 변경)
-        // 엔티티 메서드가 없다면 repository update 쿼리 추가해서 처리해도 됨.
+    private void finishChallengeOnly(Challenge challenge) {
         challenge.updateStatus(ChallengeStatus.FINISHED);
-
-        log.info("[RoundLifecycle] 챌린지 종료 처리. challengeId={}", challenge.getId());
+        log.info("[RoundLifecycle] 챌린지 종료 처리(FINISHED). challengeId={}", challenge.getId());
     }
 }

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -40,12 +40,18 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
         TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
 
         for (Round endedRound : endedRounds) {
+            Long endedRoundId = endedRound.getId();
+
             try {
                 transactionTemplate.executeWithoutResult(status -> {
-                    processSingleEndedRound(endedRound);
+                    //트랜잭션 내부에서 Round를 다시 조회해서(detached 방지) 처리
+                    Round managedEndedRound = roundRepository.findByIdWithChallengeAndCurrentRound(endedRoundId)
+                            .orElseThrow(() -> new IllegalStateException("Round not found. id=" + endedRoundId));
+
+                    processSingleEndedRound(managedEndedRound);
                 });
             } catch (Exception e) {
-                log.error("[RoundLifecycle] 라운드 종료 처리 실패. roundId={}", endedRound.getId(), e);
+                log.error("[RoundLifecycle] 라운드 종료 처리 실패. roundId={}", endedRoundId, e);
             }
         }
     }

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -92,6 +92,10 @@ public enum ErrorCode implements BaseCode{
     ROUND_NOT_STARTED(HttpStatus.BAD_REQUEST, "ROUND4003", "아직 시작되지 않은 라운드입니다."),
     ROUND_ALREADY_ENDED(HttpStatus.BAD_REQUEST, "ROUND4004", "이미 종료된 라운드입니다."),
     ROUND_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, "ROUND4045", "라운드 기록을 찾을 수 없습니다."),
+    ROUND_NOT_CURRENT(HttpStatus.BAD_REQUEST, "ROUND4006", "현재 진행 중인 라운드에 대해서만 처리할 수 있습니다."),
+    ROUND_DECISION_PERIOD_NOT_OPEN(HttpStatus.BAD_REQUEST, "ROUND4007", "아직 라운드 연장/하차 결정 기간이 아닙니다."),
+    ROUND_DECISION_INTENT_INVALID(HttpStatus.BAD_REQUEST, "ROUND4008", "연장/하차 의사결정 값이 올바르지 않습니다."),
+
 
     // mission
     RANDOM_MISSION_NOT_FOUND(HttpStatus.NOT_FOUND, "MISSION404", "미션을 찾을 수 없습니다."),

--- a/src/main/java/com/hrr/backend/global/scheduler/RoundDropScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RoundDropScheduler.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.global.scheduler;
 
 import java.time.LocalDate;
+import java.time.ZoneId;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -20,8 +21,9 @@ public class RoundDropScheduler {
     // 매일 23:59(한국시간)에 "오늘 endDate인 라운드"에서 STOP/UNDECIDED 드랍 처리
     @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
     public void dropNonContinuers() {
-        LocalDate today = LocalDate.now();
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
         log.info("[RoundDropScheduler] 드랍 처리 시작. endDate={}", today);
         roundDropService.dropNonContinuersAt(today);
     }
+
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/RoundDropScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RoundDropScheduler.java
@@ -1,0 +1,27 @@
+package com.hrr.backend.global.scheduler;
+
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.hrr.backend.domain.round.service.RoundDropService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoundDropScheduler {
+
+    private final RoundDropService roundDropService;
+
+    // 매일 23:59(한국시간)에 "오늘 endDate인 라운드"에서 STOP/UNDECIDED 드랍 처리
+    @Scheduled(cron = "0 59 23 * * *", zone = "Asia/Seoul")
+    public void dropNonContinuers() {
+        LocalDate today = LocalDate.now();
+        log.info("[RoundDropScheduler] 드랍 처리 시작. endDate={}", today);
+        roundDropService.dropNonContinuersAt(today);
+    }
+}

--- a/src/main/java/com/hrr/backend/global/scheduler/RoundLifecycleScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RoundLifecycleScheduler.java
@@ -1,7 +1,7 @@
 package com.hrr.backend.global.scheduler;
 
 import java.time.LocalDate;
-
+import java.time.ZoneId;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
@@ -20,7 +20,7 @@ public class RoundLifecycleScheduler {
     // 매일 00:10에 “어제 종료된 라운드” 처리
     @Scheduled(cron = "0 10 0 * * *")
     public void closeEndedRounds() {
-        LocalDate yesterday = LocalDate.now().minusDays(1);
+        LocalDate yesterday = LocalDate.now(ZoneId.of("Asia/Seoul")).minusDays(1);
         log.info("[RoundLifecycleScheduler] 종료 라운드 처리 시작. endDate={}", yesterday);
         roundLifecycleService.processRoundsEndedAt(yesterday);
     }

--- a/src/main/java/com/hrr/backend/global/scheduler/RoundLifecycleScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RoundLifecycleScheduler.java
@@ -1,0 +1,27 @@
+package com.hrr.backend.global.scheduler;
+
+import java.time.LocalDate;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import com.hrr.backend.domain.round.service.RoundLifecycleService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoundLifecycleScheduler {
+
+    private final RoundLifecycleService roundLifecycleService;
+
+    // 매일 00:10에 “어제 종료된 라운드” 처리
+    @Scheduled(cron = "0 10 0 * * *")
+    public void closeEndedRounds() {
+        LocalDate yesterday = LocalDate.now().minusDays(1);
+        log.info("[RoundLifecycleScheduler] 종료 라운드 처리 시작. endDate={}", yesterday);
+        roundLifecycleService.processRoundsEndedAt(yesterday);
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -13,6 +13,7 @@ import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
+import com.hrr.backend.global.s3.S3UrlUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -46,9 +47,10 @@ class ChallengeServiceProfileTest {
     @Mock private ChallengeRepository challengeRepository;
     @Mock private UserChallengeRepository userChallengeRepository;
     @Mock private VerificationRepository verificationRepository;
-
+    @Mock private S3UrlUtil s3UrlUtil;
     // Converter는 로직이 있으므로 실제 객체(Spy) 사용
-    @Spy private ChallengeConverter challengeConverter;
+    @Spy
+    private ChallengeConverter challengeConverter = new ChallengeConverter(s3UrlUtil);
 
     @Test
     @DisplayName("1. [부분 인증] 인증 요일이 월/목인데 '월요일'만 인증한 경우 -> 리스트에 MONDAY 하나만 존재")

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -14,13 +14,11 @@ import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 import com.hrr.backend.global.s3.S3UrlUtil;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
-import org.mockito.Mock;
-import org.mockito.Spy;
+import org.mockito.*;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -47,10 +45,18 @@ class ChallengeServiceProfileTest {
     @Mock private ChallengeRepository challengeRepository;
     @Mock private UserChallengeRepository userChallengeRepository;
     @Mock private VerificationRepository verificationRepository;
+
     @Mock private S3UrlUtil s3UrlUtil;
-    // Converter는 로직이 있으므로 실제 객체(Spy) 사용
-    @Spy
-    private ChallengeConverter challengeConverter = new ChallengeConverter(s3UrlUtil);
+
+    @BeforeEach
+    void setUp() {
+        // Mock s3UrlUtil을 주입하여 객체를 생성한 후 Mockito.spy()로 감쌈
+        ChallengeConverter instance = new ChallengeConverter(s3UrlUtil);
+        ChallengeConverter challengeConverter = Mockito.spy(instance);
+
+        // @InjectMocks로 생성된 서비스 객체에 수동으로 주입
+        ReflectionTestUtils.setField(challengeService, "challengeConverter", challengeConverter);
+    }
 
     @Test
     @DisplayName("1. [부분 인증] 인증 요일이 월/목인데 '월요일'만 인증한 경우 -> 리스트에 MONDAY 하나만 존재")

--- a/src/test/java/com/hrr/backend/domain/round/RoundFlowUnitTest.java
+++ b/src/test/java/com/hrr/backend/domain/round/RoundFlowUnitTest.java
@@ -1,0 +1,366 @@
+package com.hrr.backend.domain.round;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.converter.RoundConverter;
+import com.hrr.backend.domain.round.dto.RoundDecisionRequestDto;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.round.service.RoundDecisionServiceImpl;
+import com.hrr.backend.domain.round.service.RoundDropServiceImpl;
+import com.hrr.backend.domain.round.service.RoundLifecycleServiceImpl;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class RoundFlowUnitTest {
+
+    @Mock ChallengeRepository challengeRepository;
+    @Mock UserChallengeRepository userChallengeRepository;
+    @Mock RoundRepository roundRepository;
+    @Mock RoundRecordRepository roundRecordRepository;
+    @Mock RoundConverter roundConverter;
+
+    @InjectMocks RoundDecisionServiceImpl roundDecisionService;
+    @InjectMocks RoundDropServiceImpl roundDropService;
+    @InjectMocks RoundLifecycleServiceImpl roundLifecycleService;
+
+    // -------------------------------------------------------------------------
+    // 1) RoundDecisionServiceImpl 단위 테스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("decideNextRound: intent가 null/UNDECIDED면 ROUND_DECISION_INTENT_INVALID 예외")
+    void decideNextRound_throws_whenIntentInvalid() {
+        // given
+        Long userId = 1L;
+        Long challengeId = 10L;
+        LocalDate today = LocalDate.now();
+
+        Challenge challenge = mock(Challenge.class);
+        Round currentRound = mock(Round.class);
+        UserChallenge uc = mock(UserChallenge.class);
+
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
+        when(userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)).thenReturn(Optional.of(uc));
+        when(uc.getStatus()).thenReturn(ChallengeJoinStatus.JOINED);
+
+        when(challenge.getCurrentRound()).thenReturn(currentRound);
+
+        // startDate가 null이 아니어야 "라운드 기간 체크" 로직을 통과할 수 있습니다.
+        // 이미 시작된 라운드라고 가정하기 위해 과거 날짜로 설정
+        when(currentRound.getStartDate()).thenReturn(today.minusDays(10));
+
+        // endDate 설정 (결정 기간 안으로 설정)
+        when(currentRound.getEndDate()).thenReturn(today.plusDays(2));
+
+        RoundDecisionRequestDto request = new RoundDecisionRequestDto(NextRoundIntent.UNDECIDED);
+
+        // when & then
+        assertThatThrownBy(() -> roundDecisionService.decideNextRound(userId, challengeId, request))
+                .isInstanceOf(GlobalException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROUND_DECISION_INTENT_INVALID); //
+
+        verifyNoInteractions(roundRecordRepository);
+    }
+
+    @Test
+    @DisplayName("decideNextRound: 결정 기간이 아니면 ROUND_DECISION_PERIOD_NOT_OPEN 예외")
+    void decideNextRound_throws_whenOutsideDecisionWindow() {
+        // given
+        Long userId = 1L;
+        Long challengeId = 10L;
+        LocalDate today = LocalDate.now();
+
+        Challenge challenge = mock(Challenge.class);
+        Round currentRound = mock(Round.class);
+        UserChallenge uc = mock(UserChallenge.class);
+
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
+        when(userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)).thenReturn(Optional.of(uc));
+        when(uc.getStatus()).thenReturn(ChallengeJoinStatus.JOINED);
+
+        when(challenge.getCurrentRound()).thenReturn(currentRound);
+
+        // startDate가 null이면 안 됨. 시작된 라운드로 가정.
+        when(currentRound.getStartDate()).thenReturn(today.minusDays(10));
+
+        // 기간 밖으로 세팅: end=today+4 -> open=today+2, close=today+3
+        when(currentRound.getEndDate()).thenReturn(today.plusDays(4));
+
+        RoundDecisionRequestDto request = new RoundDecisionRequestDto(NextRoundIntent.CONTINUE);
+
+        // when & then
+        assertThatThrownBy(() -> roundDecisionService.decideNextRound(userId, challengeId, request))
+                .isInstanceOf(GlobalException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.ROUND_DECISION_PERIOD_NOT_OPEN); //
+
+        verifyNoInteractions(roundRecordRepository);
+    }
+
+
+    @Test
+    @DisplayName("decideNextRound: 정상 요청이면 RoundRecord.updateNextRoundIntent가 호출된다")
+    void decideNextRound_updatesRoundRecordIntent() {
+        // given
+        Long userId = 1L;
+        Long challengeId = 10L;
+        LocalDate today = LocalDate.now();
+
+        Challenge challenge = mock(Challenge.class);
+        Round currentRound = mock(Round.class);
+        UserChallenge uc = mock(UserChallenge.class);
+        RoundRecord rr = mock(RoundRecord.class);
+
+        when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
+        when(userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)).thenReturn(Optional.of(uc));
+        when(uc.getStatus()).thenReturn(ChallengeJoinStatus.JOINED);
+
+        when(challenge.getCurrentRound()).thenReturn(currentRound);
+        when(currentRound.getId()).thenReturn(100L);
+
+        // 결정기간 안으로 세팅: end=today+2 -> open=today, close=today+1
+        when(currentRound.getStartDate()).thenReturn(today.minusDays(10));
+        when(currentRound.getEndDate()).thenReturn(today.plusDays(2));
+
+        when(roundRecordRepository.findByUserChallengeAndRoundId(uc, 100L)).thenReturn(Optional.of(rr));
+
+        RoundDecisionRequestDto request = new RoundDecisionRequestDto(NextRoundIntent.CONTINUE);
+
+        // when
+        roundDecisionService.decideNextRound(userId, challengeId, request);
+
+        // then
+        verify(roundRecordRepository).findByUserChallengeAndRoundId(eq(uc), eq(100L));
+        verify(rr).updateNextRoundIntent(NextRoundIntent.CONTINUE);
+    }
+
+    // -------------------------------------------------------------------------
+    // 2) RoundDropServiceImpl 단위 테스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("dropNonContinuersAt: CONTINUE가 아닌 JOINED 유저는 DROPPED 처리 + 참가자 수 감소")
+    void dropNonContinuersAt_dropsNonContinuers() {
+        // given
+        LocalDate endDate = LocalDate.now();
+
+        Round endedRound = mock(Round.class);
+        Challenge challenge = mock(Challenge.class);
+
+        when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
+        when(endedRound.getId()).thenReturn(10L);
+        when(endedRound.getChallenge()).thenReturn(challenge);
+
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        when(challenge.getId()).thenReturn(999L);
+
+        // currentRound가 endedRound와 동일해야 처리됨(멱등성)
+        when(challenge.getCurrentRound()).thenReturn(endedRound);
+
+        RoundRecord rrContinue = mock(RoundRecord.class);
+        when(rrContinue.getNextRoundIntent()).thenReturn(NextRoundIntent.CONTINUE);
+
+        RoundRecord rrStop = mock(RoundRecord.class);
+        when(rrStop.getNextRoundIntent()).thenReturn(NextRoundIntent.STOP);
+
+        UserChallenge ucStop = mock(UserChallenge.class);
+        when(rrStop.getUserChallenge()).thenReturn(ucStop);
+        when(ucStop.getStatus()).thenReturn(ChallengeJoinStatus.JOINED);
+
+        when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
+                .thenReturn(List.of(rrContinue, rrStop));
+
+        // when
+        roundDropService.dropNonContinuersAt(endDate);
+
+        // then
+        verify(ucStop).updateStatus(ChallengeJoinStatus.DROPPED);
+        verify(challengeRepository).decreaseCurrentParticipantCount(999L);
+
+        // CONTINUE는 drop 대상이 아니므로 decrease 호출 추가 발생 X
+        verify(challengeRepository, times(1)).decreaseCurrentParticipantCount(999L);
+    }
+
+    @Test
+    @DisplayName("dropNonContinuersAt: currentRound가 이미 바뀐 경우 스킵(레코드 조회도 안 함)")
+    void dropNonContinuersAt_skips_whenCurrentRoundChanged() {
+        // given
+        LocalDate endDate = LocalDate.now();
+
+        Round endedRound = mock(Round.class);
+        Round otherRound = mock(Round.class);
+        Challenge challenge = mock(Challenge.class);
+
+        when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
+        when(endedRound.getId()).thenReturn(10L);
+        when(endedRound.getChallenge()).thenReturn(challenge);
+
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        when(challenge.getCurrentRound()).thenReturn(otherRound);
+        when(otherRound.getId()).thenReturn(9999L); // endedRound(10L)과 다름
+
+        // when
+        roundDropService.dropNonContinuersAt(endDate);
+
+        // then
+        verify(roundRecordRepository, never()).findAllByRoundWithUserAndSetting(any(), any());
+        verify(challengeRepository, never()).decreaseCurrentParticipantCount(any());
+    }
+
+    // -------------------------------------------------------------------------
+    // 3) RoundLifecycleServiceImpl 단위 테스트
+    // -------------------------------------------------------------------------
+
+    @Test
+    @DisplayName("processRoundsEndedAt: CONTINUE가 없으면 챌린지를 FINISHED로 변경")
+    void processRoundsEndedAt_finishes_whenNoContinuers() {
+        // given
+        LocalDate endDate = LocalDate.now();
+
+        Round endedRound = mock(Round.class);
+        Challenge challenge = mock(Challenge.class);
+
+        when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
+
+        when(endedRound.getId()).thenReturn(10L);
+        when(endedRound.getChallenge()).thenReturn(challenge);
+
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        when(challenge.getCurrentRound()).thenReturn(endedRound);
+
+        RoundRecord rrStop = mock(RoundRecord.class);
+        when(rrStop.getNextRoundIntent()).thenReturn(NextRoundIntent.STOP);
+
+        when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
+                .thenReturn(List.of(rrStop));
+
+        // when
+        roundLifecycleService.processRoundsEndedAt(endDate);
+
+        // then
+        verify(challenge).updateStatus(ChallengeStatus.FINISHED);
+        verify(roundRepository, never()).save(any());
+        verify(challenge, never()).changeCurrentRound(any());
+    }
+
+    @Test
+    @DisplayName("processRoundsEndedAt: CONTINUE가 있으면 다음 라운드 생성 + RoundRecord 생성 + currentRound 교체")
+    void processRoundsEndedAt_createsNextRound_andMovesCurrentRound() {
+        // given
+        LocalDate endDate = LocalDate.now();
+
+        Round endedRound = mock(Round.class);
+        Challenge challenge = mock(Challenge.class);
+
+        when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
+
+        when(endedRound.getId()).thenReturn(10L);
+        when(endedRound.getRoundNumber()).thenReturn(1);
+        when(endedRound.getChallenge()).thenReturn(challenge);
+
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        when(challenge.getId()).thenReturn(999L);
+        when(challenge.getCurrentRound()).thenReturn(endedRound);
+
+        // JOINED records 중 CONTINUE만 다음 라운드 대상
+        RoundRecord rrContinue = mock(RoundRecord.class);
+        when(rrContinue.getNextRoundIntent()).thenReturn(NextRoundIntent.CONTINUE);
+
+        UserChallenge uc = mock(UserChallenge.class);
+        when(rrContinue.getUserChallenge()).thenReturn(uc);
+
+        when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
+                .thenReturn(List.of(rrContinue));
+
+        // nextRound 생성 경로: 없으면 converter -> save
+        Round nextRound = mock(Round.class);
+        when(nextRound.getRoundNumber()).thenReturn(2);
+
+        when(roundRepository.findByChallengeIdAndRoundNumber(999L, 2)).thenReturn(Optional.empty());
+        when(roundConverter.toNextRoundEntity(challenge, endedRound)).thenReturn(nextRound);
+        when(roundRepository.save(nextRound)).thenReturn(nextRound);
+
+        // nextRR 생성
+        when(roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)).thenReturn(false);
+
+        RoundRecord nextRR = mock(RoundRecord.class);
+        when(roundConverter.toRoundRecordEntity(nextRound, uc)).thenReturn(nextRR);
+
+        // when
+        roundLifecycleService.processRoundsEndedAt(endDate);
+
+        // then
+        verify(roundRepository).save(nextRound);
+        verify(roundRecordRepository).save(nextRR);
+        verify(challenge).changeCurrentRound(nextRound);
+    }
+
+    @Test
+    @DisplayName("processRoundsEndedAt: nextRound가 이미 있으면 save 없이 기존 라운드 사용")
+    void processRoundsEndedAt_usesExistingNextRound() {
+        // given
+        LocalDate endDate = LocalDate.now();
+
+        Round endedRound = mock(Round.class);
+        Challenge challenge = mock(Challenge.class);
+
+        when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
+
+        when(endedRound.getId()).thenReturn(10L);
+        when(endedRound.getRoundNumber()).thenReturn(1);
+        when(endedRound.getChallenge()).thenReturn(challenge);
+
+        when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        when(challenge.getId()).thenReturn(999L);
+        when(challenge.getCurrentRound()).thenReturn(endedRound);
+
+        RoundRecord rrContinue = mock(RoundRecord.class);
+        when(rrContinue.getNextRoundIntent()).thenReturn(NextRoundIntent.CONTINUE);
+
+        UserChallenge uc = mock(UserChallenge.class);
+        when(rrContinue.getUserChallenge()).thenReturn(uc);
+
+        when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
+                .thenReturn(List.of(rrContinue));
+
+        Round nextRound = mock(Round.class);
+        when(roundRepository.findByChallengeIdAndRoundNumber(999L, 2)).thenReturn(Optional.of(nextRound));
+
+        when(roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)).thenReturn(true);
+
+        // when
+        roundLifecycleService.processRoundsEndedAt(endDate);
+
+        // then
+        verify(roundRepository, never()).save(any());
+        verify(roundConverter, never()).toNextRoundEntity(any(), any());
+        verify(roundRecordRepository, never()).save(any());
+        verify(challenge).changeCurrentRound(nextRound);
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -13,6 +13,10 @@ spring:
   flyway:
     enabled: false
 
+  task:
+    scheduling:
+      enabled: false
+
 springdoc:
   server-url: http://localhost:8080
 
@@ -27,9 +31,32 @@ firebase:
 
 #카카오 로그인
 kakao:
+  admin-key: ${KAKAO_ADMIN_KEY:dummy-kakao-admin-key}
   client-id: ${KAKAO_CLIENT_ID:dummy-kakao-id}
   redirect-uri: ${DOCKER_KAKAO_REDIRECT_URI:http://localhost:8080/api/v1/auth/kakao/callback}
   client-secret: ${KAKAO_CLIENT_SECRET:dummy-kakao-secret}
   token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
   #redirect-uri: ${DOCKER_KAKAO_REDIRECT_URI:hrr://oauth/kakao}
+
+apple:
+  team-id: ${APPLE_TEAM_ID:dummy-apple-team-id}
+  client-id: ${APPLE_CLIENT_ID:dummy-apple-client-id}
+  key-id: ${APPLE_KEY_ID:dummy-apple-key-id}
+  p8-key: ${APPLE_P8_KEY:dummy-apple-p8-key}
+
+naver:
+  client-id: ${NAVER_CLIENT_ID:dummy-naver-client-id}
+  client-secret: ${NAVER_CLIENT_SECRET:dummy-naver-client-secret}
+
+aws:
+  s3:
+    region: ap-northeast-2
+    bucket: test-bucket
+    prefix: test/
+    url-prefix: https://example.com/
+
+model:
+  api:
+    url: http://localhost:8000/recommend
+    embedding-url: http://localhost:8000/embedding


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #192 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
챌린지 라운드를 연장할 수 있는 기능과 3주(21일)마다 하나의 라운드가 새로 추가되도록 설정합니다.
방장과 챌린저 모두 동일하게 라운드 시작 3일 전에 연장 여부를 묻고 (하루동안만) 연장을 하지 않는다고 말한 챌린저나 연장여부를 체크하지 않은 챌린저는 모두 다음 라운드 시작 전날 23:59에 정리됩니다.
---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 테스트 코드
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="2619" height="818" alt="image" src="https://github.com/user-attachments/assets/15752b2e-255b-4ca2-b436-e421655ece71" />

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새 기능**
  * 라운드 연장/하차 의사결정 API 및 사용자 흐름 추가
  * 라운드 자동 진행 및 비연속 참가자 처리 스케줄러 추가

* **개선**
  * 라운드 결정 기간·의도 검증 및 관련 오류 메시지 추가/강화
  * 라운드 전환 시 아이디엠포턴시 및 동시성 안전성 향상

* **테스트**
  * 라운드 흐름에 대한 단위 테스트 추가

* **설정**
  * 테스트 환경용 구성 값 추가/정리

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->