### PR TITLE
[Feat] 챌린지 5개 참여 시 하단 액션 버튼 비활성화

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -179,6 +179,9 @@ public class ChallengeServiceImpl implements ChallengeService {
             isCertifiedToday = checkTodayVerification(ucOp.get().getId(), challenge);
         }
 
+		// 챌린지 참여 개수 조회
+		boolean isMaxJoined = challengeRepository.countByUserIdAndStatus(user.getId(), ChallengeJoinStatus.JOINED) >= 5;
+
 		// 좋아요 여부 조회
 		boolean isLiked = challengeLikeRepository.existsByUserAndChallenge(user, challenge);
 
@@ -191,7 +194,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
-		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday);
+		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined);
 
 		// DTO 변환 및 반환
 		return challengeConverter.toHeaderInfoDto(
@@ -730,7 +733,7 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-    private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday) {
+    private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
 
         // 끝난 챌린지는 모두 DISABLED
         if (challenge.getStatus() == ChallengeStatus.FINISHED) {
@@ -766,6 +769,11 @@ public class ChallengeServiceImpl implements ChallengeService {
                 return ActionButtonStatus.CERTIFY_AVAILABLE;
             }
         }
+
+		// 미참여자 + 챌린지 최대 개수 초과
+		if (isMaxJoined) {
+			return ActionButtonStatus.DISABLED;
+		}
 
         // 미참여자 + 정원 초과 -> 빈자리 알림
         if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -357,6 +357,40 @@ class ChallengeServiceInfoTest {
     }
 
     /**
+     * 5. 참여 제한 관련 시나리오
+     */
+    @Test
+    @DisplayName("상황 12: 미참여자 + 현재 참여 중인 챌린지가 5개임 -> DISABLED (참가 불가)")
+    void guest_already_joined_five_challenges_returns_DISABLED() {
+        // Given
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        given(user.getId()).willReturn(1L);
+
+        Challenge challenge = mock(Challenge.class);
+        // 조건: 모집중이며 자리가 남아있음
+        setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 5, 10);
+        setRoundDate(challenge, LocalDate.now());
+
+        // Mocking
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipant(user, challenge, false); // 이 챌린지에는 미참여 상태
+
+        // 핵심 조건: 이미 참여 중인 챌린지 개수가 5개임
+        given(challengeRepository.countByUserIdAndStatus(eq(user.getId()), any()))
+                .willReturn(5L);
+
+        // ActionButtonStatus.DISABLED가 반환될 것을 기대
+        mockConverter(ActionButtonStatus.DISABLED);
+
+        // When
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
+        // Then
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.DISABLED);
+    }
+
+    /**
      * Helper Methods (테스트 설정을 쉽게 하기 위한 도구들)
      */
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #250 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 챌린지 5개 참여 시 챌린지 상단 정보 조회 API에서 하단 액션 버튼을 비활성화합니다.
- 버튼 비활성화 검증 테스트 추가하였습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger, 단위 테스트
* **결과 요약:** 비활성화 확인 및 테스트 통과
---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 설명 | 이미지 |
|---|---|
| 버튼 비활성화 | <img width="1175" height="680" alt="image" src="https://github.com/user-attachments/assets/e28393e4-b448-4b6e-bd0a-0d7d74678afc" /> |
| 테스트 코드 | <img width="708" height="240" alt="image" src="https://github.com/user-attachments/assets/f44f92da-06ce-4035-a8f6-4ccbccc77112" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 사용자가 동시에 참가할 수 있는 최대 챌린지 개수를 5개로 제한하는 기능을 추가했습니다.
  * 이미 5개의 챌린지에 참가한 사용자의 참가 버튼이 비활성화됩니다.

* **Tests**
  * 최대 참가 제한 시 버튼 비활성화 동작을 검증하는 테스트를 추가했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->