### PR TITLE
[BUG] 강퇴 유저 재참여 제한 강화 및 종료된 챌린지 조회 버그 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -13,6 +13,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 public class ChallengeRequestDto {
 
@@ -83,6 +84,7 @@ public class ChallengeRequestDto {
     }
 
     @Getter
+    @Setter
     @NoArgsConstructor
     @Schema(description = "챌린지 참가 요청 DTO")
     public static class JoinChallengeDto {

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -19,7 +19,8 @@ public enum ActionButtonStatus {
 
     // 3. 제한 상태 (DISABLED 세분화)
     FINISHED("종료된 챌린지"),
-    MAX_LIMIT_EXCEEDED("참여 개수 초과");
+    MAX_LIMIT_EXCEEDED("참여 개수 초과"),
+    REJECT("참가 신청 불가");;
 
     private final String description;
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -20,7 +20,7 @@ public enum ActionButtonStatus {
     // 3. 제한 상태 (DISABLED 세분화)
     FINISHED("종료된 챌린지"),
     MAX_LIMIT_EXCEEDED("참여 개수 초과"),
-    REJECT("참가 신청 불가");;
+    REJECT("참가 신청 불가");
 
     private final String description;
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -169,15 +169,22 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 유저 상태 확인 (참여 여부, 오늘 인증 여부)
 		boolean isParticipant = false;
 		boolean isCertifiedToday = false;
+		boolean isKicked = false; // 강퇴 여부 플래그 추가
 
         // 유저가 참여 중인지 확인
         Optional<UserChallenge> ucOp = userChallengeRepository.findByUserAndChallenge(user, challenge);
 
-        if (ucOp.isPresent()) {
-            isParticipant = true;
-            // 참여자라면 오늘 인증 여부 체크 (시간대 + 오늘 기준)
-            isCertifiedToday = checkTodayVerification(ucOp.get().getId(), challenge);
-        }
+		if (ucOp.isPresent()) {
+			UserChallenge uc = ucOp.get();
+			// 챌린지가 진행 중일 때만 오늘 인증 여부를 체크함
+			if (uc.getStatus() == ChallengeJoinStatus.JOINED && challenge.getStatus() != ChallengeStatus.FINISHED) {
+				isParticipant = true;
+				isCertifiedToday = checkTodayVerification(uc.getId(), challenge);
+			}
+			else if (uc.getStatus() == ChallengeJoinStatus.KICKED) {
+				isKicked = true;
+			}
+		}
 
 		// 챌린지 참여 개수 조회
 		boolean isMaxJoined = challengeRepository.countByUserIdAndStatus(user.getId(), ChallengeJoinStatus.JOINED) >= 5;
@@ -194,7 +201,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
-		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined);
+		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
 
 		// DTO 변환 및 반환
 		return challengeConverter.toHeaderInfoDto(
@@ -673,9 +680,14 @@ public class ChallengeServiceImpl implements ChallengeService {
 		}
 
 		// 중복 참가 검증
-		if (userChallengeRepository.existsByUserAndChallenge(user, challenge)) {
-			throw new GlobalException(ErrorCode.CHALLENGE_ALREADY_JOINED);
-		}
+		userChallengeRepository.findByUserAndChallenge(user, challenge).ifPresent(uc -> {
+			if (uc.getStatus() == ChallengeJoinStatus.JOINED) {
+				throw new GlobalException(ErrorCode.CHALLENGE_ALREADY_JOINED);
+			}
+			if (uc.getStatus() == ChallengeJoinStatus.KICKED) {
+				throw new GlobalException(ErrorCode.CHALLENGE_KICKED_USER);
+			}
+		});
 
 		// 정원 초과 검증
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
@@ -745,14 +757,19 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-	private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
+	private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined, boolean isKicked) {
 
-		// 1. 챌린지 자체가 종료된 경우 (가장 먼저 체크)
+		// 1. 챌린지 자체가 종료된 경우
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
 			return ActionButtonStatus.FINISHED;
 		}
 
-		// 2. 참여자인 경우 (인증 관련 분기)
+		// 2. 강퇴된 유저의 경우
+		if (isKicked) {
+			return ActionButtonStatus.REJECT;
+		}
+
+		// 3. 참여자인 경우 (인증 관련 분기)
 		if (isParticipant) {
 			Round currentRound = challenge.getCurrentRound();
 
@@ -771,17 +788,17 @@ public class ChallengeServiceImpl implements ChallengeService {
 			return isCertifiedToday ? ActionButtonStatus.DONE : ActionButtonStatus.AVAILABLE;
 		}
 
-		// 3. 미참여자이면서 참여가 제한되는 경우
+		// 4. 미참여자이면서 참여가 제한되는 경우
 		if (isMaxJoined) {
 			return ActionButtonStatus.MAX_LIMIT_EXCEEDED;
 		}
 
-		// 4. 미참여자 정원 체크
+		// 5. 미참여자 정원 체크
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
 			return ActionButtonStatus.WAITLIST;
 		}
 
-		// 5. 그 외 참여 가능
+		// 6. 그 외 참여 가능
 		return ActionButtonStatus.JOIN;
 	}
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -497,18 +497,24 @@ public class ChallengeServiceImpl implements ChallengeService {
 	}
 
 	private void createRoundRecordOrFail(Challenge challenge, UserChallenge userChallenge) {
-		Round currentRound = challenge.getCurrentRound();
+		Round currentRound = challenge.getCurrentRound(); //
 
 		// 챌린지가 있는데 라운드가 없는 건 서버 에러
 		if (currentRound == null) {
-			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
+			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR); //
 		}
 
-		RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
-				currentRound,
-				userChallenge
-		);
-		roundRecordRepository.save(roundRecord);
+		// 이미 기록이 존재하는지 체크
+		boolean isExist = roundRecordRepository.existsByUserChallengeAndRound(userChallenge, currentRound);
+
+		if (!isExist) {
+			// 기록이 없을 때만 신규 생성
+			RoundRecord roundRecord = roundConverter.toRoundRecordEntity(
+					currentRound,
+					userChallenge
+			);
+			roundRecordRepository.save(roundRecord);
+		}
 	}
 
 	@Override

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -469,14 +469,20 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 비즈니스 룰 검증
 		validateJoinRequest(challenge, user, req.getPassword());
 
