### PR TITLE
[Feat] 챌린지 상세 페이지 하단 버튼 상태 세분화

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -6,11 +6,20 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum ActionButtonStatus {
-    CERTIFIED("인증 완료"),
-    CERTIFY_AVAILABLE("인증하기"),
+    // 1. 참여자용 상태
+    AVAILABLE("인증하기"),
+    DONE("인증 완료"),
+    UPCOMING("라운드 시작 전"),
+    NOT_DAY("인증 요일 아님"),
+    NOT_TIME("인증 시간 아님"),
+
+    // 2. 미참여자용 상태
     JOIN("참가하기"),
     WAITLIST("빈자리 알림 받기"),
-    DISABLED("참가 불가");
+
+    // 3. 제한 상태 (DISABLED 세분화)
+    FINISHED("종료된 챌린지"),
+    MAX_LIMIT_EXCEEDED("참여 개수 초과");
 
     private final String description;
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -733,56 +733,45 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-    private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
+	private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
 
-        // 끝난 챌린지는 모두 DISABLED
-        if (challenge.getStatus() == ChallengeStatus.FINISHED) {
-            return ActionButtonStatus.DISABLED;
-        }
-
-        // 참여자인 경우: 요일/시간대/인증 여부로 분기
-        if (isParticipant) {
-			// 아직 라운드 시작 전(UPCOMING 상태 등)이라면 무조건 D-Day(CERTIFIED) 처리
-			Round currentRound = challenge.getCurrentRound();
-			if (currentRound != null && LocalDate.now().isBefore(currentRound.getStartDate())) {
-				return ActionButtonStatus.CERTIFIED;
-			}
-
-			// 오늘이 인증 요일이 아니라면 → 항상 D-DAY 형식
-            boolean isTodayVerificationDay = isTodayVerificationDay(challenge);
-            if (!isTodayVerificationDay) {
-                return ActionButtonStatus.CERTIFIED;
-            }
-
-			// 오늘이 인증 요일이지만, 지금은 인증 시간대가 아님 → D-DAY 형식
-            boolean inVerificationTime = isNowWithinVerificationTime(challenge);
-            if (!inVerificationTime) {
-                return ActionButtonStatus.CERTIFIED;
-            }
-
-            // 오늘이 인증 요일 + 인증 시간대 안일 때만
-            //  - 인증 O → D-DAY
-            //  - 인증 X → 인증하기
-            if (isCertifiedToday) {
-                return ActionButtonStatus.CERTIFIED;
-            } else {
-                return ActionButtonStatus.CERTIFY_AVAILABLE;
-            }
-        }
-
-		// 미참여자 + 챌린지 최대 개수 초과
-		if (isMaxJoined) {
-			return ActionButtonStatus.DISABLED;
+		// 1. 챌린지 자체가 종료된 경우 (가장 먼저 체크)
+		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
+			return ActionButtonStatus.FINISHED;
 		}
 
-        // 미참여자 + 정원 초과 -> 빈자리 알림
-        if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
-            return ActionButtonStatus.WAITLIST;
-        }
+		// 2. 참여자인 경우 (인증 관련 분기)
+		if (isParticipant) {
+			Round currentRound = challenge.getCurrentRound();
 
-        // 그 외 -> 참가하기
+			if (currentRound != null && LocalDate.now().isBefore(currentRound.getStartDate())) {
+				return ActionButtonStatus.UPCOMING;
+			}
+
+			if (!isTodayVerificationDay(challenge)) {
+				return ActionButtonStatus.NOT_DAY;
+			}
+
+			if (!isNowWithinVerificationTime(challenge)) {
+				return ActionButtonStatus.NOT_TIME;
+			}
+
+			return isCertifiedToday ? ActionButtonStatus.DONE : ActionButtonStatus.AVAILABLE;
+		}
+
+		// 3. 미참여자이면서 참여가 제한되는 경우
+		if (isMaxJoined) {
+			return ActionButtonStatus.MAX_LIMIT_EXCEEDED;
+		}
+
+		// 4. 미참여자 정원 체크
+		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
+			return ActionButtonStatus.WAITLIST;
+		}
+
+		// 5. 그 외 참여 가능
 		return ActionButtonStatus.JOIN;
-    }
+	}
 
     /**
      * 오늘이 챌린지 인증 요일(DaysOfWeek)에 포함되는지 확인

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -46,125 +46,91 @@ class ChallengeServiceInfoTest {
     @Mock private ChallengeLikeRepository challengeLikeRepository;
     @Mock private ChallengeConverter challengeConverter;
 
-    // 나머지 Repository들은 이 테스트 범위(상단 정보 조회)에서 쓰이지 않아 생략 가능
-
     /**
      * 1. 참여자(Participant) 관련 시나리오
      */
     @Test
