### PR TITLE
[BUG] 미인증 체크 로직 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -104,10 +104,12 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
 		"JOIN rr.userChallenge uc " +
 		"JOIN uc.challenge c " +
 		"JOIN c.challengeDays cd " +
+		"JOIN rr.round r " +
 		"WHERE c.status = com.hrr.backend.global.common.enums.ChallengeStatus.ONGOING " + // 진행 중인 챌린지
 		"AND uc.status = com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus.JOINED " + // 참여 중인 유저
-		"AND rr.round = c.currentRound " +	// 현재 라운드만 확인
 		"AND cd.dayOfWeek = :yesterdayChallengeDay " + // 어제 요일이 인증 요일인지 확인
+		"AND r.startDate <= :yesterdayDate " +		// 어제 날짜 기준, 해당 라운드의 기간 내에 포함되는지 확인
+		"AND r.endDate >= :yesterdayDate " +
 		"AND NOT EXISTS ( " +
 		"    SELECT v FROM Verification v " +
 		"    WHERE v.roundRecord = rr " +

--- a/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
@@ -9,6 +9,7 @@ import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.round.repository.RoundRepository;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.common.enums.Category;
@@ -110,6 +111,7 @@ class VerificationAbsenceRepositoryTest {
         UserChallenge uc = userChallengeRepository.save(UserChallenge.builder()
                 .user(user)
                 .challenge(challenge)
+				.status(ChallengeJoinStatus.JOINED)
                 .build());
 
         // 라운드 레코드 생성
@@ -123,6 +125,7 @@ class VerificationAbsenceRepositoryTest {
 
         // then: 라운드 시작 전 날짜이므로 집계되면 안 된다
         // 현재 구현에서는 날짜 범위 검증이 빠져 있어 실패가 예상됨 (TDD용 실패 테스트)
+		// -> 라운드 기간 내 날짜만 미인증 집계 대상이 되도록 수정하여 테스트 통과
         assertThat(absentees).isEmpty();
     }
 }

--- a/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
@@ -1,0 +1,129 @@
+package com.hrr.backend.domain.verification;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.common.enums.Category;
+import com.hrr.backend.global.common.enums.ChallengeDays;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.common.enums.VerificationType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * 미인증 집계 로직 TDD 테스트
+ * - 전제: 챌린지 상태는 ONGOING이지만, 라운드 시작일이 오늘인 경우
+ * - 기대: 어제 날짜는 라운드 기간 밖이므로 미인증 집계 대상이 되면 안 된다
+ */
+@SpringBootTest
+@ActiveProfiles("test")
+@Transactional
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 설정(h2) 사용
+class VerificationAbsenceRepositoryTest {
+
+    // 리포지토리 주입
+	@Autowired
+	private RoundRecordRepository roundRecordRepository;
+	@Autowired
+	private RoundRepository roundRepository;
+	@Autowired
+	private ChallengeRepository challengeRepository;
+	@Autowired
+	private UserRepository userRepository;
+	@Autowired
+	private UserChallengeRepository userChallengeRepository;
+
+    @Test
+    @DisplayName("라운드 시작 전 날짜는 미인증 집계 대상이 아니다")
+    void shouldNotCountAbsence_WhenDateIsBeforeRoundStart() {
+        // given
+        LocalDate today = LocalDate.now();
+        LocalDate yesterday = today.minusDays(1);
+
+        // 어제 요일을 챌린지 인증 요일에 포함시킨다
+        ChallengeDays yesterdayChallengeDay = ChallengeDays.from(yesterday.getDayOfWeek());
+
+        // 유저 생성 (필수값은 빌더 기본값 사용)
+        User user = userRepository.save(User.builder()
+                .name("tester")
+                .nickname("tester_nick")
+                .isPublic(true)
+                .build());
+
+        // 챌린지 생성: 상태 ONGOING, 시작일은 '오늘' 00:00
+        Challenge challenge = challengeRepository.save(Challenge.builder()
+                .isPublic(true)
+                .category(Category.HEALTH)
+                .isViewerMode(false)
+                .maxParticipants(10)
+                .title("TDD Challenge")
+                .description("absence counting test")
+                .startDate(LocalDateTime.of(today, LocalTime.MIDNIGHT))
+                .verificationType(VerificationType.TEXT)
+                .verifyStartTime(LocalTime.of(9, 0))
+                .verifyEndTime(LocalTime.of(22, 0))
+                .currentParticipants(1)
+                .status(ChallengeStatus.ONGOING)
+                .build());
+
+        // 인증 요일 추가 (어제 요일)
+        ChallengeDayJoin dayJoin = ChallengeDayJoin.builder()
+                .challenge(challenge)
+                .dayOfWeek(yesterdayChallengeDay)
+                .build();
+        challenge.getChallengeDays().add(dayJoin);
+        challenge = challengeRepository.save(challenge);
+
+        // 라운드 생성: 시작일은 오늘, 종료일은 3주 뒤
+        Round round = roundRepository.save(Round.builder()
+                .challenge(challenge)
+                .roundNumber(1)
+                .startDate(today)
+                .endDate(today.plusWeeks(3))
+                .build());
+
+        // 챌린지의 currentRound를 설정
+        challenge.changeCurrentRound(round);
+        challenge = challengeRepository.save(challenge);
+
+        // 유저의 챌린지 참여 (JOINED)
+        UserChallenge uc = userChallengeRepository.save(UserChallenge.builder()
+                .user(user)
+                .challenge(challenge)
+                .build());
+
+        // 라운드 레코드 생성
+        roundRecordRepository.save(RoundRecord.builder()
+                .round(round)
+                .userChallenge(uc)
+                .build());
+
+        // when: 어제 날짜로 미인증 대상 조회
+        List<RoundRecord> absentees = roundRecordRepository.findAbsentees(yesterdayChallengeDay, yesterday);
+
+        // then: 라운드 시작 전 날짜이므로 집계되면 안 된다
+        // 현재 구현에서는 날짜 범위 검증이 빠져 있어 실패가 예상됨 (TDD용 실패 테스트)
+        assertThat(absentees).isEmpty();
+    }
+}
+

