### PR TITLE
[BUG] 곧 시작하는 챌린지 필터 로직 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -120,8 +120,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 		if (isUpcoming != null && isUpcoming) {
 			LocalDate today = LocalDate.now();
 
-			// 시작일
-			upcomingStartDate = today.atStartOfDay();
+			// 시작일 ; 오늘 + 1일
+			upcomingStartDate = today.atStartOfDay().plusDays(1);
 
 			// 종료일 ; 오늘 + 5일
 			upcomingEndDate = today.plusDays(UPCOMING_DAYS_CRITERIA)

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -364,13 +364,25 @@ public class ChallengeServiceImpl implements ChallengeService {
 					LocalDate challengeStartDate = infoDto.getStartDate().toLocalDate();
 					LocalDate today = LocalDate.now();
 
+					if (challengeStartDate == null) {
+						// 시작일 없는 챌린지는 Upcoming 대상 아님
+						infoDto.setIsUpcoming(false);
+						infoDto.setDDayUntilStart(0);
+					} else {
+						long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
+						boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
+
+						// dto 나머지 필드 채우기 (isUpcoming, dDayUntilStart)
+						infoDto.setIsUpcoming(isUpcomingResult);
+						infoDto.setDDayUntilStart((int)Math.max(0, dDay)); // 시작 전일 경우에만 남은 날짜를 set, else 0
+					}
+
+
 					long dDay = ChronoUnit.DAYS.between(today, challengeStartDate);
 					boolean isUpcomingResult = (dDay >= 0) && (dDay <= UPCOMING_DAYS_CRITERIA);
 
-					// dto 나머지 필드 채우기 (isUpcoming, dDayUntilStart, dayOfWeek)
+					// dto 나머지 필드 채우기 (ThumbnailUrl, dayOfWeek)
 					infoDto.setThumbnailUrl(s3UrlUtil.toFullUrl(infoDto.getThumbnailUrl()));
-					infoDto.setIsUpcoming(isUpcomingResult);
-					infoDto.setDDayUntilStart((int)Math.max(0, dDay)); // 시작 전일 경우에만 남은 날짜를 set, else 0
 					infoDto.setDaysOfWeek(daysMap.getOrDefault(infoDto.getChallengeId(), List.of()));
 
 					return infoDto;

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -171,8 +171,19 @@ class ChallengeRepositoryTest {
 		Slice<ChallengeResponseDto.InfoDto> result = challengeRepository.findChallengesWithFilters(
 			null, start, end, null, null, null, PageRequest.of(0, 10));
 
-		// Then: 5개만 조회되어야 함 - 01.16~20
-		assertThat(result.getContent()).hasSize(5);
+        // Then: 01.16~01.20만 포함되어야 함
+        List<LocalDate> startDates = result.getContent().stream()
+                .map(ChallengeResponseDto.InfoDto::getStartDate)
+                .map(LocalDateTime::toLocalDate)
+                .toList();
+
+        assertThat(startDates).containsExactlyInAnyOrder(
+                LocalDate.of(2026, 1, 16),
+                LocalDate.of(2026, 1, 17),
+                LocalDate.of(2026, 1, 18),
+                LocalDate.of(2026, 1, 19),
+                LocalDate.of(2026, 1, 20)
+        );
 	}
 
 	/**

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -157,10 +157,10 @@ class ChallengeRepositoryTest {
 		// Given: 15일, 20일, 21일 시작하는 챌린지를 실제로 DB에 저장
 		LocalDate today = LocalDate.of(2026, 1, 15);
 		saveChallenge(today);              			  // 01.15 (D-DAY) = 제외 대상
-		saveChallenge(today.plusDays(5));  // 01.16(D-1) = 포함
-		saveChallenge(today.plusDays(5));  // 01.17(D-2) = 포함
-		saveChallenge(today.plusDays(5));  // 01.18(D-3) = 포함
-		saveChallenge(today.plusDays(5));  // 01.19(D-4) = 포함
+		saveChallenge(today.plusDays(1));  // 01.16(D-1) = 포함
+		saveChallenge(today.plusDays(2));  // 01.17(D-2) = 포함
+		saveChallenge(today.plusDays(3));  // 01.18(D-3) = 포함
+		saveChallenge(today.plusDays(4));  // 01.19(D-4) = 포함
 		saveChallenge(today.plusDays(5));  // 01.20(D-5) = 포함 (경계)
 		saveChallenge(today.plusDays(6));  // 01.21(D-6) = 제외 대상
 

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.challenge.repository;
 
+import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
@@ -14,6 +15,8 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -147,4 +150,51 @@ class ChallengeRepositoryTest {
                 .verifyEndTime(LocalTime.of(18, 0))
                 .build();
     }
+
+	@Test
+	@DisplayName("Repository는 지정된 날짜 범위를 벗어난 데이터를 조회하지 않아야 한다")
+	void repository_Filtering_Test() {
+		// Given: 15일, 20일, 21일 시작하는 챌린지를 실제로 DB에 저장
+		LocalDate today = LocalDate.of(2026, 1, 15);
+		saveChallenge(today);              			  // 01.15 (D-DAY) = 제외 대상
+		saveChallenge(today.plusDays(5));  // 01.16(D-1) = 포함
+		saveChallenge(today.plusDays(5));  // 01.17(D-2) = 포함
+		saveChallenge(today.plusDays(5));  // 01.18(D-3) = 포함
+		saveChallenge(today.plusDays(5));  // 01.19(D-4) = 포함
+		saveChallenge(today.plusDays(5));  // 01.20(D-5) = 포함 (경계)
+		saveChallenge(today.plusDays(6));  // 01.21(D-6) = 제외 대상
+
+		// When: 서비스에서 계산하는 것과 동일한 범위로 조회
+		LocalDateTime start = today.atStartOfDay();
+		LocalDateTime end = today.plusDays(5).atTime(23, 59, 59);
+
+		Slice<ChallengeResponseDto.InfoDto> result = challengeRepository.findChallengesWithFilters(
+			null, start, end, null, null, null, PageRequest.of(0, 10));
+
+		// Then: 5개만 조회되어야 함 - 01.16~20
+		assertThat(result.getContent()).hasSize(5);
+	}
+
+	/**
+	 * 헬퍼 메소드
+	 */
+
+	private void saveChallenge(LocalDate startDate) {
+		Challenge challenge = Challenge.builder()
+			.title("테스트 챌린지")
+			.description("내용")
+			.startDate(startDate.atStartOfDay())
+			.status(ChallengeStatus.RECRUITING)
+			.category(Category.HABIT)
+			.verificationType(VerificationType.PHOTO)
+			.isPublic(true)
+			.isViewerMode(false)
+			.maxParticipants(10)
+			.currentParticipants(0)
+			.verifyStartTime(LocalTime.of(9, 0))
+			.verifyEndTime(LocalTime.of(18, 0))
+			.build();
+
+		challengeRepository.save(challenge);
+	}
 }

--- a/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryTest.java
@@ -165,7 +165,7 @@ class ChallengeRepositoryTest {
 		saveChallenge(today.plusDays(6));  // 01.21(D-6) = 제외 대상
 
 		// When: 서비스에서 계산하는 것과 동일한 범위로 조회
-		LocalDateTime start = today.atStartOfDay();
+		LocalDateTime start = today.atStartOfDay().plusDays(1);
 		LocalDateTime end = today.plusDays(5).atTime(23, 59, 59);
 
 		Slice<ChallengeResponseDto.InfoDto> result = challengeRepository.findChallengesWithFilters(

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -5,6 +5,7 @@ import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
 import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
+import com.hrr.backend.domain.challenge.repository.ChallengeDayJoinRepository;
 import com.hrr.backend.domain.challenge.repository.ChallengeLikeRepository;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.round.entity.Round;
@@ -16,14 +17,21 @@ import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.response.SliceResponseDto;
+import com.hrr.backend.global.s3.S3UrlUtil;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.SliceImpl;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Optional;
@@ -31,8 +39,7 @@ import java.util.Optional;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
 class ChallengeServiceInfoTest {
@@ -45,6 +52,8 @@ class ChallengeServiceInfoTest {
     @Mock private VerificationRepository verificationRepository;
     @Mock private ChallengeLikeRepository challengeLikeRepository;
     @Mock private ChallengeConverter challengeConverter;
+	@Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
+	@Mock private S3UrlUtil s3UrlUtil;
 
     /**
      * 1. 참여자(Participant) 관련 시나리오
@@ -291,6 +300,51 @@ class ChallengeServiceInfoTest {
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
     }
+
+	@Test
+	@DisplayName("곧 시작하는 챌린지 필터 적용 시 날짜 계산 및 D-Day 가공 로직 검증")
+	void getChallengeList_UpcomingLogic_Test() {
+		LocalDateTime startTime0 = LocalDateTime.of(2026, 1, 15, 10, 0, 0);	// 오늘 시작하는 챌린지 생성용
+		LocalDateTime startTime5 = LocalDateTime.of(2026, 1, 20, 23, 59, 59);	// 5일 뒤 시작하는 챌린지 생성용
+		LocalDate mockToday = LocalDate.of(2026, 1, 15);	// 오늘을 26.01.15로 고정
+
+		// 테스트용 DTO 구성 - 실제 로직에서는 Repository에서 조회해옴
+		ChallengeResponseDto.InfoDto day0 = ChallengeResponseDto.InfoDto.builder()
+			.challengeId(1L)
+			.startDate(startTime0)
+			.thumbnailUrl("test.png")
+			.build();
+
+		ChallengeResponseDto.InfoDto day5 = ChallengeResponseDto.InfoDto.builder()
+			.challengeId(2L)
+			.startDate(startTime5)
+			.thumbnailUrl("test.png")
+			.build();
+
+		// Mock 설정 - 실제 DB를 거치지 않고 아래처럼 반환되었다고 가정
+		given(challengeRepository.findChallengesWithFilters(any(), any(), any(), any(), any(), any(), any()))
+			.willReturn(new SliceImpl<>(List.of(day0, day5)));
+		given(challengeDayJoinRepository.findByChallengeIdIn(anyList())).willReturn(List.of());	// 요일 정보는 테스트 대상이 아니라 빈 값 반환
+		lenient().when(s3UrlUtil.toFullUrl(anyString())).thenReturn("http://image.url");
+
+		try (MockedStatic<LocalDate> mockedLocalDate =
+				 mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
+			// LocalDate의 static 메서드를 MockedStatic으로 전부 mock 하면 LocalDate.of() 등이 모두 null을 반환해 NPE 가능
+			// 그래서 LocalDate.now()만 mock되도록 CALLS_REAL_METHODS 설정
+
+			mockedLocalDate.when(LocalDate::now).thenReturn(mockToday);
+
+			SliceResponseDto<ChallengeResponseDto.InfoDto> result =
+				challengeService.getChallengeList(null, true, null, null, null, 0, 10);
+
+			// 테스트 결과 검증
+			assertThat(result.getContent().get(0).getIsUpcoming()).isTrue();
+			assertThat(result.getContent().get(1).getIsUpcoming()).isTrue();
+			assertThat(result.getContent().get(0).getDDayUntilStart()).isEqualTo(0);	// D-DAY
+			assertThat(result.getContent().get(1).getDDayUntilStart()).isEqualTo(5);	// D-5
+		}
+
+	}
 
     /**
      * Helper Methods


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #275 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

'곧 시작하는 챌린지' 필터 적용 시 챌린지 시작일까지 1~5일 남은 챌린지만 반환하게 수정
기존에는 오늘이 포함되어 이미 시작한 챌린지도 조회되는 오류가 있었음

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 단위 테스트
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 기존 로직 테스트 | 로직 변경 후 |
|---|---|
|<img width="621" height="469" alt="기존 로직 테스트" src="https://github.com/user-attachments/assets/859d1d14-1e78-47ad-9891-233e58b5af4f" />|<img width="739" height="522" alt="로직 변경" src="https://github.com/user-attachments/assets/3a559df0-8be6-4596-b7b4-25050387d905" />|

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 다가오는 챌린지 필터 범위를 하루 줄여 표시 방식을 조정했습니다.
  * 시작일이 없는 챌린지에 대해 안전하게 처리하여 다가오는 여부를 명확히 하고 D‑Day를 0으로 설정합니다.
  * 썸네일·요일 정보 처리 방식을 정비했습니다.

* **테스트**
  * 날짜 범위 기반 필터링 동작을 검증하는 테스트를 추가했습니다.
  * 다가오는 챌린지 판정 및 D‑Day 계산 로직을 검증하는 테스트를 추가/보강했습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->