-		// 참가 처리
-		UserChallenge userChallenge = userChallengeConverter.toChallenger(user, challenge);
+		// 기존 참여 기록이 있는지 확인 (유니크 제약 조건 충돌 방지)
+		Optional<UserChallenge> existingUcOp = userChallengeRepository.findByUserAndChallenge(user, challenge);
 
-		try {
+		UserChallenge userChallenge;
+		if (existingUcOp.isPresent()) {
+			// 기존 기록이 있다면 (validateJoinRequest를 통과했으므로 DROPPED 상태임) 상태만 JOINED로 변경
+			userChallenge = existingUcOp.get();
+			userChallenge.updateStatus(ChallengeJoinStatus.JOINED);
+		} else {
+			// 기록이 없다면 신규 생성
+			userChallenge = userChallengeConverter.toChallenger(user, challenge);
 			userChallengeRepository.save(userChallenge);
-		} catch (DataIntegrityViolationException e) {
-			throw new GlobalException(ErrorCode.CHALLENGE_ALREADY_JOINED);
 		}
+
 		// 챌린지 인원 업데이트
 		challenge.increaseCurrentParticipants();
 

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode implements BaseCode{
     USER_FAVOR_REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "CHALLENGE40014", "필수 선호 정보가 누락되었습니다."),
     CHALLENGE_CALCULATE_EMBEDDING(HttpStatus.BAD_REQUEST, "CHALLENGE40015", "챌린지 임베딩 계산 중 오류가 발생했습니다."),
     EMBEDDING_API_ERROR(HttpStatus.BAD_REQUEST, "CHALLENGE40016", "임베딩 API로부터 유효하지 않은 응답을 받았습니다."),
+    CHALLENGE_KICKED_USER(HttpStatus.FORBIDDEN, "CHALLENGE4031", "참가 자격이 제한된 챌린지입니다."),
 
     // challenge wait
     CHALLENGE_WAIT_ALREADY_EXIST(HttpStatus.CONFLICT, "WAIT4091", "이미 알림 신청을 완료한 챌린지입니다."),

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -11,6 +11,7 @@ import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.entity.enums.UserChallengeRole;
 import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
@@ -23,7 +24,6 @@ import com.hrr.backend.global.s3.S3UrlUtil;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
@@ -52,8 +52,8 @@ class ChallengeServiceInfoTest {
     @Mock private VerificationRepository verificationRepository;
     @Mock private ChallengeLikeRepository challengeLikeRepository;
     @Mock private ChallengeConverter challengeConverter;
-	@Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
-	@Mock private S3UrlUtil s3UrlUtil;
+    @Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
+    @Mock private S3UrlUtil s3UrlUtil;
 
     /**
      * 1. 참여자(Participant) 관련 시나리오
@@ -70,7 +70,7 @@ class ChallengeServiceInfoTest {
         setVerificationTime(challenge, LocalTime.of(9, 0), LocalTime.of(18, 0));
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         mockConverter(ActionButtonStatus.UPCOMING);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -93,7 +93,7 @@ class ChallengeServiceInfoTest {
         setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         mockConverter(ActionButtonStatus.NOT_DAY);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -111,7 +111,7 @@ class ChallengeServiceInfoTest {
         setVerificationTime(challenge, LocalTime.of(0, 0), LocalTime.of(0, 1));
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         mockConverter(ActionButtonStatus.NOT_TIME);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -129,7 +129,7 @@ class ChallengeServiceInfoTest {
         setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         given(verificationRepository.existsTodayVerification(any(), any(), any(), any())).willReturn(false);
         mockConverter(ActionButtonStatus.AVAILABLE);
 
@@ -148,7 +148,7 @@ class ChallengeServiceInfoTest {
         setVerificationTime(challenge, LocalTime.MIN, LocalTime.MAX);
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         given(verificationRepository.existsTodayVerification(any(), any(), any(), any())).willReturn(true);
         mockConverter(ActionButtonStatus.DONE);
 
@@ -170,7 +170,7 @@ class ChallengeServiceInfoTest {
         setRoundDate(challenge, LocalDate.now());
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false);
+        mockGuest(user, challenge);
         mockConverter(ActionButtonStatus.JOIN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -188,7 +188,7 @@ class ChallengeServiceInfoTest {
         setRoundDate(challenge, LocalDate.now());
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false);
+        mockGuest(user, challenge);
         mockConverter(ActionButtonStatus.WAITLIST);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -207,7 +207,7 @@ class ChallengeServiceInfoTest {
         setVerificationTime(challenge, LocalTime.now().minusHours(1), LocalTime.now().plusHours(1));
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, true);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
         mockConverter(ActionButtonStatus.FINISHED);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -225,7 +225,7 @@ class ChallengeServiceInfoTest {
         setRoundDate(challenge, LocalDate.now().minusDays(5));
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false);
+        mockGuest(user, challenge);
         mockConverter(ActionButtonStatus.JOIN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
@@ -253,99 +253,118 @@ class ChallengeServiceInfoTest {
         given(userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER))
                 .willReturn(Optional.of(ownerUc));
 
-        mockParticipant(user, challenge, false);
+        mockGuest(user, challenge);
         mockConverter(ActionButtonStatus.JOIN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
         assertThat(result).isNotNull();
     }
 
+    /**
+     * 4. 종료된 챌린지 관련 시나리오 (유저 상태별 일관성 검증)
+     */
     @Test
-    @DisplayName("상황 11: 방장 데이터 없음 -> 에러 없이 조회")
-    void owner_not_found_returns_info_successfully() {
+    @DisplayName("상황 11: 종료된 챌린지 + 미참여자(기록 없음) -> FINISHED")
+    void finished_guest_returns_FINISHED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        setChallengeStatus(challenge, ChallengeStatus.FINISHED, 5, 10);
+        mockFetchingChallenge(challengeId, challenge);
+        mockGuest(user, challenge);
+        mockConverter(ActionButtonStatus.FINISHED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.FINISHED);
+    }
+
+    @Test
+    @DisplayName("상황 12: 종료된 챌린지 + 참여 완료 유저(JOINED) -> FINISHED")
+    void finished_joinedUser_returns_FINISHED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        setChallengeStatus(challenge, ChallengeStatus.FINISHED, 10, 10);
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.JOINED);
+        mockConverter(ActionButtonStatus.FINISHED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.FINISHED);
+    }
+
+    @Test
+    @DisplayName("상황 13: 종료된 챌린지 + 하차한 유저(DROPPED) -> FINISHED")
+    void finished_droppedUser_returns_FINISHED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        setChallengeStatus(challenge, ChallengeStatus.FINISHED, 5, 10);
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.DROPPED);
+        mockConverter(ActionButtonStatus.FINISHED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.FINISHED);
+    }
+
+    @Test
+    @DisplayName("상황 14: 종료된 챌린지 + 강퇴된 유저(KICKED) -> FINISHED")
+    void finished_kickedUser_returns_FINISHED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        setChallengeStatus(challenge, ChallengeStatus.FINISHED, 5, 10);
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED); // 퇴출됨
+        mockConverter(ActionButtonStatus.FINISHED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.FINISHED);
+    }
+
+    /**
+     * 5. 진행 중인 챌린지 + 특수 상태 시나리오
+     */
+    @Test
+    @DisplayName("상황 15: 진행 중 + 하차(DROPPED)한 유저는 재참여 가능하므로 JOIN")
+    void ongoing_droppedUser_returns_JOIN() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
-        setRoundDate(challenge, LocalDate.now());
-        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 10, 30);
 
