### PR TITLE
[Bug] 라운드 교체 후 통계 최신화

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeParticipantsChangedEvent.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeParticipantsChangedEvent.java
@@ -1,0 +1,4 @@
+package com.hrr.backend.domain.challenge.event;
+
+public record ChallengeParticipantsChangedEvent(Long challengeId) {
+}

--- a/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeParticipantsChangedListener.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeParticipantsChangedListener.java
@@ -1,0 +1,26 @@
+package com.hrr.backend.domain.challenge.event;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+import org.springframework.transaction.event.TransactionPhase;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class ChallengeParticipantsChangedListener {
+
+    private final ChallengeStaticsUpdater challengeStaticsUpdater;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onParticipantsChanged(ChallengeParticipantsChangedEvent e) {
+        try {
+            challengeStaticsUpdater.recalculateInNewTx(e.challengeId());
+        } catch (Exception ex) {
+            // 라운드는 이미 커밋됨. 여기서 예외 터져도 라운드 전환은 유지됨.
+            log.error("[Statics] update failed after commit. challengeId={}", e.challengeId(), ex);
+        }
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
@@ -7,6 +7,8 @@ import org.springframework.transaction.annotation.Transactional;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -20,7 +22,7 @@ public class ChallengeStaticsUpdater {
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recalculateInNewTx(Long challengeId) {
         Challenge ch = challengeRepository.findById(challengeId)
-                .orElseThrow(() -> new IllegalArgumentException("Challenge not found. id=" + challengeId));
+                .orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
         challengeStaticsService.updateChallengeStatics(ch);
     }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
@@ -1,0 +1,25 @@
+package com.hrr.backend.domain.challenge.event;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ChallengeStaticsUpdater {
+
+    private final ChallengeRepository challengeRepository;
+    private final ChallengeStaticsService challengeStaticsService;
+
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void recalculateInNewTx(Long challengeId) {
+        Challenge ch = challengeRepository.getReferenceById(challengeId);
+        challengeStaticsService.updateChallengeStatics(ch);
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/event/ChallengeStaticsUpdater.java
@@ -19,7 +19,8 @@ public class ChallengeStaticsUpdater {
 
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void recalculateInNewTx(Long challengeId) {
-        Challenge ch = challengeRepository.getReferenceById(challengeId);
+        Challenge ch = challengeRepository.findById(challengeId)
+                .orElseThrow(() -> new IllegalArgumentException("Challenge not found. id=" + challengeId));
         challengeStaticsService.updateChallengeStatics(ch);
     }
 }

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -3,7 +3,9 @@ package com.hrr.backend.domain.round.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.hrr.backend.domain.challenge.event.ChallengeParticipantsChangedEvent;
 import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -35,6 +37,7 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
     private final TransactionTemplate transactionTemplate;
 
     private final ChallengeStaticsService challengeStaticsService;
+    private final ApplicationEventPublisher publisher;
 
     @Override
     public void processRoundsEndedAt(LocalDate endDate) {
@@ -113,7 +116,7 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
         challenge.changeCurrentRound(nextRound);
 
         // 8. 통계 최신화 1회
-        challengeStaticsService.updateChallengeStatics(challenge);
+        publisher.publishEvent(new ChallengeParticipantsChangedEvent(challenge.getId()));
 
         log.info("[RoundLifecycle] 라운드 전환 완료. challengeId={}, {}R -> {}R",
                 challenge.getId(), endedRound.getRoundNumber(), nextRound.getRoundNumber());

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -36,7 +36,6 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
     private final RoundConverter roundConverter;
     private final TransactionTemplate transactionTemplate;
 
-    private final ChallengeStaticsService challengeStaticsService;
     private final ApplicationEventPublisher publisher;
 
     @Override

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.round.service;
 import java.time.LocalDate;
 import java.util.List;
 
+import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -32,6 +33,8 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
     private final RoundRecordRepository roundRecordRepository;
     private final RoundConverter roundConverter;
     private final TransactionTemplate transactionTemplate;
+
+    private final ChallengeStaticsService challengeStaticsService;
 
     @Override
     public void processRoundsEndedAt(LocalDate endDate) {
@@ -108,6 +111,9 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
 
         // 7. 챌린지 currentRound 교체
         challenge.changeCurrentRound(nextRound);
+
+        // 8. 통계 최신화 1회
+        challengeStaticsService.updateChallengeStatics(challenge);
 
         log.info("[RoundLifecycle] 라운드 전환 완료. challengeId={}, {}R -> {}R",
                 challenge.getId(), endedRound.getRoundNumber(), nextRound.getRoundNumber());

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.hrr.backend.domain.challenge.event.ChallengeParticipantsChangedEvent;
-import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import org.springframework.context.ApplicationEventPublisher;

--- a/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/round/service/RoundLifecycleServiceImpl.java
@@ -5,6 +5,8 @@ import java.util.List;
 
 import com.hrr.backend.domain.challenge.event.ChallengeParticipantsChangedEvent;
 import com.hrr.backend.domain.challenge.service.ChallengeStaticsService;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.datasource.DataSourceTransactionManager;
 import org.springframework.stereotype.Service;
@@ -50,7 +52,7 @@ public class RoundLifecycleServiceImpl implements RoundLifecycleService {
                 transactionTemplate.executeWithoutResult(status -> {
                     //트랜잭션 내부에서 Round를 다시 조회해서(detached 방지) 처리
                     Round managedEndedRound = roundRepository.findByIdWithChallengeAndCurrentRound(endedRoundId)
-                            .orElseThrow(() -> new IllegalStateException("Round not found. id=" + endedRoundId));
+                            .orElseThrow(() -> new GlobalException(ErrorCode.ROUND_NOT_FOUND));
 
                     processSingleEndedRound(managedEndedRound);
                 });


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #235 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

라운드 전환이 확정되는 순간에 통계를 한 번 다시 계산

- 라운드 전환 트랜잭션 안에서는 라운드/레코드/챌린지 currentRound만 변경
- 트랜잭션이 성공적으로 commit 된 뒤에만 통계 재계산을 별도 트랜잭션(REQUIRES_NEW)으로 실행
- 통계 실패해도 라운드 전환은 롤백되지 않음

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:**
챌린지가 다양하게 있어야 테스트 가능

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 라운드 전환 시 챌린지 참가자 변경 이벤트를 발행해 통계 재계산을 비동기 트리거하도록 추가되었습니다.
  * 통계 재계산을 별도 트랜잭션으로 실행하는 구성(독립 처리 흐름)을 도입했습니다.

* **버그 수정**
  * 라운드 처리 중 대상 미존재 시 일관된 오류 처리로 안정성을 개선했습니다.
  * 재계산 실행 중 예외가 발생해도 이미 커밋된 라운드 상태에 영향이 없도록 보호했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->