### PR TITLE
[FEAT] 인프라 안정화 작업: 배포 트리거 수정/모델 서버 분리/502 에러 방지

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,8 @@
-name: Deploy to AWS EC2 with Docker
+name: Deploy to AWS EC2 with Docker from main branch
 
 on:
-  push:
-    branches: [ "develop" ] # develop 브랜치에 푸시하면 자동으로 배포 시작
-  workflow_dispatch:    # 수동 가능하게
+  release:
+    types: [published] # 릴리즈가 발행(Publish)되었을 때만 실행
 
 jobs:
   build-and-deploy:
@@ -44,7 +43,7 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/hrr-server:v1.0.0
+          tags: ${{ secrets.DOCKER_USERNAME }}/hrr-server:${{ github.event.release.tag_name }}
           platforms: linux/amd64
 
       # 설정 파일(docker-compose, nginx, deploy) EC2로 전송 (SCP)
@@ -70,4 +69,5 @@ jobs:
           script: |
             cd /home/ubuntu
             chmod +x deploy.sh
-            ./deploy.sh
+            # 릴리즈 태그를 인자로 전달
+            ./deploy.sh ${{ github.event.release.tag_name }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,9 @@ jobs:
         with:
           context: .
           push: true
-          tags: ${{ secrets.DOCKER_USERNAME }}/hrr-server:${{ github.event.release.tag_name }}
+          tags: |
+            ${{ secrets.DOCKER_USERNAME }}/hrr-server:${{ github.event.release.tag_name }}
+            ${{ secrets.DOCKER_USERNAME }}/hrr-server:latest
           platforms: linux/amd64
 
       # 설정 파일(docker-compose, nginx, deploy) EC2로 전송 (SCP)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
 FROM eclipse-temurin:17-jdk-jammy
+# curl 설치 명령어 추가
+RUN apt-get update && apt-get install -y curl && rm -rf /var/lib/apt/lists/*
+
 WORKDIR /app
 RUN mkdir -p /app/secrets
 ARG JAR_FILE=build/libs/*SNAPSHOT.jar

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,6 +64,7 @@ export APPLE_KEY_ID=$(echo "$SECRET_JSON" | jq -r '.APPLE_KEY_ID')
 export APPLE_P8_KEY=$(echo "$SECRET_JSON" | jq -r '.APPLE_P8_KEY')
 export NAVER_CLIENT_ID=$(echo "$SECRET_JSON" | jq -r '.NAVER_CLIENT_ID')
 export NAVER_CLIENT_SECRET=$(echo "$SECRET_JSON" | jq -r '.NAVER_CLIENT_SECRET')
+export MODEL_TAG=$(echo "$SECRET_JSON" | jq -r '.MODEL_TAG')
 
 echo "--- 3/4: Docker Hub에서 이미지 Pull 및 베포 준비  ---"
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -9,6 +9,18 @@ COMPOSE_FILE="docker-compose_prod.yml"
 
 set +o histexpand       # 비밀번호의 특수문자 누락 방지
 
+# --- 배포 버전 인자값 확인 ---
+# 스크립트 실행 시 첫 번째 인자로 태그를 받습니다. (예: ./deploy.sh v1.0.1)
+RELEASE_TAG=$1
+
+if [ -z "$RELEASE_TAG" ]; then
+    echo "WARNING: 배포 태그가 지정되지 않았습니다. 기본값(latest)을 사용합니다."
+    export IMAGE_TAG="latest"
+else
+    echo "INFO: ${RELEASE_TAG} 버전을 배포합니다."
+    export IMAGE_TAG="${RELEASE_TAG}"
+fi
+
 # AWS CLI 설치 및 jq 확인
 if ! command -v aws &> /dev/null || ! command -v jq &> /dev/null; then
     echo "ERROR: AWS CLI 또는 jq가 설치되어 있지 않습니다." >&2

--- a/deploy.sh
+++ b/deploy.sh
@@ -64,7 +64,7 @@ export APPLE_KEY_ID=$(echo "$SECRET_JSON" | jq -r '.APPLE_KEY_ID')
 export APPLE_P8_KEY=$(echo "$SECRET_JSON" | jq -r '.APPLE_P8_KEY')
 export NAVER_CLIENT_ID=$(echo "$SECRET_JSON" | jq -r '.NAVER_CLIENT_ID')
 export NAVER_CLIENT_SECRET=$(echo "$SECRET_JSON" | jq -r '.NAVER_CLIENT_SECRET')
-export MODEL_TAG=$(echo "$SECRET_JSON" | jq -r '.MODEL_TAG')
+export MODEL_API_URL=$(echo "$SECRET_JSON" | jq -r '.MODEL_API_URL')
 
 echo "--- 3/4: Docker Hub에서 이미지 Pull 및 베포 준비  ---"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     container_name: hrr-model-api
     platform: linux/amd64
     ports:
-      - "8000:8000"
+      - "8000:8080"
     env_file:
       - .env
     restart: always

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -74,7 +74,7 @@ services:
       NAVER_CLIENT_ID: ${NAVER_CLIENT_ID}
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
 
-      MODEL_TAG: ${MODEL_TAG}
+      MODEL_API_URL: ${MODEL_API_URL}
 
     restart: always
 
@@ -87,14 +87,6 @@ services:
       - TZ=Asia/Seoul
     volumes:
       - redis_data:/data
-
-  # 모델 서비스
-  model-api:
-    image: ychan0/hrr-model:${MODEL_TAG:-latest}
-    container_name: hrr_model_prod
-    restart: always
-    environment:
-      - TZ=Asia/Seoul
 
 volumes:
   db-data:

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -39,7 +39,7 @@ services:
 
   # Spring Boot 애플리케이션 서비스
   app:
-    image: ychan0/hrr-server:v1.0.0
+    image: ychan0/hrr-server:${IMAGE_TAG:-latest}
     container_name: hrr_app_prod
     environment:
       TZ: Asia/Seoul

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -74,6 +74,8 @@ services:
       NAVER_CLIENT_ID: ${NAVER_CLIENT_ID}
       NAVER_CLIENT_SECRET: ${NAVER_CLIENT_SECRET}
 
+      MODEL_TAG: ${MODEL_TAG}
+
     restart: always
 
   # Redis 서비스
@@ -88,7 +90,7 @@ services:
 
   # 모델 서비스
   model-api:
-    image: ychan0/hrr-model:v1.0.0
+    image: ychan0/hrr-model:${MODEL_TAG:-latest}
     container_name: hrr_model_prod
     restart: always
     environment:

--- a/docker-compose_prod.yml
+++ b/docker-compose_prod.yml
@@ -19,7 +19,8 @@ services:
     environment:
       - TZ=Asia/Seoul
     depends_on:
-      - app
+      app:
+        condition: service_healthy # app이 healthy 상태가 된 이후에 nginx 실행
 
   # Certbot
   certbot:
@@ -76,6 +77,13 @@ services:
 
       MODEL_API_URL: ${MODEL_API_URL}
 
+    healthcheck:
+      # 스웨거 페이지에 접근해서 200 OK가 떨어지는지 확인 - nginx가 켜지기 전이기 때문에 localhost로 직접 체크
+      test: [ "CMD", "curl", "-f", "http://localhost:8080/swagger-ui/index.html" ]
+      interval: 10s    # 10초마다 체크
+      timeout: 5s     # 5초 안에 응답 없으면 실패
+      retries: 10     # 10번 실패하면 unhealthy
+      start_period: 30s # 앱 실행 초기 30초는 실패해도 대기
     restart: always
 
   # Redis 서비스

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,10 +4,8 @@ events {
 
 http {
     # Spring Boot 컨테이너와 통신 설정
-    upstream app_server {
-        # 'app'은 docker-compose.yml에 정의된 서비스 이름
-        server app:8080;
-    }
+    # 도커 내장 DNS 서버 설정 - 30초마다 'app'의 IP가 바뀌었는지 다시 확인
+    resolver 127.0.0.11 valid=30s;
 
     # HTTP 처리
     server {
@@ -40,7 +38,11 @@ http {
 
         # 모든 요청을 Spring Boot 앱으로 전달하는 설정
         location / {
-            proxy_pass http://app_server;
+            # 변수를 사용하여 proxy_pass 설정
+            # 주소를 변수에 담아서 사용해야 Nginx가 위에서 설정한 resolver를 통해 IP를 재조회
+            # 'app'은 docker-compose_prod.yml에 정의된 서비스 이름
+            set $upstream_app http://app:8080;
+            proxy_pass $upstream_app;
 
             # 클라이언트의 실제 IP와 HTTPS 정보를 Spring Boot 앱에 전달
             proxy_set_header Host $host;


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #237 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

1. 베타 테스트 및 심사, 운영을 준비하며 릴리즈 발행 시에만 운영 서버인 EC2에 배포되도록 하였습니다. 이후 배포 과정은 다음과 같습니다.
    1.  develop 브랜치에서 기능을 개발한다.
    2. 배포 준비가 되면 main 브랜치로 PR을 날려서 merge 한다.
    3. 새로운 릴리즈를 발행한다. 이 때의 버전을 스토어에 업데이트될 버전으로 사용
    4. 배포 파이프라인이 동작하여 빌드부터 EC2 배포까지 수행된다.
2. 간혹 배포 시 발생하는 502 Bad Gateway 오류 해결을 위해 Health Check를 추가하였습니다. Spring boot가 정상 작동하는 걸 확인한 후 nginx가 실행됩니다.
3. 챌린지 추천 AI 모델의 서버를 분리하였습니다. 과부화 및 병목 현상을 방지하기 위해 AWS의 Lambda로 분리하여 별도의 서버에서 운영됩니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

main 브랜치에 merge 하고 릴리즈 생성 후 테스트 예정

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

이제 모델은 내부적으로 8080 포트에서 가동됩니다. 
로컬의 경우 8080 포트는 Spring boot가 점유하지만, 모델의 구동은 8000 포트에서 포트 바인딩을 통해 도커 내부의 8080 포트로 전달되기에 문제가 없습니다.
운영 서버의 경우 모델은 별도의 서버인 Lambda의 8080 포트를 사용하기에 포트 번호는 동일해도 주소가 다르기에 충돌하지 않습니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.

https://aws.amazon.com/ko/blogs/tech/creating-api-server-using-aws-lambda-function-url/


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Chores**
  * 배포 자동화 프로세스 개선 및 릴리스 이벤트 기반 배포 전환
  * 서비스 헬스체크 메커니즘 추가로 시스템 안정성 향상
  * 인프라 구성 및 컨테이너 설정 최적화

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->