-        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
-        given(userChallengeRepository.findByChallengeIdAndRole(challengeId, UserChallengeRole.OWNER))
-                .willReturn(Optional.empty());
-
-        mockParticipant(user, challenge, false);
-        mockConverter(ActionButtonStatus.JOIN);
-
-        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result).isNotNull();
-    }
-
-    @Test
-    @DisplayName("상황 12: 미참여자 + 참여 한도 초과 -> MAX_LIMIT_EXCEEDED")
-    void guest_max_limit_exceeded_returns_MAX_LIMIT_EXCEEDED() {
-        Long challengeId = 1L;
-        User user = mock(User.class);
-        given(user.getId()).willReturn(1L);
-
-        Challenge challenge = mock(Challenge.class);
-        setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 5, 10);
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 5, 10);
         setRoundDate(challenge, LocalDate.now());
 
         mockFetchingChallenge(challengeId, challenge);
-        mockParticipant(user, challenge, false);
-        given(challengeRepository.countByUserIdAndStatus(eq(user.getId()), any())).willReturn(5L);
-
-        mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.DROPPED);
+        mockConverter(ActionButtonStatus.JOIN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
     }
 
-	@Test
-	@DisplayName("곧 시작하는 챌린지 필터 적용 시 날짜 계산 및 D-Day 가공 로직 검증")
-	void getChallengeList_UpcomingLogic_Test() {
-		LocalDateTime startTime0 = LocalDateTime.of(2026, 1, 15, 10, 0, 0);	// 오늘 시작하는 챌린지 생성용
-		LocalDateTime startTime5 = LocalDateTime.of(2026, 1, 20, 23, 59, 59);	// 5일 뒤 시작하는 챌린지 생성용
-		LocalDate mockToday = LocalDate.of(2026, 1, 15);	// 오늘을 26.01.15로 고정
+    @Test
+    @DisplayName("상황 16: 진행 중 + 강퇴(KICKED)된 유저는 재참여 불가하므로 REJECT")
+    void ongoing_kickedUser_returns_REJECT() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
 
-		// 테스트용 DTO 구성 - 실제 로직에서는 Repository에서 조회해옴
-		ChallengeResponseDto.InfoDto day0 = ChallengeResponseDto.InfoDto.builder()
-			.challengeId(1L)
-			.startDate(startTime0)
-			.thumbnailUrl("test.png")
-			.build();
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 5, 10);
+        setRoundDate(challenge, LocalDate.now());
 
