### PR TITLE
[Fix] 비공개 챌린지 인증글 조회되는 문제 해결

### DIFF
--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
@@ -174,4 +174,29 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             Pageable pageable
     );
 
+    /**
+     * 사용자의 전체 챌린지 인증 기록 조회 (비공개 챌린지 필터링)
+     */
+    @Query("""
+    SELECT v FROM Verification v
+    JOIN FETCH v.roundRecord rr
+    JOIN FETCH rr.userChallenge uc
+    JOIN FETCH uc.challenge c
+    WHERE uc.user = :user
+    AND v.status = :status
+    AND (c.isPublic = true OR EXISTS (
+        SELECT 1 FROM UserChallenge uc2
+        WHERE uc2.challenge = c
+        AND uc2.user.id = :currentUserId
+        AND uc2.status = 'JOINED'
+    ))
+    ORDER BY v.createdAt DESC
+""")
+    Slice<Verification> findFilteredVerificationHistory(
+            @Param("user") User user,
+            @Param("currentUserId") Long currentUserId,
+            @Param("status") VerificationStatus status,
+            Pageable pageable
+    );
+
 }

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -382,7 +382,7 @@ public class VerificationServiceImpl implements VerificationService {
         // 3. 권한 체크용 변수 설정
         boolean isMine = currentUserId != null && author.getId().equals(currentUserId);
 
-        // 4. [보안 추가] 비공개 챌린지 접근 제한 로직
+        // 4. 비공개 챌린지 접근 제한 로직
         if (Boolean.FALSE.equals(challenge.getIsPublic())) {
             // 내가 참여 중(JOINED)인지 확인
             boolean isJoined = currentUserId != null &&
@@ -397,7 +397,7 @@ public class VerificationServiceImpl implements VerificationService {
         }
 
         // 5.현재 사용자가 로그인한 경우 차단 관계 확인
-        if (author.getUserStatus() != UserStatus.ACTIVE || author.isNotActive()) {
+        if (author.isNotActive()) {
             throw new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND);
         }
 

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -376,20 +376,31 @@ public class VerificationServiceImpl implements VerificationService {
         }
 
         RoundRecord roundRecord = verification.getRoundRecord();
-        UserChallenge userChallenge = roundRecord.getUserChallenge();
-        User author = userChallenge.getUser();
+        User author = roundRecord.getUserChallenge().getUser();
+        Challenge challenge = roundRecord.getRound().getChallenge();
 
-        // ===== 추가: 작성자 상태 확인 (탈퇴/차단) =====
-        // 1. 작성자가 탈퇴한 경우
-        if (author.getUserStatus() != UserStatus.ACTIVE) {
+        // 3. 권한 체크용 변수 설정
+        boolean isMine = currentUserId != null && author.getId().equals(currentUserId);
+
+        // 4. [보안 추가] 비공개 챌린지 접근 제한 로직
+        if (Boolean.FALSE.equals(challenge.getIsPublic())) {
+            // 내가 참여 중(JOINED)인지 확인
+            boolean isJoined = currentUserId != null &&
+                    userChallengeRepository.findByUserIdAndChallengeId(currentUserId, challenge.getId())
+                            .map(uc -> uc.getStatus() == ChallengeJoinStatus.JOINED)
+                            .orElse(false);
+
+            // 작성자 본인도 아니고, 참여자도 아니라면 접근 거부
+            if (!isMine && !isJoined) {
+                throw new GlobalException(ErrorCode.VERIFICATION_ACCESS_DENIED);
+            }
+        }
+
+        // 5.현재 사용자가 로그인한 경우 차단 관계 확인
+        if (author.getUserStatus() != UserStatus.ACTIVE || author.isNotActive()) {
             throw new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND);
         }
 
-        if (author.isNotActive()) {
-            throw new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND);
-        }
-
-        // 2. 현재 사용자가 로그인한 경우 차단 관계 확인
         if (currentUserId != null) {
             // 내가 작성자를 차단한 경우
             boolean iBlockedAuthor = userBlockRepository.existsByBlockerIdAndBlockedId(currentUserId, author.getId());
@@ -404,7 +415,6 @@ public class VerificationServiceImpl implements VerificationService {
             }
         }
 
-        boolean isMine = currentUserId != null && author.getId().equals(currentUserId);
         boolean isResolved = Boolean.TRUE.equals(verification.getIsResolved());
         boolean canEdit = isMine && !isResolved;
         boolean canDelete = isMine && !isResolved;

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -747,9 +747,11 @@ public class VerificationServiceImpl implements VerificationService {
         // 공개 계정
         Pageable pageable = PageRequest.of(page, size);
 
+        // 비공개 챌린지 인증 기록은 현재 사용자가 해당 챌린지의 JOINED 참여자인 경우에만 노출
         Slice<Verification> verificationSlice =
-                verificationRepository.findVerificationHistoryByUser(
+                verificationRepository.findFilteredVerificationHistory(
                         targetUser,
+                        currentUser.getId(),
                         VerificationStatus.COMPLETED,
                         pageable);
 

--- a/src/test/java/com/hrr/backend/domain/verification/service/VerificationServiceIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/verification/service/VerificationServiceIntegrationTest.java
@@ -1,0 +1,160 @@
+package com.hrr.backend.domain.verification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.entity.enums.UserStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.domain.verification.entity.Verification;
+import com.hrr.backend.domain.verification.repository.VerificationRepository;
+import com.hrr.backend.global.common.enums.Category;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.common.enums.VerificationType;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+
+@SpringBootTest
+@Transactional
+class VerificationServiceIntegrationTest {
+
+    @Autowired private VerificationService verificationService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private ChallengeRepository challengeRepository;
+    @Autowired private UserChallengeRepository userChallengeRepository;
+    @Autowired private RoundRepository roundRepository;
+    @Autowired private RoundRecordRepository roundRecordRepository;
+    @Autowired private VerificationRepository verificationRepository;
+
+    private User author;
+    private Challenge privateChallenge;
+    private Verification privateVerification;
+
+    @BeforeEach
+    void setUp() {
+        // 공통 Given
+        // 1. 작성자 생성
+        author = userRepository.save(User.builder()
+                .nickname("author")
+                .isPublic(true)
+                .userStatus(UserStatus.ACTIVE)
+                .build());
+
+        // 2. 비공개 챌린지 생성
+        privateChallenge = challengeRepository.save(Challenge.builder()
+                .title("비공개 챌린지")
+                .description("테스트용 챌린지")
+                .isPublic(false)
+                .category(Category.STUDY)
+                .isViewerMode(false)
+                .maxParticipants(10)
+                .currentParticipants(1)
+                .startDate(LocalDateTime.now())
+                .verificationType(VerificationType.TEXT)
+                .verifyStartTime(LocalTime.of(0, 0))
+                .verifyEndTime(LocalTime.of(23, 59))
+                .status(ChallengeStatus.ONGOING)
+                .build());
+
+        // 3. 작성자 참여 및 라운드 세팅
+        UserChallenge authorJoin = userChallengeRepository.save(UserChallenge.builder()
+                .user(author)
+                .challenge(privateChallenge)
+                .status(ChallengeJoinStatus.JOINED)
+                .build());
+
+        Round round = roundRepository.save(Round.builder()
+                .challenge(privateChallenge)
+                .roundNumber(1)
+                .startDate(LocalDate.now())
+                .endDate(LocalDate.now().plusWeeks(3))
+                .build());
+        privateChallenge.changeCurrentRound(round);
+
+        RoundRecord record = roundRecordRepository.save(RoundRecord.builder()
+                .userChallenge(authorJoin)
+                .round(round)
+                .build());
+
+        // 4. 비공개 인증글 생성
+        privateVerification = verificationRepository.save(Verification.createTextVerification(
+                authorJoin, record, "비밀글", "내용", null, null, false, round.getId()));
+    }
+
+    @Test
+    @DisplayName("비공개 챌린지 상세조회: 작성자 본인은 조회가 가능하다")
+    void getDetail_Success_WhenIsMine() {
+        // given
+        Long verificationId = privateVerification.getId();
+        Long currentUserId = author.getId();
+
+        // when
+        var result = verificationService.getVerificationDetail(verificationId, currentUserId, 0, 10);
+
+        // then
+        assertThat(result.getVerificationId()).isEqualTo(verificationId);
+        assertThat(result.getIsMine()).isTrue();
+    }
+
+    @Test
+    @DisplayName("비공개 챌린지 상세조회: 참여하지 않은 외부인은 예외가 발생한다")
+    void getDetail_Fail_WhenStranger() {
+        // given
+        User stranger = userRepository.save(User.builder().nickname("stranger").userStatus(UserStatus.ACTIVE).build());
+
+        // when & then
+        assertThatThrownBy(() ->
+                verificationService.getVerificationDetail(privateVerification.getId(), stranger.getId(), 0, 10)
+        ).isInstanceOf(GlobalException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.VERIFICATION_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("비공개 챌린지 상세조회: 참여 중인 다른 멤버는 조회가 가능하다")
+    void getDetail_Success_WhenIsMember() {
+        // given
+        User member = userRepository.save(User.builder().nickname("member").userStatus(UserStatus.ACTIVE).build());
+        userChallengeRepository.save(UserChallenge.builder()
+                .user(member).challenge(privateChallenge).status(ChallengeJoinStatus.JOINED).build());
+
+        // when
+        var result = verificationService.getVerificationDetail(privateVerification.getId(), member.getId(), 0, 10);
+
+        // then
+        assertThat(result.getVerificationId()).isEqualTo(privateVerification.getId());
+        assertThat(result.getIsMine()).isFalse();
+    }
+
+    @Test
+    @DisplayName("타인 히스토리 조회: 참여하지 않은 비공개 챌린지 글은 목록에서 필터링된다")
+    void getHistory_FilterPrivate() {
+        // given
+        User stranger = userRepository.save(User.builder().nickname("stranger").isPublic(true).userStatus(UserStatus.ACTIVE).build());
+
+        // when
+        var response = verificationService.getOtherUserVerificationHistory(author.getId(), stranger, 0, 10);
+
+        // then
+        assertThat(response.getVerifications().getContent()).isEmpty();
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,6 @@
 spring:
   datasource:
-    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;INIT=CREATE DOMAIN IF NOT EXISTS TEXT AS CLOB\;CREATE DOMAIN IF NOT EXISTS LONGBLOB AS BLOB
+    url: jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;CASE_INSENSITIVE_IDENTIFIERS=TRUE;INIT=CREATE DOMAIN IF NOT EXISTS TEXT AS CLOB\;CREATE DOMAIN IF NOT EXISTS LONGBLOB AS BLOB
     driver-class-name: org.h2.Driver
   jpa:
     database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #이슈번호

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

본인이 참여하지 않은 비공개 챌린지의 인증글이 조회되는 문제를 해결하였습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 통합 테스트
* **결과 요약:** 모든 테스트 통과


---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

<img width="453" height="150" alt="image" src="https://github.com/user-attachments/assets/c4104e7f-b3e9-4492-9fca-cd23a9857dce" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


globally_quoted_identifiers 설정으로 인해 DB 컬럼이 소문자로 생성되지만 @SQLRestriction 내 Raw SQL이 이를 대문자로 참조하여 발생하는 Column not found 에러를 있었고, 엔티티 코드를 수정하는 대신 H2 연결 옵션(CASE_INSENSITIVE_IDENTIFIERS=TRUE)을 통해 대소문자 구분 없이 식별자를 인식하도록 개선했습니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 비공개 챌린지 검증 접근 제어 강화 — 작성자 및 해당 챌린지에 참여한 사용자만 상세 조회 가능
  * 사용자별 검증 히스토리 필터링 개선 — 조회자 권한 및 챌린지 공개 여부에 따라 결과가 맞춤 제공

* **테스트**
  * 통합 테스트 추가로 접근 제어 및 히스토리 필터링 동작 검증
  * 테스트 DB 설정 개선으로 테스트 환경 안정화
<!-- end of auto-generated comment: release notes by coderabbit.ai -->