-    @DisplayName("상황 1: 참여자 + UPCOMING 상태(라운드 시작 전) -> CERTIFIED (D-Day)")
-    void participant_upcoming_beforeStart_returns_CERTIFIED() {
-        // Given
+    @DisplayName("상황 1: 참여자 + 라운드 시작 전 -> UPCOMING (라운드 시작 전)")
+    void participant_beforeStart_returns_UPCOMING() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
 
-        // 조건: 챌린지 시작일이 '내일'임
         setRoundDate(challenge, LocalDate.now().plusDays(1));
-        // 조건: 상태는 UPCOMING
         setChallengeStatus(challenge, ChallengeStatus.UPCOMING, 10, 30);
-        // 조건: 인증 시간대 내 (시간은 맞지만 날짜가 안 맞음)
         setVerificationTime(challenge, LocalTime.of(9, 0), LocalTime.of(18, 0));
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, true);
-        mockConverter(ActionButtonStatus.CERTIFIED);
+        mockConverter(ActionButtonStatus.UPCOMING);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.CERTIFIED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.UPCOMING);
     }
 
     @Test
-    @DisplayName("상황 2: 참여자 + 오늘이 인증 요일이 아님 -> CERTIFIED (D-Day)")
-    void participant_notVerificationDay_returns_CERTIFIED() {
-        // Given
+    @DisplayName("상황 2: 참여자 + 오늘이 인증 요일이 아님 -> NOT_DAY (인증 요일 아님)")
+    void participant_notVerificationDay_returns_NOT_DAY() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = mock(Challenge.class);
 
-        // 조건: 오늘이 아닌 다른 요일만 설정됨
         ChallengeDayJoin otherDayJoin = mock(ChallengeDayJoin.class);
         given(otherDayJoin.getDayOfWeek()).willReturn(getOtherDayEnum());
         given(challenge.getChallengeDays()).willReturn(List.of(otherDayJoin));
 
-        // 조건: 라운드 시작됨, 시간 맞음
         setRoundDate(challenge, LocalDate.now().minusDays(1));
         setVerificationTime(challenge, LocalTime.of(9, 0), LocalTime.of(18, 0));
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, true);
-        mockConverter(ActionButtonStatus.CERTIFIED);
+        mockConverter(ActionButtonStatus.NOT_DAY);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.CERTIFIED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.NOT_DAY);
     }
 
     @Test
-    @DisplayName("상황 3: 참여자 + 인증 요일 맞음 + 인증 시간대 아님 -> CERTIFIED (D-Day)")
-    void participant_notVerificationTime_returns_CERTIFIED() {
-        // Given
+    @DisplayName("상황 3: 참여자 + 인증 요일 맞음 + 인증 시간대 아님 -> NOT_TIME (인증 시간 아님)")
+    void participant_notVerificationTime_returns_NOT_TIME() {
         Long challengeId = 1L;
         User user = mock(User.class);
-        Challenge challenge = createChallengeBase(); // 오늘 요일 포함
+        Challenge challenge = createChallengeBase();
 
         setRoundDate(challenge, LocalDate.now().minusDays(1));
-
-        // 현재 시간과 겹치지 않도록 이른 시간대 고정
         setVerificationTime(challenge, LocalTime.of(0, 0), LocalTime.of(0, 1));
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, true);
-        mockConverter(ActionButtonStatus.CERTIFIED);
+        mockConverter(ActionButtonStatus.NOT_TIME);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.CERTIFIED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.NOT_TIME);
     }
 
     @Test
-    @DisplayName("상황 4: 참여자 + 모든 조건 충족 + 아직 인증 안 함 -> CERTIFY_AVAILABLE (인증하기)")
+    @DisplayName("상황 4: 참여자 + 모든 조건 충족 + 미인증 -> AVAILABLE (인증하기)")
     void participant_readyToVerify_returns_AVAILABLE() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
 
         setRoundDate(challenge, LocalDate.now().minusDays(1));
-        // 조건: 현재 시간이 인증 시간 내에 포함됨
         setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, true);
-
-        // 조건: 오늘 완료된 인증 없음 (false)
         given(verificationRepository.existsTodayVerification(any(), any(), any(), any())).willReturn(false);
+        mockConverter(ActionButtonStatus.AVAILABLE);
 
-        mockConverter(ActionButtonStatus.CERTIFY_AVAILABLE);
-
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.CERTIFY_AVAILABLE);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.AVAILABLE);
     }
 
     @Test
