### PR TITLE
[Feat] 회원 탈퇴 시 챌린지 처리 로직 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.auth.service;
 
 import java.time.Duration;
+import java.util.List;
 import java.util.Map;
 
 import com.hrr.backend.domain.auth.dto.AuthRequestDto;
@@ -12,6 +13,9 @@ import com.hrr.backend.domain.auth.entity.SocialAuth;
 import com.hrr.backend.domain.auth.entity.enums.SocialType;
 import com.hrr.backend.domain.auth.repository.SocialAuthRepository;
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
@@ -34,6 +38,7 @@ public class AuthService {
 
 	private final SocialAuthRepository socialAuthRepository;
 	private final UserRepository userRepository;
+	private final UserChallengeRepository userChallengeRepository;
 
     public AuthResponseDto.LoginResponse socialLogin(SocialType socialType, AuthRequestDto.SocialLoginRequest request) {
         // 지원하지 않는 소셜 타입이면 GlobalException 던지기
@@ -254,6 +259,18 @@ public class AuthService {
 
 		// 유저 상태 변경 (Soft Delete)
 		user.withdraw();
+
+		// 해당 사용자가 '참여 중(JOINED)'인 챌린지만 조회
+		List<UserChallenge> activeParticipations =
+				userChallengeRepository.findByUserAndStatus(user, ChallengeJoinStatus.JOINED);
+
+		for (UserChallenge uc : activeParticipations) {
+			// 연관된 챌린지의 현재 인원수 필드 감소
+			uc.getChallenge().decreaseCurrentParticipants();
+
+			// 유저의 참여 상태를 '하차(DROPPED)'로 업데이트
+			uc.updateStatus(ChallengeJoinStatus.DROPPED);
+		}
 
 		// TODO: 리프레시 토큰 등 세션 정보 삭제
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -77,6 +77,7 @@ public class ChallengeConverter {
     public ChallengeResponseDto.HeaderInfoDto toHeaderInfoDto(
             Challenge challenge,
             User owner,
+            boolean isOwnerActive,
             LocalDate startDate,
             LocalDate endDate,
             long remainDays,
@@ -84,14 +85,26 @@ public class ChallengeConverter {
             boolean isLiked,
             ActionButtonStatus actionButtonStatus
     ) {
-        // 방장 정보 DTO 생성
+        // 방장 정보 마스킹: owner가 null(정보 삭제됨)이거나 비활성 상태(탈퇴 처리됨)인 경우 통합 처리
+        String nickname;
+        String profileImageUrl = null;
+        Long ownerId = null;
+
+        if (owner != null && isOwnerActive) {
+            nickname = owner.getDisplayNickname();
+            profileImageUrl = owner.getProfileImage();
+            ownerId = owner.getId();
+        } else {
+            // 그 외 모든 경우 "탈퇴한 회원"으로 표시
+            nickname = "탈퇴한 사용자";
+        }
+
         ChallengeResponseDto.OwnerDto ownerDto = ChallengeResponseDto.OwnerDto.builder()
-                .id(owner.getId())
-                .nickname(owner.getDisplayNickname())
-                .profileImageUrl(owner.getProfileImage())
+                .id(ownerId)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
                 .build();
 
-        // 상단 정보 DTO 생성 및 반환
         return ChallengeResponseDto.HeaderInfoDto.builder()
                 .challengeId(challenge.getId())
                 .title(challenge.getTitle())
@@ -103,7 +116,7 @@ public class ChallengeConverter {
                 .startDate(startDate)
                 .endDate(endDate)
                 .remainDays(remainDays)
-				.isPublic(challenge.getIsPublic())
+                .isPublic(challenge.getIsPublic())
                 .isObserverMode(challenge.getIsViewerMode())
                 .isParticipant(isParticipant)
                 .isLiked(isLiked)

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/Challenge.java
@@ -111,6 +111,13 @@ public class Challenge extends BaseEntity {
 		this.currentParticipants++;
 	}
 
+	// 참가자 수 감소 편의 메서드
+	public void decreaseCurrentParticipants() {
+		if (this.currentParticipants > 0) {
+			this.currentParticipants--;
+		}
+	}
+
 	// 라운드 교체
 	public void changeCurrentRound(Round round) {
 		this.currentRound = round;

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -34,6 +34,7 @@ import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.entity.enums.UserChallengeRole;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
@@ -181,14 +182,18 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 		// 방장 정보 조회
 		UserChallenge ownerUc = userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER)
-				.orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+				.orElse(null);
+
+		// 방장 객체 및 활성 상태 추출
+		User owner = (ownerUc != null) ? ownerUc.getUser() : null;
+		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
 		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday);
 
 		// DTO 변환 및 반환
 		return challengeConverter.toHeaderInfoDto(
-				challenge, ownerUc.getUser(), startDate, endDate, remainDays,
+				challenge, owner, isOwnerActive, startDate, endDate, remainDays,
 				isParticipant, isLiked, buttonStatus
 		);
 	}

--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.verification.repository;
 
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
@@ -72,14 +73,20 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
     );
 
     // 특정 날짜(범위)의 인증 인원 수 (중복 제거, COMPLETED 상태만)
-    @Query("SELECT COUNT(DISTINCT r.userChallenge.id) FROM Verification v " +
-            "JOIN v.roundRecord r " +
-            "WHERE r.round.id = :roundId " +
-            "AND v.status = :status " +
-            "AND v.createdAt BETWEEN :start AND :end")
+    @Query("""
+    SELECT COUNT(DISTINCT r.userChallenge.id) FROM Verification v 
+    JOIN v.roundRecord r 
+    JOIN r.userChallenge uc 
+    JOIN uc.user u 
+    WHERE r.round.id = :roundId 
+    AND v.status = :status 
+    AND u.userStatus = :userStatus 
+    AND v.createdAt BETWEEN :start AND :end
+""")
     Long countDistinctCertifiers(
             @Param("roundId") Long roundId,
             @Param("status") VerificationStatus status,
+            @Param("userStatus") UserStatus userStatus,
             @Param("start") LocalDateTime start,
             @Param("end") LocalDateTime end
     );

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -7,6 +7,7 @@ import java.time.LocalTime;
 import java.util.List;
 
 import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 
 import com.hrr.backend.domain.comment.dto.CommentListResponseDto;
@@ -117,17 +118,21 @@ public class VerificationServiceImpl implements VerificationService {
             return verificationConverter.toStatDto(0, totalParticipantCount, null);
         }
 
-        Long currentRoundId = currentRound.getId();
-        LocalDateTime targetDateTime = determineTargetDateTime(challenge, currentRoundId);
+        // [수정] 실시간 현황 체크: 인증 요일/시간대가 아니면 null 반환
+        LocalDateTime targetDateTime = determineTargetDateTime(challenge);
 
         if (targetDateTime == null) {
+            // 인증 시간이 아니면 분자(certifiedCount)는 무조건 0
             return verificationConverter.toStatDto(0, totalParticipantCount, null);
         }
 
         LocalDate targetDate = targetDateTime.toLocalDate();
+
+        // 인증자 중 현재 ACTIVE 상태인 유저만 집계
         Long certifiedCount = verificationRepository.countDistinctCertifiers(
-                currentRoundId,
+                currentRound.getId(),
                 VerificationStatus.COMPLETED,
+                UserStatus.ACTIVE,
                 targetDate.atStartOfDay(),
                 targetDate.atTime(LocalTime.MAX)
         );
@@ -262,26 +267,20 @@ public class VerificationServiceImpl implements VerificationService {
         }
     }
 
-    private LocalDateTime determineTargetDateTime(Challenge challenge, Long roundId) {
-        LocalTime now = LocalTime.now();
-        LocalTime start = challenge.getVerifyStartTime();
-        LocalTime end = challenge.getVerifyEndTime();
+    private LocalDateTime determineTargetDateTime(Challenge challenge) {
+        LocalDateTime now = LocalDateTime.now();
 
-        boolean isVerificationTime;
-        if (start.isBefore(end)) {
-            isVerificationTime = !now.isBefore(start) && !now.isAfter(end);
-        } else {
-            isVerificationTime = !now.isBefore(start) || !now.isAfter(end);
+        // 오늘이 인증 요일인지 체크
+        if (!isVerificationDay(challenge, now.toLocalDate())) {
+            return null;
         }
 
-        if (isVerificationTime) {
-            return LocalDateTime.now();
-        } else {
-            return verificationRepository.findLatestVerificationTime(
-                    roundId,
-                    VerificationStatus.COMPLETED
-            );
+        // 현재 시간이 인증 시간대 내인지 체크
+        if (!isWithinVerificationTime(challenge, now.toLocalTime())) {
+            return null;
         }
+
+        return now;
     }
 
     @Override

--- a/src/test/java/com/hrr/backend/domain/auth/service/AuthServiceWithdrawTest.java
+++ b/src/test/java/com/hrr/backend/domain/auth/service/AuthServiceWithdrawTest.java
@@ -1,0 +1,92 @@
+package com.hrr.backend.domain.auth.service;
+
+import static org.mockito.BDDMockito.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.domain.user.repository.UserRepository;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceWithdrawTest {
+
+    @InjectMocks
+    private AuthService authService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private UserChallengeRepository userChallengeRepository;
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 - 참여 중인 챌린지 인원 감소 및 상태 변경 확인")
+    void withdraw_success() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class); // 유저 객체 모킹
+
+        // 테스트용 챌린지 생성 (현재 인원 5명)
+        Challenge challenge = Challenge.builder()
+                .currentParticipants(5)
+                .build();
+
+        // 테스트용 유저-챌린지 참여 정보 생성 (JOINED 상태)
+        UserChallenge userChallenge = UserChallenge.builder()
+                .user(user)
+                .challenge(challenge)
+                .status(ChallengeJoinStatus.JOINED)
+                .build();
+
+        // Repository 모킹
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(userChallengeRepository.findByUserAndStatus(user, ChallengeJoinStatus.JOINED))
+                .willReturn(List.of(userChallenge));
+
+        // when
+        authService.withdraw(userId);
+
+        // then
+        // 1. 유저 엔티티의 withdraw() 메서드가 호출되었는지 확인
+        verify(user).withdraw();
+
+        // 2. 챌린지 엔티티의 인원수가 감소했는지 확인 (5 -> 4)
+        assertThat(challenge.getCurrentParticipants()).isEqualTo(4);
+
+        // 3. UserChallenge의 상태가 DROPPED로 변경되었는지 확인
+        assertThat(userChallenge.getStatus()).isEqualTo(ChallengeJoinStatus.DROPPED);
+    }
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 - 참여 중인 챌린지가 없는 경우")
+    void withdraw_success_no_active_challenges() {
+        // given
+        Long userId = 1L;
+        User user = mock(User.class);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        // 참여 중인 챌린지가 없음
+        given(userChallengeRepository.findByUserAndStatus(user, ChallengeJoinStatus.JOINED))
+                .willReturn(List.of());
+
+        // when
+        authService.withdraw(userId);
+
+        // then
+        verify(user).withdraw();
+        // 별다른 에러 없이 로직이 종료되어야 함
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -11,6 +11,7 @@ import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.entity.enums.UserChallengeRole;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
@@ -298,6 +299,64 @@ class ChallengeServiceInfoTest {
     }
 
     /**
+     * 4. 방장 상태 관련 시나리오 (신규 추가)
+     */
+    @Test
+    @DisplayName("상황 10: 방장이 탈퇴함 (UserStatus != ACTIVE) -> 정상 조회")
+    void owner_inactive_returns_info_successfully() {
+        // Given
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+        setRoundDate(challenge, LocalDate.now());
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
+
+        // 방장이 존재하지만 탈퇴 상태
+        User owner = mock(User.class);
+        given(owner.getUserStatus()).willReturn(UserStatus.INACTIVE);
+        UserChallenge ownerUc = mock(UserChallenge.class);
+        given(ownerUc.getUser()).willReturn(owner);
+
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER))
+                .willReturn(Optional.of(ownerUc));
+
+        mockParticipant(user, challenge, false);
+        mockConverter(ActionButtonStatus.JOIN);
+
+        // When
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
+        // Then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("상황 11: 방장 데이터가 아예 없음 (owner == null) -> 에러 없이 조회")
+    void owner_not_found_returns_info_successfully() {
+        // Given
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+        setRoundDate(challenge, LocalDate.now());
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
+
+        // 방장 정보가 Optional.empty()
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER))
+                .willReturn(Optional.empty());
+
+        mockParticipant(user, challenge, false);
+        mockConverter(ActionButtonStatus.JOIN);
+
+        // When
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
+        // Then
+        assertThat(result).isNotNull();
+    }
+
+    /**
      * Helper Methods (테스트 설정을 쉽게 하기 위한 도구들)
      */
 
@@ -364,9 +423,9 @@ class ChallengeServiceInfoTest {
 
     // Converter가 Status를 그대로 통과시키도록 Stubbing
     private void mockConverter(ActionButtonStatus expectedStatus) {
-        given(challengeConverter.toHeaderInfoDto(any(), any(), any(), any(), anyLong(), anyBoolean(), anyBoolean(), any()))
+        given(challengeConverter.toHeaderInfoDto(any(), any(), anyBoolean(), any(), any(), anyLong(), anyBoolean(), anyBoolean(), any()))
                 .willAnswer(invocation -> ChallengeResponseDto.HeaderInfoDto.builder()
-                        .actionButtonStatus(invocation.getArgument(7))
+                        .actionButtonStatus(invocation.getArgument(8))
                         .build());
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #206 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

회원 탈퇴 시 발생하는 사이드 이펙트를 해결하기 위한 로직을 구현했습니다. (챌린지 인원 수 불일치, 방장 부재 시 조회 오류, 인증 통계 왜곡)

1. 챌린지 참여 인원 자동 관리: 사용자가 탈퇴할 때 참여 중인 모든 챌린지의 현재 인원수를 차감하도록 했습니다.
2. 참여 기록 상태 변경: 탈퇴자의 UserChallenge 상태를 JOINED에서 DROPPED로 변경하여 이력을 관리합니다.
3. 방장 정보 마스킹 및 예외 처리: 방장이 탈퇴하거나 정보가 삭제된 챌린지 조회 시 서버 에러 없이 탈퇴한 사용자로 반환합니다.
4. 실시간 인증 통계 최적화: 인증 통계 집계 시 현재 활성 유저(UserStatus.ACTIVE)만 계산에 포함하여 탈퇴한 회원이 통계 수치를 왜곡하지 않도록 수정했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트 및 Swagger
* **결과 요약:** 
* AuthServiceWithdrawTest: 탈퇴 시 유저 상태 변경, 챌린지 인원 감소, 참여 기록 업데이트 확인 완료
* ChallengeServiceInfoTest: 방장 부재/탈퇴 시나리오에 대한 HeaderInfo API의 NPE 방지 및 마스킹 처리 검증 완료
* 탈퇴한 사용자 반환 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 탈퇴한 사용자 확인 |
|---|
|<img width="1174" height="678" alt="image" src="https://github.com/user-attachments/assets/55d1937b-a5b5-49f7-8ff0-9df3e532d52e" />|
|AuthServiceWithdrawTest|
|<img width="591" height="201" alt="image" src="https://github.com/user-attachments/assets/e741f17f-99df-4d3d-ae71-ef7371e5ce60" />|
|ChallengeServiceInfoTest|
|<img width="303" height="110" alt="image" src="https://github.com/user-attachments/assets/a9b93069-f616-4d7b-9c2f-f83421e319f9" />|
---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- AuthService.withdraw 메서드에서 유저 탈퇴와 챌린지 인원 감소가 하나의 트랜잭션으로 묶여 있는데, 챌린저가 5개의 챌린지에 참여 중일 경우 성능상 우려되는 점이 없는지 (최대 5개 참여 가능)

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 사용자 탈퇴 시 참여 중인 모든 챌린지에서 참여 정보 자동 정리 및 참여자 수 업데이트

## 버그 수정
* 비활성 상태의 챌린지 소유자 정보를 마스킹 처리하여 표시
* 실시간 검증 시간 윈도우 기반 인증 통계 계산 로직 개선

## 테스트
* 탈퇴 프로세스 및 챌린지 정보 조회 테스트 시나리오 추가

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->