### PR TITLE
[Feat] 인증 통계 산출 기준 변경

### DIFF
--- a/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
+++ b/src/main/java/com/hrr/backend/domain/auth/service/AuthService.java
@@ -300,6 +300,8 @@ public class AuthService {
         // 챌린지 참여 상태 즉시 변경 로직 제거
         // → 탈퇴는 비활성화와 동일한 개념이므로 30일 유예기간 동안 재활성화 가능
         //   유예기간 중 챌린지 상태를 유지해야 재활성화 시 정상 복구됨
+        //   즉시 탈퇴 처리로 발생한 공석을 타 유저가 선점할 경우,
+        //   서비스 복귀 시 정원 초과로 인한 복구 실패를 방지하기 위함
 
         // AT 블랙리스트 처리 (남은 유효기간 동안 재사용 방지)
         Duration remainingExpiration = jwtService.getRemainingExpiration(token);

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -93,14 +93,7 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
             @Param("user") User user,
             @Param("roundId") Long roundId
     );
-
-	// 챌린지의 특정 라운드의 현재 참가 인원을 조회하는데, 유저의 특정 상태로 필터링 - 인증 통계 조회를 위함
-	// 다음 라운드 연장을 하지 않더라도(ChallengeJoinStatus=DROPPED) 인증 통계의 총인원에는 포함되어야 하기에 해당 enum은 쿼리에 포함시키지 않음
-	@Query("SELECT COUNT(rr) FROM RoundRecord rr " +
-		"WHERE rr.round.id = :roundId " +
-		"AND rr.userChallenge.user.userStatus = :status")
-	int countParticipantsByRoundAndUserStatus(@Param("roundId") Long roundId, @Param("status") UserStatus status);
-
+	
 	// 라운드가 진행 중인 챌린지에 참여 중인 유저가 어제 인증요일이었는데 미인증 한 사실이 있는지 조회
 	@Query("SELECT rr FROM RoundRecord rr " +
 		"JOIN rr.userChallenge uc " +
@@ -143,5 +136,21 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
 			@Param("verificationStatus") VerificationStatus verificationStatus,
 			@Param("startOfDay") LocalDateTime startOfDay,
 			@Param("endOfDay") LocalDateTime endOfDay
+	);
+
+	/**
+	 * 챌린지의 특정 라운드에서 특정 참여 상태(JOINED)인 총 인원 조회
+	 * (탈퇴자 포함, 퇴출자 제외)
+	 */
+	@Query("""
+    SELECT COUNT(rr)
+    FROM RoundRecord rr
+    JOIN rr.userChallenge uc
+    WHERE rr.round.id = :roundId
+    AND uc.status = :status
+""")
+	int countByRoundIdAndJoinStatus(
+			@Param("roundId") Long roundId,
+			@Param("status") ChallengeJoinStatus status
 	);
 }

--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.verification.repository;
 
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.entity.enums.UserStatus;
 import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
@@ -50,25 +51,6 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
     LocalDateTime findLatestVerificationTime(
             @Param("roundId") Long roundId,
             @Param("status") VerificationStatus status
-    );
-
-    // 특정 날짜(범위)의 인증 인원 수 (중복 제거, COMPLETED 상태만)
-    @Query("""
-    SELECT COUNT(DISTINCT r.userChallenge.id) FROM Verification v 
-    JOIN v.roundRecord r 
-    JOIN r.userChallenge uc 
-    JOIN uc.user u 
-    WHERE r.round.id = :roundId 
-    AND v.status = :status 
-    AND u.userStatus = :userStatus 
-    AND v.createdAt BETWEEN :start AND :end
-""")
-    Long countDistinctCertifiers(
-            @Param("roundId") Long roundId,
-            @Param("status") VerificationStatus status,
-            @Param("userStatus") UserStatus userStatus,
-            @Param("start") LocalDateTime start,
-            @Param("end") LocalDateTime end
     );
 
     @Query("SELECT v FROM Verification v " +
@@ -172,6 +154,28 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             @Param("user") User user,
             @Param("status") VerificationStatus status,
             Pageable pageable
+    );
+
+    /**
+     * 챌린지의 특정 라운드에서 특정 참여 상태(JOINED)인 인원 중 인증한 인원 조회
+     * (탈퇴자 포함, 퇴출자 제외)
+     */
+    @Query("""
+    SELECT COUNT(DISTINCT uc.id)
+    FROM Verification v
+    JOIN v.roundRecord r
+    JOIN r.userChallenge uc
+    WHERE r.round.id = :roundId
+    AND v.status = :status
+    AND uc.status = :joinStatus
+    AND v.createdAt BETWEEN :start AND :end
+""")
+    Long countDistinctCertifiers(
+            @Param("roundId") Long roundId,
+            @Param("status") VerificationStatus status,
+            @Param("joinStatus") ChallengeJoinStatus joinStatus,
+            @Param("start") LocalDateTime start,
+            @Param("end") LocalDateTime end
     );
 
 }