-    @DisplayName("상황 5: 참여자 + 모든 조건 충족 + 이미 인증 완료함 -> CERTIFIED (완료)")
-    void participant_alreadyVerified_returns_CERTIFIED() {
-        // Given
+    @DisplayName("상황 5: 참여자 + 모든 조건 충족 + 이미 인증 완료 -> DONE (인증 완료)")
+    void participant_alreadyVerified_returns_DONE() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
@@ -172,20 +138,13 @@ class ChallengeServiceInfoTest {
         setRoundDate(challenge, LocalDate.now().minusDays(1));
         setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, true);
-
-        // 조건: 오늘 완료된 인증 있음 (true)
         given(verificationRepository.existsTodayVerification(any(), any(), any(), any())).willReturn(true);
+        mockConverter(ActionButtonStatus.DONE);
 
-        mockConverter(ActionButtonStatus.CERTIFIED);
-
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.CERTIFIED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.DONE);
     }
 
     /**
@@ -194,124 +153,88 @@ class ChallengeServiceInfoTest {
     @Test
     @DisplayName("상황 6: 미참여자 + 모집중 + 자리 있음 -> JOIN (참가하기)")
     void guest_recruiting_hasSpace_returns_JOIN() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = mock(Challenge.class);
 
-        // 조건: 모집중, 인원 5/10
         setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 5, 10);
         setRoundDate(challenge, LocalDate.now());
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false); // 미참여자
-
+        mockParticipant(user, challenge, false);
         mockConverter(ActionButtonStatus.JOIN);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
     }
 
     @Test
     @DisplayName("상황 7: 미참여자 + 모집중 + 만석 -> WAITLIST (빈자리 알림)")
     void guest_recruiting_full_returns_WAITLIST() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = mock(Challenge.class);
 
-        // 조건: 모집중이지만 인원 30/30 (만석)
         setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 30, 30);
         setRoundDate(challenge, LocalDate.now());
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, false);
-
         mockConverter(ActionButtonStatus.WAITLIST);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLIST);
     }
 
-    /**
-     * 3. 공통/종료 시나리오
-     */
-
     @Test
-    @DisplayName("상황 8: 챌린지 종료(FINISHED) -> 무조건 DISABLED")
-    void challenge_finished_returns_DISABLED() {
-        // Given
+    @DisplayName("상황 8: 챌린지 종료 -> FINISHED (종료된 챌린지)")
+    void challenge_finished_returns_FINISHED() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = mock(Challenge.class);
 
-        // 조건: 종료됨
         setChallengeStatus(challenge, ChallengeStatus.FINISHED, 10, 30);
         setRoundDate(challenge, LocalDate.now().minusDays(30));
-
-        // NPE 방지를 위한 시간 설정
         setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true); // 참여자여도 비활성화되어야 함
+        mockParticipant(user, challenge, true);
+        mockConverter(ActionButtonStatus.FINISHED);
 
-        mockConverter(ActionButtonStatus.DISABLED);
-
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.DISABLED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.FINISHED);
     }
 
     @Test
-    @DisplayName("상황 9: 미참여자 + 진행중(ONGOING) + 자리 있음 -> JOIN (중도 참여 허용 확인)")
+    @DisplayName("상황 9: 미참여자 + 진행중 + 자리 있음 -> JOIN (중도 참여)")
     void guest_ongoing_hasSpace_returns_JOIN() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = mock(Challenge.class);
 
-        // 조건: 진행 중(ONGOING), 인원 여유 있음
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 5, 10);
-        setRoundDate(challenge, LocalDate.now().minusDays(5)); // 이미 시작된지 5일 지남
+        setRoundDate(challenge, LocalDate.now().minusDays(5));
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
         mockParticipant(user, challenge, false);
-
         mockConverter(ActionButtonStatus.JOIN);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
     }
 
     /**
-     * 4. 방장 상태 관련 시나리오 (신규 추가)
+     * 3. 방장 및 예외 시나리오
      */
     @Test
-    @DisplayName("상황 10: 방장이 탈퇴함 (UserStatus != ACTIVE) -> 정상 조회")
+    @DisplayName("상황 10: 방장이 탈퇴함 -> 정상 조회 성공")
     void owner_inactive_returns_info_successfully() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
         setRoundDate(challenge, LocalDate.now());
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
-        // 방장이 존재하지만 탈퇴 상태
         User owner = mock(User.class);
         given(owner.getUserStatus()).willReturn(UserStatus.INACTIVE);
         UserChallenge ownerUc = mock(UserChallenge.class);