-		ChallengeResponseDto.InfoDto day5 = ChallengeResponseDto.InfoDto.builder()
-			.challengeId(2L)
-			.startDate(startTime5)
-			.thumbnailUrl("test.png")
-			.build();
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
+        mockConverter(ActionButtonStatus.REJECT);
 
-		// Mock 설정 - 실제 DB를 거치지 않고 아래처럼 반환되었다고 가정
-		given(challengeRepository.findChallengesWithFilters(any(), any(), any(), any(), any(), any(), any()))
-			.willReturn(new SliceImpl<>(List.of(day0, day5)));
-		given(challengeDayJoinRepository.findByChallengeIdIn(anyList())).willReturn(List.of());	// 요일 정보는 테스트 대상이 아니라 빈 값 반환
-		lenient().when(s3UrlUtil.toFullUrl(anyString())).thenReturn("http://image.url");
-
-		try (MockedStatic<LocalDate> mockedLocalDate =
-				 mockStatic(LocalDate.class, CALLS_REAL_METHODS)) {
-			// LocalDate의 static 메서드를 MockedStatic으로 전부 mock 하면 LocalDate.of() 등이 모두 null을 반환해 NPE 가능
-			// 그래서 LocalDate.now()만 mock되도록 CALLS_REAL_METHODS 설정
-
-			mockedLocalDate.when(LocalDate::now).thenReturn(mockToday);
-
-			SliceResponseDto<ChallengeResponseDto.InfoDto> result =
-				challengeService.getChallengeList(null, true, null, null, null, 0, 10);
-
-			// 테스트 결과 검증
-			assertThat(result.getContent().get(0).getIsUpcoming()).isTrue();
-			assertThat(result.getContent().get(1).getIsUpcoming()).isTrue();
-			assertThat(result.getContent().get(0).getDDayUntilStart()).isEqualTo(0);	// D-DAY
-			assertThat(result.getContent().get(1).getDDayUntilStart()).isEqualTo(5);	// D-5
-		}
-
-	}
-
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.REJECT);
+    }
     /**
      * Helper Methods
      */
