### PR TITLE
[FEAT] 인증 관련 알림 기능 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/comment/service/CommentServiceImpl.java
@@ -8,6 +8,7 @@ import com.hrr.backend.domain.comment.dto.CommentResponseDto;
 import com.hrr.backend.domain.comment.dto.CommentUpdateRequestDto;
 import com.hrr.backend.domain.comment.entity.Comment;
 import com.hrr.backend.domain.comment.repository.CommentRepository;
+import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
@@ -20,6 +21,7 @@ import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -40,6 +42,7 @@ public class CommentServiceImpl implements CommentService {
     private final CommentConverter commentConverter;
     private final UserBlockRepository userBlockRepository;
     private final UserChallengeRepository userChallengeRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /** 댓글 작성 */
     @Override
@@ -119,6 +122,12 @@ public class CommentServiceImpl implements CommentService {
         );
 
         commentRepository.save(comment);
+
+        eventPublisher.publishEvent(new CommentCreatedEvent(
+                verificationId,
+                comment.getId(),
+                userId
+        ));
 
         // 차단 관계 조회 (댓글 작성 시에는 자신의 댓글이므로 빈 Set 전달)
         Set<Long> blockedUserIds = Collections.emptySet();

--- a/src/main/java/com/hrr/backend/domain/comment/service/CommentServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/comment/service/CommentServiceImpl.java
@@ -123,6 +123,7 @@ public class CommentServiceImpl implements CommentService {
 
         commentRepository.save(comment);
 
+        // 댓글 저장과 알림 생성을 분리하기 위해 이벤트 발행
         eventPublisher.publishEvent(new CommentCreatedEvent(
                 verificationId,
                 comment.getId(),

--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
@@ -7,5 +7,7 @@ public enum NotificationTypeName {
 
     VERIFICATION_DEADLINE_3H,     // 인증 마감 3시간 전
     VERIFICATION_DEADLINE_1H,     // 인증 마감 1시간 전
-    VERIFICATION_DEADLINE_NOW     // 인증 시간이 1시간 미만 → 시작 즉시
+    VERIFICATION_DEADLINE_NOW,    // 인증 시간이 1시간 미만 → 시작 즉시
+
+    COMMENT_CREATED               // 내 인증에 댓글 생성
 }

--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
@@ -9,5 +9,7 @@ public enum NotificationTypeName {
     VERIFICATION_DEADLINE_1H,     // 인증 마감 1시간 전
     VERIFICATION_DEADLINE_NOW,    // 인증 시간이 1시간 미만 → 시작 즉시
 
-    COMMENT_CREATED               // 내 인증에 댓글 생성
+    COMMENT_CREATED,              // 내 인증에 댓글 생성
+
+    QUESTION_VERIFICATION         // 질문 인증 생성
 }

--- a/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
+++ b/src/main/java/com/hrr/backend/domain/notification/entity/enums/NotificationTypeName.java
@@ -11,5 +11,7 @@ public enum NotificationTypeName {
 
     COMMENT_CREATED,              // 내 인증에 댓글 생성
 
-    QUESTION_VERIFICATION         // 질문 인증 생성
+    QUESTION_VERIFICATION,        // 질문 인증 생성
+
+    WEAK_VERIFICATION_WARNING     // 부실 인증 경고
 }

--- a/src/main/java/com/hrr/backend/domain/notification/event/CommentCreatedEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/event/CommentCreatedEvent.java
@@ -1,0 +1,8 @@
+package com.hrr.backend.domain.notification.event;
+
+public record CommentCreatedEvent(
+        Long verificationId,
+        Long commentId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/hrr/backend/domain/notification/event/QuestionVerificationCreatedEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/event/QuestionVerificationCreatedEvent.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.notification.event;
+
+public record QuestionVerificationCreatedEvent(
+        Long verificationId,
+        Long actorId
+) {
+}

--- a/src/main/java/com/hrr/backend/domain/notification/event/WeakVerificationWarningEvent.java
+++ b/src/main/java/com/hrr/backend/domain/notification/event/WeakVerificationWarningEvent.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.notification.event;
+
+public record WeakVerificationWarningEvent(
+        Long verificationId,
+        Long warnedUserId
+) {
+}

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -1,5 +1,6 @@
 package com.hrr.backend.domain.notification.listener;
 
+import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.service.NotificationCommandService;
@@ -38,5 +39,17 @@ public class NotificationEventListener {
         log.info("[알림 이벤트 리스너] 챌린지 연장 응답 결과 알림 처리 시작 | RoundId={}, UserId={}",
                 event.roundId(), event.user().getId());
         notificationCommandService.sendChallengeExtensionResponseNotification(event);
+    }
+
+    /**
+     * 인증 댓글 생성 이벤트 핸들러
+     * 댓글 생성 트랜잭션 커밋 후 인증 작성자에게 알림을 발송
+     */
+    @Async("getAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCommentCreatedEvent(CommentCreatedEvent event) {
+        log.info("[알림 이벤트 리스너] 인증 댓글 생성 알림 처리 시작 | VerificationId={}, CommentId={}",
+                event.verificationId(), event.commentId());
+        notificationCommandService.sendCommentCreatedNotification(event);
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -4,6 +4,7 @@ import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
+import com.hrr.backend.domain.notification.event.WeakVerificationWarningEvent;
 import com.hrr.backend.domain.notification.service.NotificationCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -64,5 +65,17 @@ public class NotificationEventListener {
         log.info("[알림 이벤트 리스너] 질문 인증 생성 알림 처리 시작 | VerificationId={}",
                 event.verificationId());
         notificationCommandService.sendQuestionVerificationCreatedNotification(event);
+    }
+
+    /**
+     * 부실 인증 경고 이벤트 핸들러
+     * 부실 인증 신고 누적으로 경고가 증가한 사용자에게 알림을 발송
+     */
+    @Async("getAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleWeakVerificationWarningEvent(WeakVerificationWarningEvent event) {
+        log.info("[알림 이벤트 리스너] 부실 인증 경고 알림 처리 시작 | VerificationId={}, WarnedUserId={}",
+                event.verificationId(), event.warnedUserId());
+        notificationCommandService.sendWeakVerificationWarningNotification(event);
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
+++ b/src/main/java/com/hrr/backend/domain/notification/listener/NotificationEventListener.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.notification.listener;
 import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
+import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
 import com.hrr.backend.domain.notification.service.NotificationCommandService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -51,5 +52,17 @@ public class NotificationEventListener {
         log.info("[알림 이벤트 리스너] 인증 댓글 생성 알림 처리 시작 | VerificationId={}, CommentId={}",
                 event.verificationId(), event.commentId());
         notificationCommandService.sendCommentCreatedNotification(event);
+    }
+
+    /**
+     * 질문 인증 생성 이벤트 핸들러
+     * 질문 인증 생성 트랜잭션 커밋 후 같은 챌린지 참여자에게 알림을 발송
+     */
+    @Async("getAsyncExecutor")
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleQuestionVerificationCreatedEvent(QuestionVerificationCreatedEvent event) {
+        log.info("[알림 이벤트 리스너] 질문 인증 생성 알림 처리 시작 | VerificationId={}",
+                event.verificationId());
+        notificationCommandService.sendQuestionVerificationCreatedNotification(event);
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationRepository.java
@@ -20,6 +20,7 @@ public interface NotificationRepository extends JpaRepository<NotificationDelive
 
     @Query("SELECT nd FROM NotificationDelivery nd " +
             "JOIN FETCH nd.event e " +
+            "JOIN FETCH e.type " +
             "WHERE nd.receiver = :user " +
             "AND (:category IS NULL OR e.category = :category) " +
             "ORDER BY nd.createdAt DESC") // 최신순 정렬

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.notification.service;
 
 import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
+import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.event.VerificationDeadlineEvent;
@@ -15,4 +16,7 @@ public interface NotificationCommandService {
 
     // 챌린지 연장 응답 결과 발송
     void sendChallengeExtensionResponseNotification(ChallengeExtensionResponseEvent event);
+
+    // 인증 댓글 생성 알림 발송
+    void sendCommentCreatedNotification(CommentCreatedEvent event);
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
@@ -4,6 +4,7 @@ import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
 import com.hrr.backend.domain.notification.event.CommentCreatedEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
+import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
 import com.hrr.backend.domain.notification.event.VerificationDeadlineEvent;
 import java.time.LocalDate;
 
@@ -19,4 +20,7 @@ public interface NotificationCommandService {
 
     // 인증 댓글 생성 알림 발송
     void sendCommentCreatedNotification(CommentCreatedEvent event);
+
+    // 질문 인증 생성 알림 발송
+    void sendQuestionVerificationCreatedNotification(QuestionVerificationCreatedEvent event);
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandService.java
@@ -6,6 +6,7 @@ import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
 import com.hrr.backend.domain.notification.event.VerificationDeadlineEvent;
+import com.hrr.backend.domain.notification.event.WeakVerificationWarningEvent;
 import java.time.LocalDate;
 
 public interface NotificationCommandService {
@@ -23,4 +24,7 @@ public interface NotificationCommandService {
 
     // 질문 인증 생성 알림 발송
     void sendQuestionVerificationCreatedNotification(QuestionVerificationCreatedEvent event);
+
+    // 부실 인증 경고 알림 발송
+    void sendWeakVerificationWarningNotification(WeakVerificationWarningEvent event);
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -1,6 +1,8 @@
 package com.hrr.backend.domain.notification.service;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.comment.entity.Comment;
+import com.hrr.backend.domain.comment.repository.CommentRepository;
 import com.hrr.backend.domain.fcm.event.FcmPushSendEvent;
 import com.hrr.backend.domain.notification.entity.*;
 import com.hrr.backend.domain.notification.entity.enums.*;
@@ -13,7 +15,9 @@ import com.hrr.backend.domain.round.repository.*;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
 import com.hrr.backend.domain.user.repository.UserRepository;
+import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
+import com.hrr.backend.domain.verification.repository.VerificationRepository;
 import com.hrr.backend.global.exception.GlobalException;
 import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -39,6 +43,8 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     private final NotificationEventRepository eventRepository;
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final VerificationRepository verificationRepository;
+    private final CommentRepository commentRepository;
     private final ApplicationEventPublisher eventPublisher;
     private final NotificationEventHelper eventHelper;
 
@@ -87,6 +93,57 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
             if (!pushTargets.isEmpty()) {
                 eventPublisher.publishEvent(new FcmPushSendEvent(pushTargets, notificationEvent));
             }
+        }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendCommentCreatedNotification(CommentCreatedEvent event) {
+        Verification verification = verificationRepository.findById(event.verificationId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND));
+        Comment comment = commentRepository.findById(event.commentId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.COMMENT_NOT_FOUND));
+
+        User receiver = verification.getUserChallenge().getUser();
+        if (receiver.getId().equals(event.actorId())) {
+            return;
+        }
+
+        NotificationType type = typeRepository.findByTypeName(NotificationTypeName.COMMENT_CREATED)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+        Challenge challenge = verification.getRoundRecord().getRound().getChallenge();
+
+        NotificationEvent notificationEvent = NotificationEvent.builder()
+                .type(type)
+                .actor(comment.getUser())
+                .category(NotificationCategory.VERIFICATION)
+                .targetType(ResourceType.VERIFICATION)
+                .targetId(verification.getId())
+                .contextType(ResourceType.COMMENT)
+                .contextId(comment.getId())
+                .title("내 인증에 댓글이 달렸어요")
+                .message(comment.getContent())
+                .imageKey(challenge.getImageKey())
+                .createdDate(LocalDate.now())
+                .build();
+
+        try {
+            eventRepository.saveAndFlush(notificationEvent);
+        } catch (DataIntegrityViolationException e) {
+            log.info("중복된 댓글 생성 알림 이벤트 생성이 차단되었습니다. (CommentId={})", comment.getId());
+            return;
+        }
+
+        NotificationDelivery delivery = NotificationDelivery.builder()
+                .event(notificationEvent)
+                .receiver(receiver)
+                .isRead(false)
+                .build();
+
+        notificationRepository.save(delivery);
+
+        if (receiver.getNotificationSetting().isVerificationEnabled()) {
+            eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
         }
     }
 

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -221,10 +221,6 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         User receiver = userRepository.findById(event.warnedUserId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
 
-        if (!receiver.getNotificationSetting().isVerificationEnabled()) {
-            return;
-        }
-
         Challenge challenge = verification.getRoundRecord().getRound().getChallenge();
         NotificationType type = typeRepository.findByTypeName(NotificationTypeName.WEAK_VERIFICATION_WARNING)
                 .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
@@ -234,7 +230,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 .actor(null)
                 .category(NotificationCategory.VERIFICATION)
                 .targetType(ResourceType.VERIFICATION)
-                .targetId(receiver.getId())
+                .targetId(verification.getId())
                 .contextType(ResourceType.VERIFICATION)
                 .contextId(verification.getId())
                 .title("챌린지 부실 인증 경고")
@@ -258,7 +254,10 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 .build();
 
         notificationRepository.save(delivery);
-        eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
+
+        if (receiver.getNotificationSetting().isVerificationEnabled()) {
+            eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
+        }
     }
 
     @Override

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -215,6 +215,54 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendWeakVerificationWarningNotification(WeakVerificationWarningEvent event) {
+        Verification verification = verificationRepository.findById(event.verificationId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND));
+        User receiver = userRepository.findById(event.warnedUserId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_NOT_FOUND));
+
+        if (!receiver.getNotificationSetting().isVerificationEnabled()) {
+            return;
+        }
+
+        Challenge challenge = verification.getRoundRecord().getRound().getChallenge();
+        NotificationType type = typeRepository.findByTypeName(NotificationTypeName.WEAK_VERIFICATION_WARNING)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+
+        NotificationEvent notificationEvent = NotificationEvent.builder()
+                .type(type)
+                .actor(null)
+                .category(NotificationCategory.VERIFICATION)
+                .targetType(ResourceType.VERIFICATION)
+                .targetId(receiver.getId())
+                .contextType(ResourceType.VERIFICATION)
+                .contextId(verification.getId())
+                .title("챌린지 부실 인증 경고")
+                .message(String.format("%s 챌린지에서 부실 인증 경고가 적립되었어요", challenge.getTitle()))
+                .imageKey(challenge.getImageKey())
+                .createdDate(LocalDate.now())
+                .build();
+
+        try {
+            eventRepository.saveAndFlush(notificationEvent);
+        } catch (DataIntegrityViolationException e) {
+            log.info("중복된 부실 인증 경고 알림 이벤트 생성이 차단되었습니다. (VerificationId={}, WarnedUserId={})",
+                    verification.getId(), receiver.getId());
+            return;
+        }
+
+        NotificationDelivery delivery = NotificationDelivery.builder()
+                .event(notificationEvent)
+                .receiver(receiver)
+                .isRead(false)
+                .build();
+
+        notificationRepository.save(delivery);
+        eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void sendChallengeExtensionNotification(ChallengeExtensionEvent event) {
         Long roundId = event.roundId();
 

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -13,7 +13,9 @@ import com.hrr.backend.domain.round.entity.*;
 import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.round.repository.*;
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
 import com.hrr.backend.domain.user.repository.UserRepository;
 import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
@@ -43,6 +45,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
     private final NotificationEventRepository eventRepository;
     private final NotificationRepository notificationRepository;
     private final UserRepository userRepository;
+    private final UserChallengeRepository userChallengeRepository;
     private final VerificationRepository verificationRepository;
     private final CommentRepository commentRepository;
     private final ApplicationEventPublisher eventPublisher;
@@ -144,6 +147,69 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
         if (receiver.getNotificationSetting().isVerificationEnabled()) {
             eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
+        }
+    }
+
+    @Override
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void sendQuestionVerificationCreatedNotification(QuestionVerificationCreatedEvent event) {
+        Verification verification = verificationRepository.findById(event.verificationId())
+                .orElseThrow(() -> new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND));
+
+        if (!Boolean.TRUE.equals(verification.getIsQuestion())) {
+            return;
+        }
+
+        Challenge challenge = verification.getRoundRecord().getRound().getChallenge();
+        User actor = verification.getUserChallenge().getUser();
+        NotificationType type = typeRepository.findByTypeName(NotificationTypeName.QUESTION_VERIFICATION)
+                .orElseThrow(() -> new GlobalException(ErrorCode.NOTIFICATION_TYPE_NOT_FOUND));
+
+        NotificationEvent notificationEvent = NotificationEvent.builder()
+                .type(type)
+                .actor(actor)
+                .category(NotificationCategory.VERIFICATION)
+                .targetType(ResourceType.VERIFICATION)
+                .targetId(verification.getId())
+                .contextType(ResourceType.VERIFICATION)
+                .contextId(verification.getId())
+                .title("새로운 질문이 등록되었어요")
+                .message(String.format("%s 챌린지에 새로운 질문 인증글이 등록되었어요", challenge.getTitle()))
+                .imageKey(challenge.getImageKey())
+                .createdDate(LocalDate.now())
+                .build();
+
+        try {
+            eventRepository.saveAndFlush(notificationEvent);
+        } catch (DataIntegrityViolationException e) {
+            log.info("중복된 질문 인증 알림 이벤트 생성이 차단되었습니다. (VerificationId={})", verification.getId());
+            return;
+        }
+
+        List<UserChallenge> joinedUserChallenges =
+                userChallengeRepository.findAllByChallengeIdAndStatusWithUserAndSetting(
+                        challenge.getId(), ChallengeJoinStatus.JOINED);
+
+        List<NotificationDelivery> allDeliveries = joinedUserChallenges.stream()
+                .map(UserChallenge::getUser)
+                .filter(receiver -> !receiver.getId().equals(event.actorId()))
+                .map(receiver -> NotificationDelivery.builder()
+                        .event(notificationEvent)
+                        .receiver(receiver)
+                        .isRead(false)
+                        .build())
+                .toList();
+
+        if (!allDeliveries.isEmpty()) {
+            notificationRepository.saveAll(allDeliveries);
+
+            List<NotificationDelivery> pushTargets = allDeliveries.stream()
+                    .filter(d -> d.getReceiver().getNotificationSetting().isVerificationEnabled())
+                    .toList();
+
+            if (!pushTargets.isEmpty()) {
+                eventPublisher.publishEvent(new FcmPushSendEvent(pushTargets, notificationEvent));
+            }
         }
     }
 

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -101,6 +101,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
 
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
+    // 알림 저장 실패가 원본 비즈니스 트랜잭션에 영향을 주지 않도록 별도 트랜잭션 사용
     public void sendCommentCreatedNotification(CommentCreatedEvent event) {
         Verification verification = verificationRepository.findById(event.verificationId())
                 .orElseThrow(() -> new GlobalException(ErrorCode.VERIFICATION_NOT_FOUND));
@@ -108,6 +109,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 .orElseThrow(() -> new GlobalException(ErrorCode.COMMENT_NOT_FOUND));
 
         User receiver = verification.getUserChallenge().getUser();
+        // 자신의 인증에 직접 댓글을 작성한 경우 알림 미발송
         if (receiver.getId().equals(event.actorId())) {
             return;
         }
@@ -190,6 +192,7 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 userChallengeRepository.findAllByChallengeIdAndStatusWithUserAndSetting(
                         challenge.getId(), ChallengeJoinStatus.JOINED);
 
+        // 질문 작성자는 제외하고 같은 챌린지 참여자에게만 알림 생성
         List<NotificationDelivery> allDeliveries = joinedUserChallenges.stream()
                 .map(UserChallenge::getUser)
                 .filter(receiver -> !receiver.getId().equals(event.actorId()))

--- a/src/main/java/com/hrr/backend/domain/report/service/ReportServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/report/service/ReportServiceImpl.java
@@ -1,9 +1,11 @@
 package com.hrr.backend.domain.report.service;
 
 import org.springframework.stereotype.Service;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.notification.event.WeakVerificationWarningEvent;
 import com.hrr.backend.domain.report.dto.ReportRequestDto;
 import com.hrr.backend.domain.report.entity.UserReport;
 import com.hrr.backend.domain.report.entity.VerificationPostReport;
@@ -43,6 +45,8 @@ public class ReportServiceImpl implements ReportService {
 
 	private final RoundRecordService roundRecordService;
 
+	private final ApplicationEventPublisher eventPublisher;
+
 	@Override
 	@Transactional
 	public void reportWeakVerification(User reporter,Long verificationId) {
@@ -81,7 +85,14 @@ public class ReportServiceImpl implements ReportService {
 		weakVerificationReportRepository.save(report);
 
 		// 경고 횟수를 업데이트 후 퇴출 여부를 결정하는 메소드 호출
+		int previousWarnCount = targetRecord.getWarnCount();
 		roundRecordService.synchronizeWarnCount(targetRecord.getId());
+		if (targetRecord.getWarnCount() > previousWarnCount) {
+			eventPublisher.publishEvent(new WeakVerificationWarningEvent(
+				targetVerification.getId(),
+				targetVerification.getUserChallenge().getUser().getId()
+			));
+		}
 	}
 
 	/**

--- a/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepository.java
+++ b/src/main/java/com/hrr/backend/domain/user/repository/UserChallengeRepository.java
@@ -68,6 +68,19 @@ public interface UserChallengeRepository extends JpaRepository<UserChallenge, Lo
     List<UserChallenge> findAllByChallengeId(@Param("challengeId") Long challengeId);
 
     /**
+     * 챌린지에 참여 중인 사용자와 알림 설정을 함께 조회
+     */
+    @Query("SELECT uc FROM UserChallenge uc " +
+            "JOIN FETCH uc.user u " +
+            "JOIN FETCH u.notificationSetting " +
+            "WHERE uc.challenge.id = :challengeId " +
+            "AND uc.status = :status")
+    List<UserChallenge> findAllByChallengeIdAndStatusWithUserAndSetting(
+            @Param("challengeId") Long challengeId,
+            @Param("status") ChallengeJoinStatus status
+    );
+
+    /**
      * 챌린지에 정상적으로 참여 중인(JOINED) 모든 사용자 및 선호 정보 조회
      */
     @Query("SELECT uc FROM UserChallenge uc " +

--- a/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/verification/service/VerificationServiceImpl.java
@@ -18,7 +18,9 @@ import com.hrr.backend.domain.comment.dto.CommentResponseDto;
 import com.hrr.backend.domain.comment.entity.Comment;
 import com.hrr.backend.domain.comment.repository.CommentRepository;
 import com.hrr.backend.domain.comment.service.CommentService;
+import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
 import com.hrr.backend.domain.verification.dto.VerificationUpdateRequestDto;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -67,6 +69,7 @@ public class VerificationServiceImpl implements VerificationService {
     private final CommentService commentService;
     private final CommentRepository commentRepository;
     private final UserBlockRepository userBlockRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
 
     @Override
@@ -230,6 +233,7 @@ public class VerificationServiceImpl implements VerificationService {
             Verification savedVerification = verificationRepository.save(verification);
             verificationRepository.flush(); // DB 제약 조건 위반을 즉시 확인
             roundRecord.increaseVerificationCount();
+            publishQuestionVerificationCreatedEventIfNeeded(savedVerification, userId);
             return verificationConverter.toResponseDto(savedVerification);
         } catch (org.springframework.dao.DataIntegrityViolationException e) {
             // 중복된 인증 생성이 시도될 경우 에러 반환
@@ -281,6 +285,7 @@ public class VerificationServiceImpl implements VerificationService {
             Verification saved = verificationRepository.save(verification);
             verificationRepository.flush(); // DB 제약 조건 위반을 즉시 확인
             roundRecord.increaseVerificationCount();
+            publishQuestionVerificationCreatedEventIfNeeded(saved, userId);
             return verificationConverter.toResponseDto(saved);
         } catch (org.springframework.dao.DataIntegrityViolationException e) {
             // 중복된 인증 생성이 시도될 경우 에러 반환
@@ -334,6 +339,12 @@ public class VerificationServiceImpl implements VerificationService {
 
         if (alreadyVerified) {
             throw new GlobalException(ErrorCode.VERIFICATION_ALREADY_EXISTS);
+        }
+    }
+
+    private void publishQuestionVerificationCreatedEventIfNeeded(Verification verification, Long actorId) {
+        if (Boolean.TRUE.equals(verification.getIsQuestion())) {
+            eventPublisher.publishEvent(new QuestionVerificationCreatedEvent(verification.getId(), actorId));
         }
     }
 
@@ -779,4 +790,3 @@ public class VerificationServiceImpl implements VerificationService {
                 .build();
     }
 }
-

--- a/src/main/resources/db/migration/V2.36__add_verification_notification_types.sql
+++ b/src/main/resources/db/migration/V2.36__add_verification_notification_types.sql
@@ -1,0 +1,28 @@
+ALTER TABLE notification_event
+    MODIFY COLUMN category ENUM(
+    'BADGE',
+    'CHALLENGE',
+    'FOLLOW',
+    'VERIFICATION'
+    ) NOT NULL;
+
+ALTER TABLE notification_type
+    MODIFY COLUMN type_name ENUM(
+    'CHALLENGE_EXTENSION',
+    'CHALLENGE_EXTENSION_SUCCESS',
+    'CHALLENGE_EXTENSION_CANCEL',
+    'VERIFICATION_DEADLINE_3H',
+    'VERIFICATION_DEADLINE_1H',
+    'VERIFICATION_DEADLINE_NOW',
+    'COMMENT_CREATED',
+    'QUESTION_VERIFICATION',
+    'WEAK_VERIFICATION_WARNING'
+    ) NOT NULL;
+
+INSERT INTO notification_type (type_name, default_enabled, is_mandatory, created_at)
+VALUES
+    ('COMMENT_CREATED', 1, 0, NOW()),
+    ('QUESTION_VERIFICATION', 1, 0, NOW()),
+    ('WEAK_VERIFICATION_WARNING', 1, 0, NOW())
+    ON DUPLICATE KEY UPDATE
+                         updated_at = NOW();

--- a/src/test/java/com/hrr/backend/domain/comment/service/CommentServiceTest.java
+++ b/src/test/java/com/hrr/backend/domain/comment/service/CommentServiceTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -55,6 +56,7 @@ class CommentServiceTest {
         @Mock private UserBlockRepository userBlockRepository;
         @Mock private UserChallengeRepository userChallengeRepository;
         @Mock private S3UrlUtil s3UrlUtil;
+        @Mock private ApplicationEventPublisher eventPublisher;
 
         @BeforeEach
         void setUp() {
@@ -68,7 +70,8 @@ class CommentServiceTest {
                     userRepository,
                     commentConverter,
                     userBlockRepository,
-                    userChallengeRepository
+                    userChallengeRepository,
+                    eventPublisher
             );
         }
 

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
@@ -3,9 +3,12 @@ package com.hrr.backend.domain.notification;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
 import com.hrr.backend.domain.notification.entity.*;
+import com.hrr.backend.domain.notification.entity.enums.NotificationCategory;
 import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
+import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
+import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
 import com.hrr.backend.domain.notification.listener.NotificationEventListener;
 import com.hrr.backend.domain.notification.repository.*;
 import com.hrr.backend.domain.notification.service.NotificationCommandService;
@@ -283,6 +286,66 @@ class NotificationIntegrationTest {
         transactionTemplate.executeWithoutResult(status -> {
             assertThat(notificationEventRepository.findAll()).hasSize(1);
             assertThat(notificationRepository.findAll()).hasSize(2);
+        });
+    }
+
+    @Test
+    @DisplayName("8. 질문 인증 생성 알림: 작성자를 제외한 동일 챌린지 JOINED 참여자에게 알림이 저장된다")
+    void questionVerificationCreated_Integration_Test() throws InterruptedException {
+        // given
+        User author = createUser("question_author", true);
+        User joinedReceiver = createUser("joined_receiver", true);
+        User disabledReceiver = createUser("disabled", false);
+        User droppedUser = createUser("dropped_user", true);
+
+        RoundRecord authorRecord = createRoundRecord(joinChallenge(author));
+        joinChallenge(joinedReceiver);
+        joinChallenge(disabledReceiver);
+        userChallengeRepository.save(UserChallenge.builder()
+                .user(droppedUser)
+                .challenge(testChallenge)
+                .status(ChallengeJoinStatus.DROPPED)
+                .build());
+
+        Verification questionVerification = verificationRepository.save(Verification.builder()
+                .roundRecord(authorRecord)
+                .userChallenge(authorRecord.getUserChallenge())
+                .roundId(testRound.getId())
+                .title("질문입니다")
+                .content("내용")
+                .isQuestion(true)
+                .status(VerificationStatus.COMPLETED)
+                .build());
+        verificationRepository.flush();
+
+        // when
+        eventListener.handleQuestionVerificationCreatedEvent(
+                new QuestionVerificationCreatedEvent(questionVerification.getId(), author.getId()));
+        Thread.sleep(1500);
+
+        // then
+        transactionTemplate.executeWithoutResult(status -> {
+            List<NotificationEvent> events = notificationEventRepository.findAll();
+            List<NotificationDelivery> deliveries = notificationRepository.findAll();
+
+            assertThat(events).hasSize(1);
+            NotificationEvent notificationEvent = events.get(0);
+            assertThat(notificationEvent.getType().getTypeName()).isEqualTo(NotificationTypeName.QUESTION_VERIFICATION);
+            assertThat(notificationEvent.getActor().getId()).isEqualTo(author.getId());
+            assertThat(notificationEvent.getCategory()).isEqualTo(NotificationCategory.VERIFICATION);
+            assertThat(notificationEvent.getTargetType()).isEqualTo(ResourceType.VERIFICATION);
+            assertThat(notificationEvent.getTargetId()).isEqualTo(questionVerification.getId());
+            assertThat(notificationEvent.getContextType()).isEqualTo(ResourceType.VERIFICATION);
+            assertThat(notificationEvent.getContextId()).isEqualTo(questionVerification.getId());
+            assertThat(notificationEvent.getTitle()).isEqualTo("새로운 질문이 등록되었어요");
+            assertThat(notificationEvent.getMessage()).isEqualTo("테스트 챌린지 챌린지에 새로운 질문 인증글이 등록되었어요");
+            assertThat(notificationEvent.getImageKey()).isEqualTo("test-image-key");
+
+            assertThat(deliveries).hasSize(2);
+            assertThat(deliveries)
+                    .extracting(delivery -> delivery.getReceiver().getName())
+                    .containsExactlyInAnyOrder("joined_receiver", "disabled")
+                    .doesNotContain("question_author", "dropped_user");
         });
     }
 

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
@@ -9,6 +9,7 @@ import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionEvent;
 import com.hrr.backend.domain.notification.event.ChallengeExtensionResponseEvent;
 import com.hrr.backend.domain.notification.event.QuestionVerificationCreatedEvent;
+import com.hrr.backend.domain.notification.event.WeakVerificationWarningEvent;
 import com.hrr.backend.domain.notification.listener.NotificationEventListener;
 import com.hrr.backend.domain.notification.repository.*;
 import com.hrr.backend.domain.notification.service.NotificationCommandService;
@@ -346,6 +347,51 @@ class NotificationIntegrationTest {
                     .extracting(delivery -> delivery.getReceiver().getName())
                     .containsExactlyInAnyOrder("joined_receiver", "disabled")
                     .doesNotContain("question_author", "dropped_user");
+        });
+    }
+
+    @Test
+    @DisplayName("9. 부실 인증 경고 알림: 경고를 받은 사용자에게만 알림이 저장된다")
+    void weakVerificationWarning_Integration_Test() throws InterruptedException {
+        // given
+        User warnedUser = createUser("warned_user", true);
+        RoundRecord warnedRecord = createRoundRecord(joinChallenge(warnedUser));
+        Verification weakVerification = verificationRepository.save(Verification.builder()
+                .roundRecord(warnedRecord)
+                .userChallenge(warnedRecord.getUserChallenge())
+                .roundId(testRound.getId())
+                .title("부실 인증")
+                .content("내용")
+                .isQuestion(false)
+                .status(VerificationStatus.COMPLETED)
+                .build());
+        verificationRepository.flush();
+
+        // when
+        eventListener.handleWeakVerificationWarningEvent(
+                new WeakVerificationWarningEvent(weakVerification.getId(), warnedUser.getId()));
+        Thread.sleep(1500);
+
+        // then
+        transactionTemplate.executeWithoutResult(status -> {
+            List<NotificationEvent> events = notificationEventRepository.findAll();
+            List<NotificationDelivery> deliveries = notificationRepository.findAll();
+
+            assertThat(events).hasSize(1);
+            NotificationEvent notificationEvent = events.get(0);
+            assertThat(notificationEvent.getType().getTypeName()).isEqualTo(NotificationTypeName.WEAK_VERIFICATION_WARNING);
+            assertThat(notificationEvent.getActor()).isNull();
+            assertThat(notificationEvent.getCategory()).isEqualTo(NotificationCategory.VERIFICATION);
+            assertThat(notificationEvent.getTargetType()).isEqualTo(ResourceType.VERIFICATION);
+            assertThat(notificationEvent.getTargetId()).isEqualTo(warnedUser.getId());
+            assertThat(notificationEvent.getContextType()).isEqualTo(ResourceType.VERIFICATION);
+            assertThat(notificationEvent.getContextId()).isEqualTo(weakVerification.getId());
+            assertThat(notificationEvent.getTitle()).isEqualTo("챌린지 부실 인증 경고");
+            assertThat(notificationEvent.getMessage()).isEqualTo("테스트 챌린지 챌린지에서 부실 인증 경고가 적립되었어요");
+            assertThat(notificationEvent.getImageKey()).isEqualTo("test-image-key");
+
+            assertThat(deliveries).hasSize(1);
+            assertThat(deliveries.get(0).getReceiver().getId()).isEqualTo(warnedUser.getId());
         });
     }
 

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
@@ -383,7 +383,7 @@ class NotificationIntegrationTest {
             assertThat(notificationEvent.getActor()).isNull();
             assertThat(notificationEvent.getCategory()).isEqualTo(NotificationCategory.VERIFICATION);
             assertThat(notificationEvent.getTargetType()).isEqualTo(ResourceType.VERIFICATION);
-            assertThat(notificationEvent.getTargetId()).isEqualTo(warnedUser.getId());
+            assertThat(notificationEvent.getTargetId()).isEqualTo(weakVerification.getId());
             assertThat(notificationEvent.getContextType()).isEqualTo(ResourceType.VERIFICATION);
             assertThat(notificationEvent.getContextId()).isEqualTo(weakVerification.getId());
             assertThat(notificationEvent.getTitle()).isEqualTo("챌린지 부실 인증 경고");

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
@@ -233,6 +233,8 @@ class NotificationQueryPatternTest {
                     NotificationCategory.CHALLENGE;
             case VERIFICATION_DEADLINE_3H, VERIFICATION_DEADLINE_1H, VERIFICATION_DEADLINE_NOW ->
                     NotificationCategory.VERIFICATION;
+            case COMMENT_CREATED ->
+                    NotificationCategory.VERIFICATION;
         };
     }
 

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
@@ -233,7 +233,7 @@ class NotificationQueryPatternTest {
                     NotificationCategory.CHALLENGE;
             case VERIFICATION_DEADLINE_3H, VERIFICATION_DEADLINE_1H, VERIFICATION_DEADLINE_NOW ->
                     NotificationCategory.VERIFICATION;
-            case COMMENT_CREATED ->
+            case COMMENT_CREATED, QUESTION_VERIFICATION ->
                     NotificationCategory.VERIFICATION;
         };
     }

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationQueryPatternTest.java
@@ -233,7 +233,7 @@ class NotificationQueryPatternTest {
                     NotificationCategory.CHALLENGE;
             case VERIFICATION_DEADLINE_3H, VERIFICATION_DEADLINE_1H, VERIFICATION_DEADLINE_NOW ->
                     NotificationCategory.VERIFICATION;
-            case COMMENT_CREATED, QUESTION_VERIFICATION ->
+            case COMMENT_CREATED, QUESTION_VERIFICATION, WEAK_VERIFICATION_WARNING ->
                     NotificationCategory.VERIFICATION;
         };
     }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #333 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

- 인증 관련 알림 기능을 추가했습니다.
   - 댓글 작성 알림 (COMMENT_CREATED)
   - 질문 인증 등록 알림 (QUESTION_VERIFICATION)
   - 부실 인증 경고 알림 (WEAK_VERIFICATION_WARNING)

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** NotificationIntegrationTest
* **결과 요약:** 댓글 작성 알림, 질문 인증 등록 알림, 부실 인증 경고 알림 생성 및 수신 대상 검증

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| NotificationIntegrationTest |
|---|
| <img width="382" height="110" alt="image" src="https://github.com/user-attachments/assets/eef84abd-a4dd-4980-b8d1-f7248c9529b4" /> |

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
- 이벤트 발행 시점과 알림 대상 선정 로직이 적절한지 중점적으로 리뷰 부탁드립니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 댓글 생성, 질문 인증 생성, 부실 인증 경고에 대한 인증 알림 전송을 추가했습니다.
  * 신규 인증 관련 알림 유형 3종을 지원합니다.
* **개선**
  * 인증 알림은 사용자 알림 설정에 따라 푸시 전송을 제어하며, 알림 저장 처리는 동일하게 동작합니다.
  * 알림 조회 시 알림 유형 정보가 함께 표시됩니다.
* **테스트**
  * 질문/부실 인증 알림 처리 시나리오를 통합 테스트로 보강했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->