@@ -324,24 +247,19 @@ class ChallengeServiceInfoTest {
         mockParticipant(user, challenge, false);
         mockConverter(ActionButtonStatus.JOIN);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
         assertThat(result).isNotNull();
     }
 
     @Test
-    @DisplayName("상황 11: 방장 데이터가 아예 없음 (owner == null) -> 에러 없이 조회")
+    @DisplayName("상황 11: 방장 데이터 없음 -> 에러 없이 조회")
     void owner_not_found_returns_info_successfully() {
-        // Given
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
         setRoundDate(challenge, LocalDate.now());
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
-        // 방장 정보가 Optional.empty()
         given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
         given(userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER))
                 .willReturn(Optional.empty());
@@ -349,87 +267,61 @@ class ChallengeServiceInfoTest {
         mockParticipant(user, challenge, false);
         mockConverter(ActionButtonStatus.JOIN);
 
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
         assertThat(result).isNotNull();
     }
 
-    /**
-     * 5. 참여 제한 관련 시나리오
-     */
     @Test
-    @DisplayName("상황 12: 미참여자 + 현재 참여 중인 챌린지가 5개임 -> DISABLED (참가 불가)")
-    void guest_already_joined_five_challenges_returns_DISABLED() {
-        // Given
+    @DisplayName("상황 12: 미참여자 + 참여 한도 초과 -> MAX_LIMIT_EXCEEDED")
+    void guest_max_limit_exceeded_returns_MAX_LIMIT_EXCEEDED() {
         Long challengeId = 1L;
         User user = mock(User.class);
         given(user.getId()).willReturn(1L);
 
         Challenge challenge = mock(Challenge.class);
-        // 조건: 모집중이며 자리가 남아있음
         setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 5, 10);
         setRoundDate(challenge, LocalDate.now());
 
-        // Mocking
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false); // 이 챌린지에는 미참여 상태
+        mockParticipant(user, challenge, false);
+        given(challengeRepository.countByUserIdAndStatus(eq(user.getId()), any())).willReturn(5L);
 
-        // 핵심 조건: 이미 참여 중인 챌린지 개수가 5개임
-        given(challengeRepository.countByUserIdAndStatus(eq(user.getId()), any()))
-                .willReturn(5L);
+        mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
 
-        // ActionButtonStatus.DISABLED가 반환될 것을 기대
-        mockConverter(ActionButtonStatus.DISABLED);
-
-        // When
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-
-        // Then
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.DISABLED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
     }
 
     /**
-     * Helper Methods (테스트 설정을 쉽게 하기 위한 도구들)
-     */
-
-    /**
-     * 오늘 요일이 포함된 Mock Challenge 생성
+     * Helper Methods
      */
     private Challenge createChallengeBase() {
         Challenge challenge = mock(Challenge.class);
         ChallengeDayJoin todayJoin = mock(ChallengeDayJoin.class);
-
-        // lenient 사용
         lenient().when(todayJoin.getDayOfWeek()).thenReturn(getTodayChallengeDayEnum());
         lenient().when(challenge.getChallengeDays()).thenReturn(List.of(todayJoin));
-
         return challenge;
     }
 
     private void mockFetchingChallenge(Long id, Challenge challenge) {
         given(challengeRepository.findByIdWithDays(id)).willReturn(Optional.of(challenge));
-        given(userChallengeRepository.findByChallengeIdAndRole(id, UserChallengeRole.OWNER))
-                .willReturn(Optional.of(mock(UserChallenge.class))); // 방장 정보는 에러만 안 나게 처리
+        lenient().when(userChallengeRepository.findByChallengeIdAndRole(id, UserChallengeRole.OWNER))
+                .thenReturn(Optional.of(mock(UserChallenge.class)));
     }
 
     private void mockParticipant(User user, Challenge challenge, boolean isParticipant) {
         if (isParticipant) {
             UserChallenge uc = mock(UserChallenge.class);
             given(uc.getId()).willReturn(100L);
-            given(userChallengeRepository.findByUserAndChallenge(user, challenge))
-                    .willReturn(Optional.of(uc));
+            given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(uc));
         } else {
-            given(userChallengeRepository.findByUserAndChallenge(user, challenge))
-                    .willReturn(Optional.empty());
+            given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.empty());
         }
     }
 
     private void setRoundDate(Challenge challenge, LocalDate startDate) {
         Round round = mock(Round.class);
         given(round.getStartDate()).willReturn(startDate);
-        // endDate는 D-Day 계산용이지만 로직 흐름에는 큰 영향 없어서 임의 설정
         given(round.getEndDate()).willReturn(startDate.plusDays(20));
         given(challenge.getCurrentRound()).willReturn(round);
     }
