### PR TITLE
[FIX] 종료된 챌린지는 인기 챌린지에서 조회되지 않도록 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustom.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustom.java
@@ -24,6 +24,6 @@ public interface ChallengeRepositoryCustom {
 		Pageable pageable
 	);
 
-	// 챌린지 id 목록으로 정보 조회
-	List<ChallengeResponseDto.InfoDto> findChallengesByIds(List<Long> ids);
+	// 챌린지 id 목록으로 정보 조회(단, 종료된 챌린지는 제외)
+	List<ChallengeResponseDto.InfoDto> findNotFinishedChallengesByIds(List<Long> ids);
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepositoryCustomImpl.java
@@ -14,6 +14,7 @@ import com.hrr.backend.domain.challenge.entity.QChallenge;
 import com.hrr.backend.domain.challenge.entity.QChallengeDayJoin;
 import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.common.enums.ChallengeDays;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
 import com.hrr.backend.global.common.enums.SortType;
 import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.core.types.Projections;
@@ -79,7 +80,7 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom{
 
 
 	@Override
-	public List<ChallengeResponseDto.InfoDto> findChallengesByIds(List<Long> ids) {
+	public List<ChallengeResponseDto.InfoDto> findNotFinishedChallengesByIds(List<Long> ids) {
 		return jpaQueryFactory
 			.select(Projections.bean(ChallengeResponseDto.InfoDto.class,
 				qChallenge.id.as("challengeId"),
@@ -93,7 +94,7 @@ public class ChallengeRepositoryCustomImpl implements ChallengeRepositoryCustom{
 
 			))
 			.from(qChallenge)
-			.where(qChallenge.id.in(ids))
+			.where(qChallenge.id.in(ids), qChallenge.status.ne(ChallengeStatus.FINISHED))
 			.fetch();
 	}
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -43,7 +43,6 @@ import com.hrr.backend.global.common.enums.ChallengeStatus;
 import com.hrr.backend.global.s3.S3UrlUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.ApplicationEventPublisher;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -300,7 +299,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 				.map(tuple -> Long.parseLong(Objects.requireNonNull(tuple.getValue())))
 				.toList();
 
-		List<ChallengeResponseDto.InfoDto> rawInfosFromRDB = challengeRepository.findChallengesByIds(challengeIds);
+		List<ChallengeResponseDto.InfoDto> rawInfosFromRDB = challengeRepository.findNotFinishedChallengesByIds(challengeIds);
 
 		// D-Day, isUpcoming, daysOfWeek 추가
 		List<ChallengeResponseDto.InfoDto> enrichedInfos = enrichChallengeInfo(rawInfosFromRDB);

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImplTest.java
@@ -1,0 +1,81 @@
+package com.hrr.backend.domain.challenge.service;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.*;
+import static org.mockito.BDDMockito.*;
+
+import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.redis.core.DefaultTypedTuple;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ZSetOperations;
+
+import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.challenge.repository.ChallengeDayJoinRepository;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.global.s3.S3UrlUtil;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeServiceImplTest {
+
+	@Mock private ChallengeRepository challengeRepository;
+	@Mock private RedisTemplate<String, String> redisTemplate;
+	@Mock private ZSetOperations<String, String> zSetOperations;
+	@Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
+	@Mock private S3UrlUtil s3UrlUtil;
+
+	@InjectMocks
+	private ChallengeServiceImpl challengeService;
+
+	@Test
+	@DisplayName("일간 인기 챌린지 조회 시 종료된 챌린지는 제외되어야 한다")
+	void getDailyTopChallenges_FilterFinishedChallenges() {
+		// Arrange
+		int requestedNumber = 5;
+		String rankingKey = "today:challenge:clicks";
+
+		given(redisTemplate.opsForZSet()).willReturn(zSetOperations);
+
+		// Redis에 데이터가 2개만 있다고 가정 (size = 2L)
+		given(zSetOperations.size(rankingKey)).willReturn(2L);
+
+		Set<ZSetOperations.TypedTuple<String>> mockRedisResult = new LinkedHashSet<>();
+		mockRedisResult.add(new DefaultTypedTuple<>("1", 10.0));
+		mockRedisResult.add(new DefaultTypedTuple<>("2", 5.0));
+
+		given(zSetOperations.reverseRangeWithScores(eq(rankingKey), anyLong(), anyLong()))
+			.willReturn(mockRedisResult);
+
+		// RDB 설정 (1번만 활성 상태)
+		ChallengeResponseDto.InfoDto activeChallengeInfo = ChallengeResponseDto.InfoDto.builder()
+			.challengeId(1L)
+			.title("진행 중인 챌린지")
+			.startDate(LocalDateTime.now().plusDays(1))
+			.thumbnailUrl("thumb.jpg")
+			.build();
+
+		given(challengeRepository.findNotFinishedChallengesByIds(List.of(1L, 2L)))
+			.willReturn(List.of(activeChallengeInfo));
+
+		// 나머지 Mock 설정 (S3UrlUtil 등 필드 주입 필요 시 추가)
+		given(s3UrlUtil.toFullUrl(any())).willReturn("http://full-url.com");
+		given(challengeDayJoinRepository.findByChallengeIdIn(anyList())).willReturn(Collections.emptyList());
+
+		// Act
+		List<ChallengeResponseDto.DailyTopDto> result = challengeService.getDailyTopChallenges(requestedNumber);
+
+		// Assert
+		assertThat(result).hasSize(1);
+		assertThat(result.get(0).getInfo().getChallengeId()).isEqualTo(1L);
+		assertThat(result.get(0).getRanking()).isEqualTo(1);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #299 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

오늘의 인기 챌린지 조회 API에서 종료된 챌린지는 조회되지 않도록 수정하였습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 단위 테스트
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **Bug Fixes**
  * 일일 최고 도전 목록에서 완료된 도전이 제외되도록 수정되었습니다.

* **Tests**
  * 완료된 도전이 일일 최고 목록에서 올바르게 필터링되는지 검증하는 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->