### PR TITLE
[Feat] 챌린지 연장 응답에 따른 알림 생성 로직 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundDecisionServiceImpl.java
@@ -2,6 +2,9 @@ package com.hrr.backend.domain.round.service;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
+
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,6 +30,7 @@ public class RoundDecisionServiceImpl implements RoundDecisionService {
     private final ChallengeRepository challengeRepository;
     private final UserChallengeRepository userChallengeRepository;
     private final RoundRecordRepository roundRecordRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     @Transactional
@@ -81,5 +85,13 @@ public class RoundDecisionServiceImpl implements RoundDecisionService {
         rr.updateNextRoundIntent(intent);
         // rr은 영속 상태라 save 없어도 되지만, 명시적으로 해도 OK
         // roundRecordRepository.save(rr);
+
+        // 알림 이벤트 발행
+        // 비동기 리스너가 이 이벤트를 받아 SUCCESS 또는 CANCEL 알림을 생성
+        eventPublisher.publishEvent(new ChallengeExtensionResponseEvent(
+                currentRound.getId(),
+                uc.getUser(),
+                intent
+        ));
     }
 }

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -31,14 +31,12 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
     private final RoundRepository roundRepository;
     private final RoundRecordRepository roundRecordRepository;
     private final RoundConverter roundConverter;