@@ -444,18 +336,16 @@ class ChallengeServiceInfoTest {
         lenient().when(challenge.getCurrentParticipants()).thenReturn(current);
         lenient().when(challenge.getMaxParticipants()).thenReturn(max);
     }
-    // 오늘 요일 구하기
+
     private ChallengeDays getTodayChallengeDayEnum() {
         return ChallengeDays.valueOf(LocalDate.now().getDayOfWeek().name());
     }
 
-    // 오늘이 아닌 다른 요일 구하기
     private ChallengeDays getOtherDayEnum() {
         ChallengeDays today = getTodayChallengeDayEnum();
         return today == ChallengeDays.MONDAY ? ChallengeDays.TUESDAY : ChallengeDays.MONDAY;
     }
 
-    // Converter가 Status를 그대로 통과시키도록 Stubbing
     private void mockConverter(ActionButtonStatus expectedStatus) {
         given(challengeConverter.toHeaderInfoDto(any(), any(), anyBoolean(), any(), any(), anyLong(), anyBoolean(), anyBoolean(), any()))
                 .willAnswer(invocation -> ChallengeResponseDto.HeaderInfoDto.builder()


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #268 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
챌린지 상세 페이지 하단 버튼의 상태(ActionButtonStatus)를 세분화하여 사용자 경험(UX)을 개선하고 로직을 명확하게 리팩토링했습니다.
- 상태 값 세분화: 기존 CERTIFIED, DISABLED 등으로 뭉뚱그려졌던 상태를 사용자가 납득할 수 있는 구체적인 사유(종료됨, 시작 전, 요일 아님 등)로 분리했습니다.
- 비즈니스 로직 고도화: ChallengeServiceImpl의 버튼 결정 로직을 우선순위에 따라 재구성하여 예외 케이스를 줄였습니다.
- 검증 강화: 세분화된 12가지 시나리오에 대해 단위 테스트를 수행하여 로직의 정확성을 확인했습니다.

구분 | Enum 상수 | 버튼 문구 (Description) | 발생 상황 (Situation)
-- | -- | -- | --
참여자 | AVAILABLE | 인증하기 | [인증 가능] 오늘이 인증 요일이고, 현재 인증 시간대이며, 아직 인증하지 않은 경우
참여자 | DONE | 인증 완료 | [인증 완료] 오늘 할 일을 이미 성공적으로 마친 경우
참여자 | UPCOMING | 라운드 시작 전 | [대기] 챌린지에 참여 중이나, 첫 라운드 시작 날짜가 아직 되지 않은 경우
참여자 | NOT_DAY | 인증 요일 아님 | [대기] 참여 중이지만, 오늘은 지정된 인증 요일(예: 월/수/금)이 아닌 경우
참여자 | NOT_TIME | 인증 시간 아님 | [대기] 인증 요일은 맞으나, 현재 시간이 설정된 인증 시간대 전후인 경우
미참여자 | JOIN | 참가하기 | [참가 가능] 미참여 상태이며, 챌린지 정원에 여유가 있고 본인의 참여 한도가 남은 경우
미참여자 | WAITLIST | 빈자리 알림 받기 | [정원 초과] 미참여 상태이나, 현재 챌린지 정원이 가득 차서 자리가 없는 경우
공통/제한 | FINISHED | 종료된 챌린지 | [종료] 참여 여부와 상관없이 챌린지 자체가 이미 종료(FINISHED)된 경우
공통/제한 | MAX_LIMIT_EXCEEDED | 참여 개수 초과 | [참여 제한] 미참여 상태이나, 사용자가 이미 최대 참여 가능한 챌린지 개수(예: 5개)를 채운 경우

- **프론트에서 당장 수정이 어렵다고 하면 머지는 추후에 진행하도록 하겠습니다.**


---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요? 

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** ChallengeServiceInfoTest 단위 테스트 실행
* **결과 요약:** 총 12개의 시나리오(참여자 5종, 미참여자 4종, 공통 및 예외 3종)에 대해 모두 Success 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

<img width="349" height="126" alt="image" src="https://github.com/user-attachments/assets/028af9e3-9cbe-43eb-9882-1dd87667f96e" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **기능 개선**
  * 챌린지 참여 버튼의 상태 메시지를 개선했습니다. 사용자가 참여할 수 없을 때 더욱 명확한 사유를 확인할 수 있습니다. (예: 라운드 시작 전, 인증 불가능한 요일/시간, 참여 제한 초과, 종료된 챌린지 등)

* **Tests**
  * 테스트 케이스를 업데이트했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->