--- a/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
+++ b/src/test/java/com/hrr/backend/domain/verification/VerificationAbsenceRepositoryTest.java
@@ -128,5 +128,84 @@ class VerificationAbsenceRepositoryTest {
 		// -> 라운드 기간 내 날짜만 미인증 집계 대상이 되도록 수정하여 테스트 통과
         assertThat(absentees).isEmpty();
     }
+
+	@Test
+	@DisplayName("라운드 전환 시점에도 어제 날짜를 포함하는 이전 라운드 레코드를 정확히 조회한다")
+	void shouldCountAbsence_WhenRoundTransitions() {
+		// given
+		LocalDate today = LocalDate.now();
+		LocalDate yesterday = today.minusDays(1);
+		ChallengeDays yesterdayChallengeDay = ChallengeDays.from(yesterday.getDayOfWeek());
+
+		// 1. 유저 및 챌린지 설정 (상태: ONGOING)
+		User user = userRepository.save(User.builder()
+			.name("transition_tester")
+			.nickname("transition_nick")
+			.isPublic(true)
+			.build());
+
+		Challenge challenge = challengeRepository.save(Challenge.builder()
+			.isPublic(true)
+			.category(Category.HEALTH)
+			.isViewerMode(false)
+			.maxParticipants(10)
+			.currentParticipants(1)
+			.title("Transition Test Challenge")
+			.description("transition test description")
+			.startDate(yesterday.atStartOfDay().minusDays(7))
+			.verificationType(VerificationType.TEXT)
+			.verifyStartTime(LocalTime.of(9, 0))
+			.verifyEndTime(LocalTime.of(22, 0))
+			.status(ChallengeStatus.ONGOING)
+			.build());
+
+		// 어제 요일을 인증 요일에 포함
+		ChallengeDayJoin dayJoin = ChallengeDayJoin.builder()
+			.challenge(challenge)
+			.dayOfWeek(yesterdayChallengeDay)
+			.build();
+		challenge.getChallengeDays().add(dayJoin);
+		challengeRepository.save(challenge);
+
+		// 2. 라운드 설정: 라운드 2(어제가 종료일) -> 라운드 3(오늘이 시작일)
+		Round round2 = roundRepository.save(Round.builder()
+			.challenge(challenge)
+			.roundNumber(2)
+			.startDate(yesterday.minusDays(6))
+			.endDate(yesterday) // 어제가 마지막 날
+			.build());
+
+		Round round3 = roundRepository.save(Round.builder()
+			.challenge(challenge)
+			.roundNumber(3)
+			.startDate(today) // 오늘부터 시작
+			.endDate(today.plusDays(6))
+			.build());
+
+		// 챌린지의 현재 라운드를 이미 라운드 3으로 변경 (스케줄러에 의해 이미 넘어간 상황 시뮬레이션)
+		challenge.changeCurrentRound(round3);
+		challengeRepository.save(challenge);
+
+		// 3. 참여 정보 및 라운드 레코드 생성
+		UserChallenge uc = userChallengeRepository.save(UserChallenge.builder()
+			.user(user)
+			.challenge(challenge)
+			.build());
+
+		// 라운드 2에 대한 레코드 생성 (이전 라운드 미인증을 체크해야 함)
+		RoundRecord rr2 = roundRecordRepository.save(RoundRecord.builder()
+			.round(round2)
+			.userChallenge(uc)
+			.build());
+
+		// when: 어제 날짜로 미인증 대상 조회
+		List<RoundRecord> absentees = roundRecordRepository.findAbsentees(yesterdayChallengeDay, yesterday);
+
+		// then: 현재 라운드는 3이지만, 어제 날짜를 포함했던 라운드 2의 레코드가 조회되어야 함
+		assertThat(absentees).hasSize(1);
+		assertThat(absentees.get(0).getRound().getRoundNumber()).isEqualTo(2);
+		assertThat(absentees.get(0).getId()).isEqualTo(rr2.getId());
+	}
+
 }
 

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:test
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;INIT=CREATE DOMAIN IF NOT EXISTS TEXT AS CLOB\;CREATE DOMAIN IF NOT EXISTS LONGBLOB AS BLOB
     driver-class-name: org.h2.Driver
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #313

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