@@ -363,14 +382,15 @@ class ChallengeServiceInfoTest {
                 .thenReturn(Optional.of(mock(UserChallenge.class)));
     }
 
-    private void mockParticipant(User user, Challenge challenge, boolean isParticipant) {
-        if (isParticipant) {
-            UserChallenge uc = mock(UserChallenge.class);
-            given(uc.getId()).willReturn(100L);
-            given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(uc));
-        } else {
-            given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.empty());
-        }
+    private void mockGuest(User user, Challenge challenge) {
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.empty());
+    }
+
+    private void mockParticipantWithStatus(User user, Challenge challenge, ChallengeJoinStatus status) {
+        UserChallenge uc = mock(UserChallenge.class);
+        lenient().when(uc.getId()).thenReturn(100L);
+        lenient().when(uc.getStatus()).thenReturn(status);
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(uc));
     }
 
     private void setRoundDate(Challenge challenge, LocalDate startDate) {

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
@@ -1,0 +1,193 @@
+package com.hrr.backend.domain.challenge.service;
+
+import com.hrr.backend.domain.challenge.converter.ChallengeConverter;
+import com.hrr.backend.domain.challenge.dto.ChallengeRequestDto;
+import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.converter.RoundConverter;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.user.converter.UserChallengeConverter;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeServiceJoinTest {
+
+    @InjectMocks
+    private ChallengeServiceImpl challengeService;
+
+    @Mock private ChallengeRepository challengeRepository;
+    @Mock private UserChallengeRepository userChallengeRepository;
+    @Mock private RoundRecordRepository roundRecordRepository;
+    @Mock private UserChallengeConverter userChallengeConverter;
+    @Mock private ChallengeConverter challengeConverter;
+    @Mock private RoundConverter roundConverter;
+    @Mock private ChallengeStaticsService challengeStaticsService;
+
+    private User user;
+    private Challenge challenge;
+    private ChallengeRequestDto.JoinChallengeDto joinReq;
+
+    @BeforeEach
+    void setUp() {
+        user = mock(User.class);
+        challenge = mock(Challenge.class);
+        joinReq = new ChallengeRequestDto.JoinChallengeDto();
+
+        // 기본 챌린지 설정 (진행 중, 정원 여유, 공개 챌린지)
+        lenient().when(challenge.getStatus()).thenReturn(ChallengeStatus.ONGOING);
+        lenient().when(challenge.getCurrentParticipants()).thenReturn(5);
+        lenient().when(challenge.getMaxParticipants()).thenReturn(10);
+        lenient().when(challenge.getCurrentRound()).thenReturn(mock(Round.class));
+        lenient().when(challenge.getIsPublic()).thenReturn(true);
+    }
+
+    @Test
+    @DisplayName("가입 상황 1: 신규 유저 참여 -> save() 호출 확인 및 가입 성공")
+    void join_NewUser_Success() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(anyLong())).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.empty());
+
+        UserChallenge newUc = mock(UserChallenge.class);
+        given(userChallengeConverter.toChallenger(user, challenge)).willReturn(newUc);
+        given(challengeConverter.toJoinResponseDto(challenge)).willReturn(mock(ChallengeResponseDto.JoinChallengeDto.class));
+
+        // [When]
+        challengeService.joinChallenge(user, challengeId, joinReq);
+
+        // [Then]
+        verify(userChallengeRepository, times(1)).save(any(UserChallenge.class));
+        verify(challenge, times(1)).increaseCurrentParticipants();
+    }
+
+    @Test
+    @DisplayName("가입 상황 2: 하차(DROPPED) 유저 재참여 -> updateStatus() 호출 및 save() 미호출 (DB 충돌 방지)")
+    void join_DroppedUser_Success() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(anyLong())).willReturn(Optional.of(challenge));
+
+        UserChallenge existingUc = mock(UserChallenge.class);
+        given(existingUc.getStatus()).willReturn(ChallengeJoinStatus.DROPPED);
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(existingUc));
+
+        given(challengeConverter.toJoinResponseDto(challenge)).willReturn(mock(ChallengeResponseDto.JoinChallengeDto.class));
+
+        // [When]
+        challengeService.joinChallenge(user, challengeId, joinReq);
+
+        // [Then]
+        verify(existingUc, times(1)).updateStatus(ChallengeJoinStatus.JOINED);
+        verify(userChallengeRepository, never()).save(any(UserChallenge.class));
+    }
+
+    @Test
+    @DisplayName("가입 상황 3: 강퇴(KICKED) 유저 재참여 시도 -> CHALLENGE_KICKED_USER 예외 발생")
+    void join_KickedUser_Throws_Exception() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+
+        UserChallenge kickedUc = mock(UserChallenge.class);
+        given(kickedUc.getStatus()).willReturn(ChallengeJoinStatus.KICKED);
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(kickedUc));
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_KICKED_USER);
+    }
+
+    @Test
+    @DisplayName("가입 상황 4: 이미 참여 중(JOINED)인 유저 -> CHALLENGE_ALREADY_JOINED 예외 발생")
+    void join_AlreadyJoinedUser_Throws_Exception() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+
+        UserChallenge joinedUc = mock(UserChallenge.class);
+        given(joinedUc.getStatus()).willReturn(ChallengeJoinStatus.JOINED);
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(joinedUc));
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_ALREADY_JOINED);
+    }
+
+    @Test
+    @DisplayName("가입 상황 5: 참여 중인 챌린지가 5개 초과 -> MAX_CHALLENGE_EXCEEDED 예외 발생")
+    void join_MaxLimitExceeded_Throws_Exception() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(challengeRepository.countByUserIdAndStatus(any(), eq(ChallengeJoinStatus.JOINED))).willReturn(5L);
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MAX_CHALLENGE_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("가입 상황 6: 챌린지 정원 마감 -> CHALLENGE_FULL 예외 발생")
+    void join_ChallengeFull_Throws_Exception() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(challenge.getCurrentParticipants()).willReturn(10);
+        given(challenge.getMaxParticipants()).willReturn(10);
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_FULL);
+    }
+
+    @Test
+    @DisplayName("가입 상황 7: 비공개 챌린지 비밀번호 불일치 -> CHALLENGE_PASSWORD_MISMATCH 예외 발생")
+    void join_PasswordMismatch_Throws_Exception() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+
+        given(challenge.getIsPublic()).willReturn(false);
+        given(challenge.getPassword()).willReturn("1234");
+
+        joinReq.setPassword("9999");
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_PASSWORD_MISMATCH); //
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #이슈번호

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