--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationRepository.java
@@ -140,6 +140,22 @@ public interface VerificationRepository extends JpaRepository<Verification, Long
             Pageable pageable
     );
 
+    /**
+     * 사용자의 전체 챌린지 인증 기록 조회 (페이징)
+     */
+    @Query("SELECT v FROM Verification v " +
+            "JOIN FETCH v.roundRecord rr " +
+            "JOIN FETCH rr.userChallenge uc " +
+            "JOIN FETCH uc.challenge c " +
+            "WHERE uc.user = :user " +
+            "AND v.status = :status " +
+            "ORDER BY v.createdAt DESC")
+    Slice<Verification> findVerificationHistoryByUser(
+            @Param("user") User user,
+            @Param("status") VerificationStatus status,
+            Pageable pageable
+    );
+
      /**
      * 챌린지의 특정 라운드에서 특정 참여 상태(JOINED)인 인원 중 인증한 인원 조회
      * (탈퇴자 포함, 퇴출자 제외)

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -121,10 +121,14 @@ public class VerificationServiceImpl implements VerificationService {
             return verificationConverter.toStatDto(0, 0, null);
         }
 
-		// 인증 통계에서의 총인원은 '인증을 해야할 인원'을 의미하므로, 현재 라운드에 참가 중이면서 비활성이나 탈퇴 상태가 아닌 유저만 조회
-		Integer totalParticipantCount = roundRecordRepository.countParticipantsByRoundAndUserStatus(currentRound.getId(), UserStatus.ACTIVE);
+		// 퇴출된 유저 제외하고 조회
+        // 탈퇴 후 재활성화 가능 기간을 고려하여, 비활성(INACTIVE) 유저도 참여 상태가 유지되는 한 통계에 포함함
+        Integer totalParticipantCount = roundRecordRepository.countByRoundIdAndJoinStatus(
+                currentRound.getId(),
+                ChallengeJoinStatus.JOINED
+        );
 
-        // [수정] 실시간 현황 체크: 인증 요일/시간대가 아니면 null 반환
+        // 인증 요일/시간대가 아니면 null 반환
         LocalDateTime targetDateTime = determineTargetDateTime(challenge);
 
         if (targetDateTime == null) {
@@ -134,11 +138,11 @@ public class VerificationServiceImpl implements VerificationService {
 
         LocalDate targetDate = targetDateTime.toLocalDate();
 
-        // 인증자 중 현재 ACTIVE 상태인 유저만 집계 - 자동으로 비활성화 유저는 집계에서 제외됨
+        // 인증한 사람 중 퇴출한 유저 제외
         Long certifiedCount = verificationRepository.countDistinctCertifiers(
                 currentRound.getId(),
                 VerificationStatus.COMPLETED,
-                UserStatus.ACTIVE,
+                ChallengeJoinStatus.JOINED,
                 targetDate.atStartOfDay(),
                 targetDate.atTime(LocalTime.MAX)
         );


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #322

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

통계 로직 개선: 계정 상태(UserStatus)가 아닌 챌린지 참여 상태(ChallengeJoinStatus)를 기준으로 통계를 산출하도록 변경하여, 탈퇴 유저(INACTIVE)는 포함하고 퇴출 유저(KICKED)는 제외했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬 DB
* **테스트 방법:** SQL 직접 삽입을 통한 시나리오 검증
* **결과 요약:**
* **시나리오**: 활성 유저 2명 + 탈퇴 유저 1명 + 퇴출 유저 1명 (총 4명 참여 중)
* **기대 결과**: 전체 대상 3명, 오늘 인증 1명 -> 결과 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

<img width="1164" height="434" alt="image" src="https://github.com/user-attachments/assets/b2b1be9f-433e-4f42-8ec1-1952e534ca3c" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 참가자 집계 및 인증 통계의 기준을 사용자 계정 상태에서 참가의 조인 상태(예: JOINED)로 전환하여 라운드별 참여자 수와 인증자 수 계산이 더 일관되고 정확해졌습니다.
* **Documentation**
  * 즉시 탈퇴 시 발생할 수 있는 동시성 영향 등 의도를 명확히 하는 주석을 정리했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->