확인 결과: 챌린지 상태는 반영하고 있었음

실제 문제 원인: 스케줄러 실행 시점의 챌린지 상태가 ONGOING이면 챌린지 시작 전날이나 라운드 교체 시점을 구분하지 못하고 인증 요일 여부만 확인하여 잘못 집계됨.

- 문제 상황 1: 챌린지 시작일이 3일인 경우, 3일 00:05 스케줄러는 어제인 2일의 인증 여부를 확인. 이때 챌린지 상태가 이미 ONGOING이므로, 시작 전인 2일을 미인증으로 처리하여 유저가 억울하게 경고를 받음
- 문제 상황 2: 2일이 2라운드 마지막 날이고 3일이 3라운드 시작일일 때, 3일 00:05에는 현재 라운드가 3라운드. 기존 로직은 currentRound만 확인하므로, 2라운드의 마지막 날(2일) 미인증 기록을 찾지 못하고 누락됨

-> 라운드 전환 시점에도 미인증은 기록하고 넘어가야 한다고 생각하여 로직 수정

해결 방식: 쿼리에 어제 날짜(인증 여부 판단 대상 날짜) 기준, 실제 해당 라운드 기간(startDate ~ endDate) 내에 포함되는지 확인하는 조건을 추가

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등) 로컬
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등) 통합 테스트
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료) 테스트 통과

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 수정 전 | 수정 후 |
|---|---|
|<img width="1490" height="393" alt="image" src="https://github.com/user-attachments/assets/451930e7-6de7-404c-a722-b86d585dd62a" />|<img width="1007" height="367" alt="image" src="https://github.com/user-attachments/assets/48eb382e-b936-4a19-8b47-a315010deb47" />|

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

사실 기능 구현 테스트를 위해서는 통합 테스트를 하는 게 맞는데, 지금까지 테스트 환경 이슈로 단위 테스트만 했던 걸로 알고 있습니다.
임시방편으로 환경을 강제 변경하니 저는 통과해서 이후에는 통합 테스트도 적극 활용해주시면 감사하겠습니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 특정 날짜에 실제로 활성화된 라운드만 조회되도록 부재 집계 로직의 날짜 검증 강화

* **Tests**
  * 부재(결석) 집계 흐름을 검증하는 통합 테스트 추가
  * 테스트 환경 데이터베이스 설정을 MySQL 호환 모드로 조정하여 테스트 신뢰성 향상
<!-- end of auto-generated comment: release notes by coderabbit.ai -->