### PR TITLE
[Refactor] 챌린지 참가 로직 동시성 제어 적용

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/repository/ChallengeRepository.java
@@ -6,7 +6,9 @@ import java.util.Optional;
 
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -32,6 +34,17 @@ public interface ChallengeRepository extends JpaRepository<Challenge, Long>, Cha
 	// 요일 정보(ChallengeDays)까지 한 번에 가져오는 Fetch Join 쿼리
 	@Query("SELECT c FROM Challenge c LEFT JOIN FETCH c.challengeDays WHERE c.id = :id")
 	Optional<Challenge> findByIdWithDays(@Param("id") Long id);
+
+	/**
+	 * 챌린지 참가 처리 시 참가자 수 정합성 보장을 위한 비관적 락 조회
+	 */
+	@Lock(LockModeType.PESSIMISTIC_WRITE)
+	@Query("""
+		SELECT c
+		FROM Challenge c
+		WHERE c.id = :challengeId
+	""")
+	Optional<Challenge> findByIdForUpdate(@Param("challengeId") Long challengeId);
 
 	/**
 	 * 기준 시각 이전(포함)의 UPCOMING 챌린지 ID 조회

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -462,8 +462,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 			Long challengeId,
 			ChallengeRequestDto.JoinChallengeDto req
 	) {
-		// 챌린지 조회
-		Challenge challenge = findChallenge(challengeId);
+		// 정원 초과 방지를 위한 락 조회
+		Challenge challenge = findChallengeForUpdate(challengeId);
 
 		// 비즈니스 룰 검증
 		validateJoinRequest(challenge, user, req.getPassword());
@@ -723,6 +723,14 @@ public class ChallengeServiceImpl implements ChallengeService {
 	// 챌린지 일반 조회용
 	private Challenge findChallenge(Long challengeId) {
 		return challengeRepository.findById(challengeId)
+				.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
+	}
+
+	/**
+	 * 챌린지 참가 시 참가자 수 정합성 보장을 위한 락 조회
+	 */
+	private Challenge findChallengeForUpdate(Long challengeId) {
+		return challengeRepository.findByIdForUpdate(challengeId)
 				.orElseThrow(() -> new GlobalException(ErrorCode.CHALLENGE_NOT_FOUND));
 	}
 

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
@@ -1,0 +1,227 @@
+package com.hrr.backend.domain.challenge.service;
+
+import com.hrr.backend.domain.challenge.dto.ChallengeRequestDto;
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.challenge.repository.ChallengeStaticsRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.global.common.enums.Category;
+import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.common.enums.VerificationType;
+import jakarta.persistence.EntityManager;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class ChallengeJoinConcurrencyIntegrationTest {
+
+    private static final int MAX_PARTICIPANTS = 30;
+    private static final int INITIAL_PARTICIPANTS = 29;
+    private static final int CONCURRENT_REQUESTS = 50;
+    private static final AtomicInteger USER_SEQUENCE = new AtomicInteger();
+
+    @Autowired private ChallengeService challengeService;
+    @Autowired private ChallengeRepository challengeRepository;
+    @Autowired private ChallengeStaticsRepository challengeStaticsRepository;
+    @Autowired private RoundRepository roundRepository;
+    @Autowired private RoundRecordRepository roundRecordRepository;
+    @Autowired private UserRepository userRepository;
+    @Autowired private UserChallengeRepository userChallengeRepository;
+    @Autowired private TransactionTemplate transactionTemplate;
+    @Autowired private EntityManager entityManager;
+
+    @BeforeEach
+    void setUp() {
+        cleanDatabase();
+    }
+
+    @AfterEach
+    void tearDown() {
+        cleanDatabase();
+    }
+
+    @Test
+    @DisplayName("joinChallenge 동시 호출 시 최종 참가자 수가 정원을 초과하지 않는다")
+    void joinChallenge_WithPessimisticLock_DoesNotAllowOverCapacity() throws InterruptedException {
+        Long challengeId = createChallengeWithCurrentRoundAndParticipants();
+        List<Long> userIds = createUsers("joiner", CONCURRENT_REQUESTS);
+
+        AtomicInteger successCount = new AtomicInteger();
+        AtomicInteger failureCount = new AtomicInteger();
+        CountDownLatch startLatch = new CountDownLatch(1);
+        CountDownLatch endLatch = new CountDownLatch(CONCURRENT_REQUESTS);
+        ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
+
+        for (Long userId : userIds) {
+            executorService.submit(() -> {
+                try {
+                    startLatch.await();
+
+                    User user = userRepository.findById(userId).orElseThrow();
+                    ChallengeRequestDto.JoinChallengeDto request = new ChallengeRequestDto.JoinChallengeDto();
+
+                    challengeService.joinChallenge(user, challengeId, request);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                } finally {
+                    endLatch.countDown();
+                }
+            });
+        }
+
+        startLatch.countDown();
+
+        boolean completed = endLatch.await(20, TimeUnit.SECONDS);
+        executorService.shutdown();
+        boolean terminated = executorService.awaitTermination(10, TimeUnit.SECONDS);
+
+        assertThat(completed).as("모든 joinChallenge 요청이 제한 시간 안에 완료되어야 한다").isTrue();
+        assertThat(terminated).as("ExecutorService가 정상 종료되어야 한다").isTrue();
+
+        entityManager.clear();
+
+        Challenge challenge = challengeRepository.findById(challengeId).orElseThrow();
+        long joinedCount = userChallengeRepository.countByChallengeIdAndStatus(
+                challengeId,
+                ChallengeJoinStatus.JOINED
+        );
+
+        printResult(challenge.getCurrentParticipants(), joinedCount, successCount.get(), failureCount.get());
+
+        assertThat(successCount.get() + failureCount.get())
+                .as("성공/실패 요청 수 합계")
+                .isEqualTo(CONCURRENT_REQUESTS);
+        assertThat(challenge.getCurrentParticipants())
+                .as("Challenge.currentParticipants는 정원까지만 증가해야 한다")
+                .isEqualTo(MAX_PARTICIPANTS);
+        assertThat(joinedCount)
+                .as("JOINED 상태 UserChallenge 개수는 정원과 같아야 한다")
+                .isEqualTo(MAX_PARTICIPANTS);
+        assertThat(joinedCount)
+                .as("JOINED 상태 UserChallenge 개수는 maxParticipants를 초과하면 안 된다")
+                .isLessThanOrEqualTo(challenge.getMaxParticipants());
+    }
+
+    private Long createChallengeWithCurrentRoundAndParticipants() {
+        return transactionTemplate.execute(status -> {
+            LocalDate startDate = LocalDate.now();
+
+            Challenge challenge = challengeRepository.save(Challenge.builder()
+                    .title("concurrency")
+                    .description("join race test")
+                    .isPublic(true)
+                    .isViewerMode(false)
+                    .category(Category.HEALTH)
+                    .verificationType(VerificationType.TEXT)
+                    .startDate(LocalDateTime.of(startDate, LocalTime.MIDNIGHT))
+                    .verifyStartTime(LocalTime.of(9, 0))
+                    .verifyEndTime(LocalTime.of(22, 0))
+                    .maxParticipants(MAX_PARTICIPANTS)
+                    .currentParticipants(INITIAL_PARTICIPANTS)
+                    .status(ChallengeStatus.RECRUITING)
+                    .imageKey("test-image-key")
+                    .build());
+
+            Round currentRound = roundRepository.save(Round.builder()
+                    .challenge(challenge)
+                    .roundNumber(1)
+                    .startDate(startDate)
+                    .endDate(startDate.plusWeeks(Challenge.ROUND_WEEKS).minusDays(1))
+                    .build());
+
+            challenge.changeCurrentRound(currentRound);
+
+            List<User> existingUsers = createUsersInCurrentTransaction("existing", INITIAL_PARTICIPANTS);
+            for (User user : existingUsers) {
+                UserChallenge userChallenge = userChallengeRepository.save(UserChallenge.builder()
+                        .user(user)
+                        .challenge(challenge)
+                        .status(ChallengeJoinStatus.JOINED)
+                        .build());
+
+                roundRecordRepository.save(RoundRecord.builder()
+                        .round(currentRound)
+                        .userChallenge(userChallenge)
+                        .build());
+            }
+
+            return challenge.getId();
+        });
+    }
+
+    private List<Long> createUsers(String prefix, int count) {
+        return transactionTemplate.execute(status ->
+                createUsersInCurrentTransaction(prefix, count).stream()
+                        .map(User::getId)
+                        .toList()
+        );
+    }
+
+    private List<User> createUsersInCurrentTransaction(String prefix, int count) {
+        List<User> users = new ArrayList<>();
+
+        for (int i = 0; i < count; i++) {
+            String uniqueName = prefix + "_" + USER_SEQUENCE.incrementAndGet();
+            users.add(userRepository.save(User.builder()
+                    .name(uniqueName)
+                    .nickname(uniqueName)
+                    .isPublic(true)
+                    .build()));
+        }
+
+        return users;
+    }
+
+    private void printResult(Integer currentParticipants, long joinedCount, int successCount, int failureCount) {
+        System.out.println();
+        System.out.println("========== joinChallenge concurrency test result ==========");
+        System.out.printf("Challenge.currentParticipants : %d%n", currentParticipants);
+        System.out.printf("JOINED UserChallenge count    : %d%n", joinedCount);
+        System.out.printf("success request count         : %d%n", successCount);
+        System.out.printf("failure request count         : %d%n", failureCount);
+        System.out.println("===========================================================");
+        System.out.println();
+    }
+
+    private void cleanDatabase() {
+        transactionTemplate.executeWithoutResult(status -> {
+            challengeStaticsRepository.deleteAll();
+            roundRecordRepository.deleteAll();
+            roundRepository.deleteAll();
+            userChallengeRepository.deleteAll();
+            challengeRepository.deleteAll();
+            userRepository.deleteAll();
+        });
+    }
+}

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
@@ -116,6 +116,10 @@ class ChallengeJoinConcurrencyIntegrationTest {
         executorService.shutdown();
         boolean terminated = executorService.awaitTermination(10, TimeUnit.SECONDS);
 
+        if (!terminated) {
+            executorService.shutdownNow();
+        }
+
         assertThat(completed).as("모든 joinChallenge 요청이 제한 시간 안에 완료되어야 한다").isTrue();
         assertThat(terminated).as("ExecutorService가 정상 종료되어야 한다").isTrue();
 

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeJoinConcurrencyIntegrationTest.java
@@ -16,6 +16,8 @@ import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.global.common.enums.Category;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
 import com.hrr.backend.global.common.enums.VerificationType;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,6 +33,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
@@ -78,6 +81,7 @@ class ChallengeJoinConcurrencyIntegrationTest {
 
         AtomicInteger successCount = new AtomicInteger();
         AtomicInteger failureCount = new AtomicInteger();
+        List<Exception> unexpectedErrors = Collections.synchronizedList(new ArrayList<>());
         CountDownLatch startLatch = new CountDownLatch(1);
         CountDownLatch endLatch = new CountDownLatch(CONCURRENT_REQUESTS);
         ExecutorService executorService = Executors.newFixedThreadPool(CONCURRENT_REQUESTS);
@@ -92,8 +96,14 @@ class ChallengeJoinConcurrencyIntegrationTest {
 
                     challengeService.joinChallenge(user, challengeId, request);
                     successCount.incrementAndGet();
+                } catch (GlobalException e) {
+                    if (e.getErrorCode() == ErrorCode.CHALLENGE_FULL) {
+                        failureCount.incrementAndGet();
+                    } else {
+                        unexpectedErrors.add(e);
+                    }
                 } catch (Exception e) {
-                    failureCount.incrementAndGet();
+                    unexpectedErrors.add(e);
                 } finally {
                     endLatch.countDown();
                 }
@@ -131,6 +141,9 @@ class ChallengeJoinConcurrencyIntegrationTest {
         assertThat(joinedCount)
                 .as("JOINED 상태 UserChallenge 개수는 maxParticipants를 초과하면 안 된다")
                 .isLessThanOrEqualTo(challenge.getMaxParticipants());
+        assertThat(unexpectedErrors)
+                .as("예상하지 못한 예외가 없어야 한다")
+                .isEmpty();
     }
 
     private Long createChallengeWithCurrentRoundAndParticipants() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #330 

## ✨ 작업 내용 (Summary)

챌린지 참가 로직의 동시성 문제를 검증하고 정원 초과 참가가 발생하지 않도록 개선했습니다.

기존에는 참가 요청이 동시에 들어올 경우 정원 검증과 참가 처리 사이에서 Race Condition이 발생할 수 있었습니다. 실제 동시성 테스트를 통해 정원 30명인 챌린지에 39명이 참가 가능한 상황을 재현하였고, 이를 해결하기 위해 비관적 락(PESSIMISTIC_WRITE)을 적용했습니다.

### 주요 변경 사항

* `ChallengeJoinConcurrencyIntegrationTest` 추가

  * CountDownLatch 기반 동시성 테스트 작성
  * 정원 초과 Race Condition 재현
* `ChallengeRepository`

  * `findByIdForUpdate()` 추가
  * `PESSIMISTIC_WRITE` 적용
* `ChallengeServiceImpl`

  * `joinChallenge()`에서 락 기반 조회 사용
* 회귀 테스트 추가

  * 정원 초과가 발생하지 않는지 검증

---

## ✅ 변경 사항 체크리스트

* [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
* [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
* [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

### 테스트 환경

* Local
* MySQL
* Spring Boot Integration Test

### 테스트 방법

* `ChallengeJoinConcurrencyIntegrationTest`
* CountDownLatch + ExecutorService 활용
* 동시 참가 요청 50건 생성

### 결과 요약

#### 수정 전

* maxParticipants = 30
* currentParticipants = 29
* 동시 요청 50건

결과

* Challenge.currentParticipants = 30
* JOINED UserChallenge = 39

→ 정원 초과 참가 발생

#### 수정 후

* Challenge.currentParticipants = 30
* JOINED UserChallenge = 30
* success request count = 1
* failure request count = 49

→ 정원 초과 참가 방지 확인

모든 테스트 통과

---

## 📸 스크린샷

---

## 💬 리뷰 요구사항

* 비관적 락 적용 위치가 적절한지

검토 부탁드립니다.

---

## 📎 참고 자료


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * 챌린지 참여 요청이 동시에 들어올 때도 정원/참여 인원 정합성을 유지하며, 정원 초과 참여 문제를 해결했습니다.

* **Tests**
  * 최대 참가자 직전 상태에서 다수 사용자가 동시에 참여를 시도하는 동시성 통합 테스트를 추가해, 최종 참여 수가 정원을 넘지 않음을 검증합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->