### PR TITLE
[Fix] 연장 알림 시스템 안정성 강화 및 기능 확장

### DIFF
--- a/src/main/java/com/hrr/backend/domain/notification/dto/NotificationResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/notification/dto/NotificationResponseDto.java
@@ -13,6 +13,7 @@ import java.time.LocalDateTime;
 public class NotificationResponseDto {
 
     @Getter
+    @Setter
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
@@ -50,6 +51,9 @@ public class NotificationResponseDto {
 
         @Schema(description = "읽음 여부 (true: 읽음, false: 안읽음-NEW)", example = "false")
         private Boolean isRead;
+
+        @Schema(description = "응답 완료 여부 (연장 알림 한정)", example = "true")
+        private Boolean isResponded;
 
         @Schema(description = "알림 발생 시간", example = "2025-12-25T14:30:00")
         private LocalDateTime createdAt;

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -98,16 +98,15 @@ public class NotificationEventListener {
         Long roundId = event.getRoundId();
         User user = event.getUser();
 
-        // 체크할 결과 타입 정의 (성공 또는 취소)
+        // 1. [멱등성 체크] 이미 성공 또는 취소 알림이 발송되었는지 확인
+        // 안내 알림(CHALLENGE_EXTENSION)과 달리 결과 알림은 '성공' 혹은 '취소' 중 하나만 존재해야 합니다.
         List<NotificationTypeName> resultTypes = List.of(
                 NotificationTypeName.CHALLENGE_EXTENSION_SUCCESS,
                 NotificationTypeName.CHALLENGE_EXTENSION_CANCEL
         );
 
-        // 멱등성 체크: 해당 리스트에 포함된 타입이 하나라도 존재하면 중단
-        if (notificationRepository.existsResponseNotification(
-                user, ResourceType.ROUND, roundId, resultTypes)) {
-            log.debug("이미 결과 알림(성공/취소)이 처리된 라운드입니다: User={}, Round={}", user.getNickname(), roundId);
+        if (notificationRepository.existsResponseNotification(user, ResourceType.ROUND, roundId, resultTypes)) {
+            log.info("이미 결과 알림(성공/취소)이 처리된 라운드입니다: User={}, Round={}", user.getId(), roundId);
             return;
         }
 

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationServiceImpl.java
@@ -6,8 +6,11 @@ import com.hrr.backend.domain.notification.dto.NotificationResponseDto;
 import com.hrr.backend.domain.notification.entity.NotificationDelivery;
 import com.hrr.backend.domain.notification.entity.NotificationSetting;
 import com.hrr.backend.domain.notification.entity.enums.NotificationCategory;
+import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
 import com.hrr.backend.domain.notification.repository.NotificationRepository;
 import com.hrr.backend.domain.notification.repository.NotificationSettingRepository;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
@@ -28,6 +31,7 @@ public class NotificationServiceImpl implements NotificationService {
     private final NotificationRepository notificationRepository;
     private final NotificationSettingRepository notificationSettingRepository;
     private final NotificationConverter notificationConverter;
+    private final RoundRecordRepository roundRecordRepository;
 
     private final S3UrlUtil s3UrlUtil;
 
@@ -46,7 +50,19 @@ public class NotificationServiceImpl implements NotificationService {
         Slice<NotificationResponseDto.InfoDto> dtoSlice = deliverySlice
                 .map(delivery -> {
                     String fullUrl = s3UrlUtil.toFullUrl(delivery.getEvent().getImageKey());
-                    return notificationConverter.toInfoDto(delivery, fullUrl);
+                    NotificationResponseDto.InfoDto dto = notificationConverter.toInfoDto(delivery, fullUrl);
+
+                    // 연장 안내 알림일 경우 응답 여부 계산
+                    if (dto.getType() == NotificationTypeName.CHALLENGE_EXTENSION) {
+                        boolean responded = roundRecordRepository.findByUserAndRoundId(user, dto.getContextId())
+                                .map(record -> record.getNextRoundIntent() != NextRoundIntent.UNDECIDED)
+                                .orElse(false);
+                        dto.setIsResponded(responded);
+                    } else {
+                        dto.setIsResponded(null);
+                    }
+
+                    return dto;
                 });
 
         return new SliceResponseDto<>(dtoSlice);

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -2,6 +2,7 @@ package com.hrr.backend.domain.round.repository;
 
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -70,5 +71,12 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
     /**멱등성 위한 exists 메서드 추가-> 스케줄러 장애 또는 재시작으로 재실행돼도 중복 생성 방지하게*/
     boolean existsByUserChallengeAndRound(UserChallenge userChallenge, Round round);
 
-
+    /** 사용자와 라운드 ID로 RoundRecord 조회 (응답 여부 확인용) */
+    @Query("SELECT rr FROM RoundRecord rr " +
+            "JOIN rr.userChallenge uc " +
+            "WHERE uc.user = :user AND rr.round.id = :roundId")
+    Optional<RoundRecord> findByUserAndRoundId(
+            @Param("user") User user,
+            @Param("roundId") Long roundId
+    );
 }

--- a/src/main/java/com/hrr/backend/global/config/AsyncConfig.java
+++ b/src/main/java/com/hrr/backend/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.global.config;
 
 import org.springframework.aop.interceptor.AsyncUncaughtExceptionHandler;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -15,6 +16,7 @@ import lombok.extern.slf4j.Slf4j;
 public class AsyncConfig implements AsyncConfigurer {
 
     @Override
+    @Bean(name = "getAsyncExecutor")
     public Executor getAsyncExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(2);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #221 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
1. 비동기 실행자(Async Executor) 설정 오류 수정: @Async("getAsyncExecutor") 호출 시 발생하던 NoSuchBeanDefinitionException을 해결하기 위해 빈 등록 로직을 수정했습니다.
2. 알림 중복 발송 방지(멱등성) 로직 적용: 사용자의 반복 클릭이나 스케줄러와의 경합으로 인해 결과 알림이 중복 생성되는 문제를 방어하기 위해 리스너에 멱등성 체크 로직을 추가했습니다.
3. 알림 목록 내 응답 완료 여부(isResponded) 반환: 사용자가 연장 안내 알림에 대해 이미 의사결정을 마쳤는지 여부를 실시간으로 판단하여 알림 목록 API에 포함했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트
* **결과 요약:** 모든 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

#### isResponsed 추가
<img width="1174" height="689" alt="image" src="https://github.com/user-attachments/assets/480a578a-d110-4c50-948e-0f1bbe1c738c" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 결함 격리 및 멱등성: `NotificationEventListener`에서 도입한 `existsResponseNotification` 쿼리가 비동기 환경의 레이스 컨디션을 충분히 방어할 수 있을지

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 알림 시스템에 응답 완료 여부 추적 기능이 추가되었습니다. 연장 알림에 대해 사용자의 응답 여부를 확인할 수 있습니다.

* **Chores**
  * 로깅 포맷이 개선되었습니다.
  * 내부 비동기 처리 설정이 업데이트되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->