챌린지 참여 유저의 상세 상태(JOINED, DROPPED, KICKED)를 고려한 버튼 상태 결정 로직을 고도화하고 챌린지 참여 시에 에러코드도 추가하여 로직을 보강하였습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트
* **결과 요약:** 총 16개 테스트 모두 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

#### 하단 버튼 테스트 (16개 시나리오)
<img width="251" height="83" alt="image" src="https://github.com/user-attachments/assets/04c89830-cf7a-49a1-85f3-ae7d29b66909" />

#### 챌린지 참가 테스트 (7개 시나리오)
<img width="215" height="62" alt="image" src="https://github.com/user-attachments/assets/c699c94b-12f2-49f2-bff1-85c17faffdd6" />

#### 하차한 챌린지 참가
<img width="500" alt="image" src="https://github.com/user-attachments/assets/8cad169b-4ea1-483c-b928-2cebb26390f7" />

> DB에서 UserChallenge의 status가 DROPPED -> JOIN으로 바뀌는 것 확인

#### 퇴출당한 챌린지 참가
<img width="500" alt="image" src="https://github.com/user-attachments/assets/cbfdd58d-19dd-4675-b910-4f37522263c3" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 강퇴된 사용자는 재참가 시도가 즉시 거부되어 관련 안내가 표시됩니다.
  * 참가 버튼 상태에 강퇴 상태에 따른 새로운 표시가 추가되었습니다.

* **개선사항**
  * 참가 신청 흐름이 기존 참여 기록을 재활용하도록 개선되어 중복 기록이 줄어듭니다.
  * 라운드 기록 생성 시 중복 생성을 방지하도록 검증이 추가되었습니다.
  * 참가 요청 검증 로직이 상태 기반으로 정교화되었습니다.
  * 참가 요청 DTO에 비밀번호 설정을 위한 접근자가 추가되었습니다.

* **테스트**
  * 강퇴·참가·탈퇴 등 다양한 사용자 상태에 대한 단위 테스트가 추가·확장되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->