-    private final PlatformTransactionManager transactionManager;
+    private final TransactionTemplate transactionTemplate;
 
     @Override
     public void processRoundsEndedAt(LocalDate endDate) {
 
         List<Round> endedRounds = roundRepository.findAllByEndDate(endDate);
-
-        TransactionTemplate transactionTemplate = new TransactionTemplate(transactionManager);
 
         for (Round endedRound : endedRounds) {
             Long endedRoundId = endedRound.getId();

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -81,20 +81,26 @@ public class NotificationScheduler {
         List<Round> targetRounds = roundRepository.findAllByEndDate(targetEndDate);
 
         for (Round round : targetRounds) {
-            // 해당 라운드의 참여자 전체 조회
-            List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
-                    round, ChallengeJoinStatus.JOINED);
+            try { // 1차 격리: 특정 라운드 조회 실패 시에도 다른 라운드는 진행
+                List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
+                        round, ChallengeJoinStatus.JOINED);
 
-            for (RoundRecord record : records) {
-                // API로 응답한 유저: 리스너의 멱등성 로직이 중복 발송을 막아줌
-                // 미응답 유저(UNDECIDED): 리스너 로직에 의해 자동으로 '종료' 알림이 발송됨
-                eventPublisher.publishEvent(new ChallengeExtensionResponseEvent(
-                        round.getId(),
-                        record.getUserChallenge().getUser(),
-                        record.getNextRoundIntent()
-                ));
+                for (RoundRecord record : records) {
+                    try { // 2차 격리: 특정 사용자 이벤트 발행 실패 시에도 다음 사용자는 진행
+                        eventPublisher.publishEvent(new ChallengeExtensionResponseEvent(
+                                round.getId(),
+                                record.getUserChallenge().getUser(),
+                                record.getNextRoundIntent()
+                        ));
+                    } catch (Exception e) {
+                        log.error("[ExtensionResultScheduler] 이벤트 발행 실패 - RoundId: {}, UserId: {}, 사유: {}",
+                                round.getId(), record.getUserChallenge().getUser().getId(), e.getMessage());
+                    }
+                }
+                log.info("[ExtensionResultScheduler] RoundId: {} 결과 알림 발행 완료", round.getId());
+            } catch (Exception e) {
+                log.error("[ExtensionResultScheduler] 라운드 처리 실패 - RoundId: {}, 사유: {}", round.getId(), e.getMessage());
             }
-            log.info("[ExtensionResultScheduler] RoundId: {} 결과 알림 발행 완료", round.getId());
         }
     }
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -71,9 +71,9 @@ public class NotificationScheduler {
      * 결정 기간(endDate - 2)이 종료되는 시점인 자정에 바로 실행합니다.
      */
     @Transactional(readOnly = true)
-    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정 실행
+    @Scheduled(cron = "0 0 0 * * *") // 매일 자정 실행
     public void scheduleChallengeExtensionResultNotifications() {
-        // 오늘(자정)이 endDate - 1일인 라운드들을 찾습니다. (즉, 내일이 endDate인 라운드)
+        // 오늘(자정)이 endDate - 1일인 라운드들을 찾음
         LocalDate targetEndDate = LocalDate.now().plusDays(1);
 
         log.info("[ExtensionResultScheduler] 결정 기간 종료. 결과 알림 발송 시작 (대상 endDate: {})", targetEndDate);

--- a/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/NotificationScheduler.java
@@ -2,8 +2,12 @@ package com.hrr.backend.global.scheduler;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j; // [추가] 로깅 라이브러리
 import org.springframework.context.ApplicationEventPublisher;
@@ -20,6 +24,7 @@ import java.util.List;
 public class NotificationScheduler {
 
     private final RoundRepository roundRepository;
+    private final RoundRecordRepository roundRecordRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional(readOnly = true)
@@ -58,6 +63,38 @@ public class NotificationScheduler {
         } catch (Exception e) {
             // 전체 프로세스 중 예외 발생 시 에러 로깅
             log.error("[ChallengeExtensionScheduler] 스케줄러 실행 중 심각한 오류 발생 (대상 날짜: {}), 에러: ", targetDate, e);
+        }
+    }
+
+    /**
+     * 연장 응답 기간 종료 직후(자정) 최종 결과 알림 발송
+     * 결정 기간(endDate - 2)이 종료되는 시점인 자정에 바로 실행합니다.
+     */
+    @Transactional(readOnly = true)
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul") // 매일 자정 실행
+    public void scheduleChallengeExtensionResultNotifications() {
+        // 오늘(자정)이 endDate - 1일인 라운드들을 찾습니다. (즉, 내일이 endDate인 라운드)
+        LocalDate targetEndDate = LocalDate.now().plusDays(1);
+
+        log.info("[ExtensionResultScheduler] 결정 기간 종료. 결과 알림 발송 시작 (대상 endDate: {})", targetEndDate);
+
+        List<Round> targetRounds = roundRepository.findAllByEndDate(targetEndDate);
+
+        for (Round round : targetRounds) {
+            // 해당 라운드의 참여자 전체 조회
+            List<RoundRecord> records = roundRecordRepository.findAllByRoundWithUserAndSetting(
+                    round, ChallengeJoinStatus.JOINED);
+
+            for (RoundRecord record : records) {
+                // API로 응답한 유저: 리스너의 멱등성 로직이 중복 발송을 막아줌
+                // 미응답 유저(UNDECIDED): 리스너 로직에 의해 자동으로 '종료' 알림이 발송됨
+                eventPublisher.publishEvent(new ChallengeExtensionResponseEvent(
+                        round.getId(),
+                        record.getUserChallenge().getUser(),
+                        record.getNextRoundIntent()
+                ));
+            }
+            log.info("[ExtensionResultScheduler] RoundId: {} 결과 알림 발행 완료", round.getId());
         }
     }
 }

--- a/src/test/java/com/hrr/backend/domain/round/RoundFlowUnitTest.java
+++ b/src/test/java/com/hrr/backend/domain/round/RoundFlowUnitTest.java
@@ -8,9 +8,11 @@ import static org.mockito.Mockito.*;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Consumer;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.round.converter.RoundConverter;
 import com.hrr.backend.domain.round.dto.RoundDecisionRequestDto;
 import com.hrr.backend.domain.round.entity.Round;
@@ -34,6 +36,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @ExtendWith(MockitoExtension.class)
 class RoundFlowUnitTest {
@@ -43,10 +48,20 @@ class RoundFlowUnitTest {
     @Mock RoundRepository roundRepository;
     @Mock RoundRecordRepository roundRecordRepository;
     @Mock RoundConverter roundConverter;
+    @Mock TransactionTemplate transactionTemplate;
+    @Mock ApplicationEventPublisher eventPublisher;
 
     @InjectMocks RoundDecisionServiceImpl roundDecisionService;
     @InjectMocks RoundDropServiceImpl roundDropService;
     @InjectMocks RoundLifecycleServiceImpl roundLifecycleService;
+
+    private void mockTransaction() {
+        lenient().doAnswer(invocation -> {
+            Consumer<TransactionStatus> callback = invocation.getArgument(0);
+            callback.accept(null); // 트랜잭션 내부 로직 실행
+            return null;
+        }).when(transactionTemplate).executeWithoutResult(any());
+    }
 
     // -------------------------------------------------------------------------
     // 1) RoundDecisionServiceImpl 단위 테스트
@@ -125,7 +140,7 @@ class RoundFlowUnitTest {
 
 
     @Test
-    @DisplayName("decideNextRound: 정상 요청이면 RoundRecord.updateNextRoundIntent가 호출된다")
+    @DisplayName("decideNextRound: 정상 요청이면 RoundRecord 업데이트 및 알림 이벤트 발행")
     void decideNextRound_updatesRoundRecordIntent() {
         // given
         Long userId = 1L;
@@ -140,14 +155,10 @@ class RoundFlowUnitTest {
         when(challengeRepository.findById(challengeId)).thenReturn(Optional.of(challenge));
         when(userChallengeRepository.findByUserIdAndChallengeId(userId, challengeId)).thenReturn(Optional.of(uc));
         when(uc.getStatus()).thenReturn(ChallengeJoinStatus.JOINED);
-
         when(challenge.getCurrentRound()).thenReturn(currentRound);
         when(currentRound.getId()).thenReturn(100L);
-
-        // 결정기간 안으로 세팅: end=today+2 -> open=today, close=today+1
-        when(currentRound.getStartDate()).thenReturn(today.minusDays(10));
+        when(currentRound.getStartDate()).thenReturn(today.minusDays(1));
         when(currentRound.getEndDate()).thenReturn(today.plusDays(2));
-
         when(roundRecordRepository.findByUserChallengeAndRoundId(uc, 100L)).thenReturn(Optional.of(rr));
 
         RoundDecisionRequestDto request = new RoundDecisionRequestDto(NextRoundIntent.CONTINUE);
@@ -156,8 +167,9 @@ class RoundFlowUnitTest {
         roundDecisionService.decideNextRound(userId, challengeId, request);
 
         // then
-        verify(roundRecordRepository).findByUserChallengeAndRoundId(eq(uc), eq(100L));
         verify(rr).updateNextRoundIntent(NextRoundIntent.CONTINUE);
+        // 알림 이벤트 발행 검증
+        verify(eventPublisher).publishEvent(any(ChallengeExtensionResponseEvent.class));
     }
 
     // -------------------------------------------------------------------------
@@ -241,22 +253,22 @@ class RoundFlowUnitTest {
     @DisplayName("processRoundsEndedAt: CONTINUE가 없으면 챌린지를 FINISHED로 변경")
     void processRoundsEndedAt_finishes_whenNoContinuers() {
         // given
+        mockTransaction(); // 트랜잭션 실행 모킹
         LocalDate endDate = LocalDate.now();
-
         Round endedRound = mock(Round.class);
         Challenge challenge = mock(Challenge.class);
 
         when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
-
         when(endedRound.getId()).thenReturn(10L);
-        when(endedRound.getChallenge()).thenReturn(challenge);
+        // 트랜잭션 내부에서 호출하는 메서드 Stubbing
+        when(roundRepository.findByIdWithChallengeAndCurrentRound(10L)).thenReturn(Optional.of(endedRound));
 
+        when(endedRound.getChallenge()).thenReturn(challenge);
         when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
         when(challenge.getCurrentRound()).thenReturn(endedRound);
 
         RoundRecord rrStop = mock(RoundRecord.class);
         when(rrStop.getNextRoundIntent()).thenReturn(NextRoundIntent.STOP);
-
         when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
                 .thenReturn(List.of(rrStop));
 
@@ -265,50 +277,40 @@ class RoundFlowUnitTest {
 
         // then
         verify(challenge).updateStatus(ChallengeStatus.FINISHED);
-        verify(roundRepository, never()).save(any());
-        verify(challenge, never()).changeCurrentRound(any());
     }
 
     @Test
     @DisplayName("processRoundsEndedAt: CONTINUE가 있으면 다음 라운드 생성 + RoundRecord 생성 + currentRound 교체")
     void processRoundsEndedAt_createsNextRound_andMovesCurrentRound() {
         // given
+        mockTransaction();
         LocalDate endDate = LocalDate.now();
-
         Round endedRound = mock(Round.class);
         Challenge challenge = mock(Challenge.class);
 
         when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
-
         when(endedRound.getId()).thenReturn(10L);
+        when(roundRepository.findByIdWithChallengeAndCurrentRound(10L)).thenReturn(Optional.of(endedRound));
+
         when(endedRound.getRoundNumber()).thenReturn(1);
         when(endedRound.getChallenge()).thenReturn(challenge);
-
         when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
         when(challenge.getId()).thenReturn(999L);
         when(challenge.getCurrentRound()).thenReturn(endedRound);
 
-        // JOINED records 중 CONTINUE만 다음 라운드 대상
         RoundRecord rrContinue = mock(RoundRecord.class);
         when(rrContinue.getNextRoundIntent()).thenReturn(NextRoundIntent.CONTINUE);
-
         UserChallenge uc = mock(UserChallenge.class);
         when(rrContinue.getUserChallenge()).thenReturn(uc);
-
         when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
                 .thenReturn(List.of(rrContinue));
 
-        // nextRound 생성 경로: 없으면 converter -> save
         Round nextRound = mock(Round.class);
         when(nextRound.getRoundNumber()).thenReturn(2);
-
         when(roundRepository.findByChallengeIdAndRoundNumber(999L, 2)).thenReturn(Optional.empty());
         when(roundConverter.toNextRoundEntity(challenge, endedRound)).thenReturn(nextRound);
         when(roundRepository.save(nextRound)).thenReturn(nextRound);
-
-        // nextRR 생성
         when(roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)).thenReturn(false);
-
         RoundRecord nextRR = mock(RoundRecord.class);
         when(roundConverter.toRoundRecordEntity(nextRound, uc)).thenReturn(nextRR);
 
@@ -325,33 +327,30 @@ class RoundFlowUnitTest {
     @DisplayName("processRoundsEndedAt: nextRound가 이미 있으면 save 없이 기존 라운드 사용")
     void processRoundsEndedAt_usesExistingNextRound() {
         // given
+        mockTransaction();
         LocalDate endDate = LocalDate.now();
-
         Round endedRound = mock(Round.class);
         Challenge challenge = mock(Challenge.class);
 
         when(roundRepository.findAllByEndDate(endDate)).thenReturn(List.of(endedRound));
-
         when(endedRound.getId()).thenReturn(10L);
+        when(roundRepository.findByIdWithChallengeAndCurrentRound(10L)).thenReturn(Optional.of(endedRound));
+
         when(endedRound.getRoundNumber()).thenReturn(1);
         when(endedRound.getChallenge()).thenReturn(challenge);
-
         when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
         when(challenge.getId()).thenReturn(999L);
         when(challenge.getCurrentRound()).thenReturn(endedRound);
 
         RoundRecord rrContinue = mock(RoundRecord.class);
         when(rrContinue.getNextRoundIntent()).thenReturn(NextRoundIntent.CONTINUE);
-
         UserChallenge uc = mock(UserChallenge.class);
         when(rrContinue.getUserChallenge()).thenReturn(uc);
-
         when(roundRecordRepository.findAllByRoundWithUserAndSetting(endedRound, ChallengeJoinStatus.JOINED))
                 .thenReturn(List.of(rrContinue));
 
         Round nextRound = mock(Round.class);
         when(roundRepository.findByChallengeIdAndRoundNumber(999L, 2)).thenReturn(Optional.of(nextRound));
-
         when(roundRecordRepository.existsByUserChallengeAndRound(uc, nextRound)).thenReturn(true);
 
         // when
@@ -359,8 +358,6 @@ class RoundFlowUnitTest {
 
         // then
         verify(roundRepository, never()).save(any());
-        verify(roundConverter, never()).toNextRoundEntity(any(), any());
-        verify(roundRecordRepository, never()).save(any());
         verify(challenge).changeCurrentRound(nextRound);
     }
 }

--- a/src/test/java/com/hrr/backend/global/scheduler/NotificationSchedulerTest.java
+++ b/src/test/java/com/hrr/backend/global/scheduler/NotificationSchedulerTest.java
@@ -1,0 +1,89 @@
+package com.hrr.backend.global.scheduler;
+
+import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationSchedulerTest {
+
+    @InjectMocks
+    private NotificationScheduler notificationScheduler;
+
+    @Mock
+    private RoundRepository roundRepository;
+
+    @Mock
+    private RoundRecordRepository roundRecordRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
+    @Test
+    @DisplayName("결과 알림 스케줄러: 대상 라운드의 참여자 전원에게 이벤트를 발행한다")
+    void scheduleChallengeExtensionResultNotifications_Success() {
+        // given
+        // 결정 기간 종료 후(endDate - 1) 시점을 테스트하기 위해 대상 날짜 설정
+        LocalDate targetEndDate = LocalDate.now().plusDays(1);
+        Round round = mock(Round.class);
+        given(round.getId()).willReturn(100L);
+
+        // 종료 예정 라운드 조회 모킹
+        given(roundRepository.findAllByEndDate(targetEndDate)).willReturn(List.of(round));
+
+        User user = User.builder().id(1L).build();
+        RoundRecord record = mock(RoundRecord.class);
+        UserChallenge uc = mock(UserChallenge.class);
+
+        given(record.getUserChallenge()).willReturn(uc);
+        given(uc.getUser()).willReturn(user);
+        given(record.getNextRoundIntent()).willReturn(NextRoundIntent.CONTINUE);
+
+        // 해당 라운드 참여자 목록 조회 모킹
+        given(roundRecordRepository.findAllByRoundWithUserAndSetting(round, ChallengeJoinStatus.JOINED))
+                .willReturn(List.of(record));
+
+        // when
+        notificationScheduler.scheduleChallengeExtensionResultNotifications();
+
+        // then
+        // 참여자 수(1명)만큼 이벤트가 발행되었는지 검증
+        verify(eventPublisher, times(1)).publishEvent(any(ChallengeExtensionResponseEvent.class));
+    }
+
+    @Test
+    @DisplayName("결과 알림 스케줄러: 대상 라운드가 없으면 이벤트를 발행하지 않는다")
+    void scheduleChallengeExtensionResultNotifications_NoRounds() {
+        // given
+        LocalDate targetEndDate = LocalDate.now().plusDays(1);
+        given(roundRepository.findAllByEndDate(targetEndDate)).willReturn(List.of());
+
+        // when
+        notificationScheduler.scheduleChallengeExtensionResultNotifications();
+
+        // then
+        // 라운드가 없으므로 참여자 조회나 이벤트 발행이 일어나지 않아야 함
+        verify(roundRecordRepository, never()).findAllByRoundWithUserAndSetting(any(), any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #211 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

사용자가 API로 응답할 때와 미응답 상태로 기간이 종료되었을 때(스케줄러) 챌린지 연장 응답에 따른 알림이 정확히 발송되도록 이벤트를 연동했습니다.

1. 이벤트 기반 알림 연동: RoundDecisionService API 호출 시 알림 이벤트를 발행하도록 연결
2. 자동 알림 스케줄러 추가: 연장 응답 기간이 종료되는 자정에 미응답자를 포함하여 전체 결과를 안내하는 스케줄러를 구현했습니다.
3. 테스트 코드 작성: 신규 기능에 대한 단위 테스트를 추가했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트
* **결과 요약:** NotificationSchedulerTest: 자정에 대상 라운드 참여자 전원에게 알림 이벤트를 정상 발행함 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="316" height="129" alt="image" src="https://github.com/user-attachments/assets/a94c7956-db9e-4d4d-8fe1-38f12001ad2c" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

테스트 범위: `RoundFlowUnitTest`에서 에러가 발생하였는데 제가 작성한 코드가 아니기에 해당 테스트 파일에는 테스트 코드를 추가로 작성하지 않았고, 우선 `NotificationSchedulerTest`를 통해 독립적으로 검증했습니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 라운드 결정 시 관련 응답 이벤트가 비동기로 발행됩니다.
  * 자정에 도전 과제 확장 최종 결과 알림이 해당 참여자들에게 자동으로 전송됩니다.
  * 기존 오전 9시 알림 흐름은 유지됩니다.

* **테스트**
  * 알림 스케줄러의 결과 전송 동작(대상 있음/없음)과 라운드 흐름에서 이벤트 발행을 검증하는 단위 테스트가 추가/확장되었습니다.

* **리팩터**
  * 트랜잭션 처리 방식이 내부적으로 조정되어 실행 방식이 변경되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->