### PR TITLE
[Feat] 챌린지 수정용 조회 API 추가 + 챌린지 나가기 기능 도입

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -213,4 +213,20 @@ public class ChallengeController {
                 challengeService.updateChallenge(userDetails.getUser(), challengeId, request)
         );
     }
+
+    @Operation(
+            summary = "챌린지 나가기",
+            description = "참가 중인 챌린지에서 나갑니다. 방장은 나갈 수 없으며, 챌린지 시작일 전까지만 가능합니다."
+    )
+    @PostMapping("/{challengeId}/leave")
+    public ApiResponse<ChallengeResponseDto.LeaveChallengeDto> leaveChallenge(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("challengeId") Long challengeId
+    ) {
+        return ApiResponse.onSuccess(
+                SuccessCode.CHALLENGE_LEAVE_OK,
+                challengeService.leaveChallenge(userDetails.getUser(), challengeId)
+        );
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -214,6 +214,24 @@ public class ChallengeController {
         );
     }
 
+    @GetMapping("/{challengeId}/edit-info")
+    @Operation(
+            summary = "챌린지 수정용 상세 정보 조회",
+            description = "챌린지 수정 화면 진입 시 기존 값을 채우기 위한 전체 정보를 조회합니다. "
+                    + "방장만 조회 가능하며, 챌린지 시작일 전날까지만 조회할 수 있습니다."
+    )
+    public ApiResponse<ChallengeResponseDto.EditInfoDto> getChallengeEditInfo(
+            @Parameter(hidden = true)
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("challengeId") Long challengeId
+    ) {
+        ChallengeResponseDto.EditInfoDto response = challengeService.getChallengeEditInfo(
+                userDetails.getUser(),
+                challengeId
+        );
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
+    }
+
     @Operation(
             summary = "챌린지 나가기",
             description = "참가 중인 챌린지에서 나갑니다. 방장은 나갈 수 없으며, 챌린지 시작일 전까지만 가능합니다."

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -195,7 +195,7 @@ public class ChallengeConverter {
                 .title(challenge.getTitle())
                 .description(challenge.getDescription())
                 .isPublic(challenge.getIsPublic())
-                .password(challenge.getPassword())
+                .hasPassword(challenge.getPassword() != null && !challenge.getPassword().isBlank())
                 .category(challenge.getCategory())
                 .verificationType(challenge.getVerificationType())
                 .startDate(challenge.getStartDate().toLocalDate())

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -17,6 +17,7 @@ import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 import com.hrr.backend.global.common.enums.ChallengeStatus;
+import com.hrr.backend.global.common.enums.VerificationType;
 
 @Component
 @RequiredArgsConstructor
@@ -84,6 +85,7 @@ public class ChallengeConverter {
             boolean isParticipant,
             boolean isLiked,
             ActionButtonStatus actionButtonStatus
+            boolean isOwner
     ) {
         // 방장 정보 마스킹: owner가 null(정보 삭제됨)이거나 비활성 상태(탈퇴 처리됨)인 경우 통합 처리
         String nickname;
@@ -119,6 +121,7 @@ public class ChallengeConverter {
                 .isPublic(challenge.getIsPublic())
                 .isObserverMode(challenge.getIsViewerMode())
                 .isParticipant(isParticipant)
+                .isOwner(isOwner)
                 .isLiked(isLiked)
                 .owner(ownerDto)
                 .actionButtonStatus(actionButtonStatus)
@@ -172,5 +175,38 @@ public class ChallengeConverter {
 
     public ChallengeResponseDto.UpdateChallengeDto toUpdateResponseDto(Challenge challenge) {
         return new ChallengeResponseDto.UpdateChallengeDto(challenge.getId());
+    }
+
+    public ChallengeResponseDto.LeaveChallengeDto toLeaveResponseDto(Challenge challenge) {
+        return new ChallengeResponseDto.LeaveChallengeDto(
+                challenge.getId(),
+                challenge.getCurrentParticipants()
+        );
+    }
+
+    public ChallengeResponseDto.EditInfoDto toEditInfoDto(Challenge challenge) {
+        // Entity의 ChallengeDayJoin 리스트를 Enum 리스트로 변환 (toProfileDto와 동일한 방식)
+        List<ChallengeDays> daysOfWeek = challenge.getChallengeDays().stream()
+                .map(ChallengeDayJoin::getDay)
+                .sorted()
+                .toList();
+
+        return ChallengeResponseDto.EditInfoDto.builder()
+                .title(challenge.getTitle())
+                .description(challenge.getDescription())
+                .isPublic(challenge.getIsPublic())
+                .password(challenge.getPassword())
+                .category(challenge.getCategory())
+                .verificationType(challenge.getVerificationType())
+                .startDate(challenge.getStartDate().toLocalDate())
+                .maxParticipants(challenge.getMaxParticipants())
+                .isViewerMode(challenge.getIsViewerMode())
+                .rule(challenge.getRule())
+                .verifyStartTime(challenge.getVerifyStartTime())
+                .verifyEndTime(challenge.getVerifyEndTime())
+                .daysOfWeek(daysOfWeek)
+                .imageKey(challenge.getImageKey())
+                .imageUrl(s3UrlUtil.toFullUrl(challenge.getImageKey()))
+                .build();
     }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -84,7 +84,7 @@ public class ChallengeConverter {
             long remainDays,
             boolean isParticipant,
             boolean isLiked,
-            ActionButtonStatus actionButtonStatus
+            ActionButtonStatus actionButtonStatus,
             boolean isOwner
     ) {
         // 방장 정보 마스킹: owner가 null(정보 삭제됨)이거나 비활성 상태(탈퇴 처리됨)인 경우 통합 처리

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeRequestDto.java
@@ -113,8 +113,8 @@ public class ChallengeRequestDto {
         @NotNull(message = "isPublic은 필수입니다.")
         private Boolean isPublic;
 
-        @Schema(description = "비공개 비밀번호 (4자리 숫자). 공개 챌린지라면 null 가능", example = "1234")
-        @Pattern(regexp = "^\\d{4}$", message = "비밀번호는 4자리 숫자여야 합니다.")
+        @Schema(description = "비공개 비밀번호 (4자리 숫자). 공개 챌린지라면 null 가능. 비공개 챌린지에서 비워두면 기존 비밀번호가 유지됩니다.", example = "1234")
+        @Pattern(regexp = "^$|^\\d{4}$", message = "비밀번호는 4자리 숫자여야 합니다.")
         private String password;
 
         @Schema(description = "챌린지 카테고리", example = "HEALTH")

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -265,8 +265,8 @@ public class ChallengeResponseDto {
         @Schema(description = "공개 여부 (true: 공개, false: 비공개)", example = "true")
         private Boolean isPublic;
 
-        @Schema(description = "비공개 비밀번호 (4자리 숫자). 공개 챌린지라면 null", example = "1234")
-        private String password;
+        @Schema(description = "비공개 비밀번호 설정 여부 (true: 설정됨, false: 없음/공개 챌린지). 평문 비밀번호는 응답에 포함되지 않으며, 수정 시 비워두면 기존 비밀번호가 유지됩니다.", example = "true")
+        private Boolean hasPassword;
 
         @Schema(description = "챌린지 카테고리", example = "STUDY")
         private Category category;

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -10,6 +10,7 @@ import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 
 import com.hrr.backend.global.common.enums.VerificationType;
+import com.hrr.backend.global.common.enums.Category;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -155,6 +156,9 @@ public class ChallengeResponseDto {
 		@Schema(description = "현재 유저의 참여 여부", example = "true")
 		private Boolean isParticipant;
 
+        @Schema(description = "현재 유저가 방장인지 여부", example = "false")
+        private Boolean isOwner;
+
 		@Schema(description = "현재 유저의 좋아요(찜) 여부", example = "false")
 		private Boolean isLiked;
 
@@ -234,4 +238,67 @@ public class ChallengeResponseDto {
         private Long challengeId;
     }
 
+    @Getter
+    @AllArgsConstructor
+    @Schema(description = "챌린지 나가기 응답 DTO")
+    public static class LeaveChallengeDto {
+
+        @Schema(description = "나간 챌린지 ID", example = "1")
+        private Long challengeId;
+
+        @Schema(description = "나간 후 현재 인원 수", example = "9")
+        private Integer currentParticipantCount;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @Schema(description = "챌린지 수정용 상세 정보 응답 DTO (개설 화면 폼 채우기용)")
+    public static class EditInfoDto {
+
+        @Schema(description = "챌린지 제목", example = "백준 실버3 코테")
+        private String title;
+
+        @Schema(description = "챌린지 설명", example = "백준 실버3 매일 풀고 공유")
+        private String description;
+
+        @Schema(description = "공개 여부 (true: 공개, false: 비공개)", example = "true")
+        private Boolean isPublic;
+
+        @Schema(description = "비공개 비밀번호 (4자리 숫자). 공개 챌린지라면 null", example = "1234")
+        private String password;
+
+        @Schema(description = "챌린지 카테고리", example = "STUDY")
+        private Category category;
+
+        @Schema(description = "인증 방식", example = "PHOTO")
+        private VerificationType verificationType;
+
+        @Schema(description = "챌린지 시작일", example = "2025-11-24")
+        private LocalDate startDate;
+
+        @Schema(description = "최대 참여 인원", example = "10")
+        private Integer maxParticipants;
+
+        @Schema(description = "관찰자 모드 허용 여부", example = "true")
+        private Boolean isViewerMode;
+
+        @Schema(description = "챌린지 규칙", example = "하루에 1만 보 이상 걸은 스크린샷을 인증해야 합니다.")
+        private String rule;
+
+        @Schema(description = "인증 시작 시간", example = "10:00:00")
+        private LocalTime verifyStartTime;
+
+        @Schema(description = "인증 종료 시간", example = "18:00:00")
+        private LocalTime verifyEndTime;
+
+        @Schema(description = "인증 요일 목록", example = "[\"MONDAY\", \"THURSDAY\"]")
+        private List<ChallengeDays> daysOfWeek;
+
+        @Schema(description = "챌린지 이미지 Key", example = "challenges/uuid_image.jpg")
+        private String imageKey;
+
+        @Schema(description = "챌린지 이미지 미리보기 URL", example = "https://example.com/challenges/uuid_image.jpg")
+        private String imageUrl;
+    }
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -70,4 +70,10 @@ public interface ChallengeService {
             Long challengeId,
             ChallengeRequestDto.UpdateChallengeDto requestDto
     );
+
+    // 챌린지 나가기 (방장 불가, 시작일 전까지만 가능)
+    ChallengeResponseDto.LeaveChallengeDto leaveChallenge(User user, Long challengeId);
+
+    // 챌린지 수정 화면 진입 시 폼을 채우기 위한 상세 정보 조회
+    ChallengeResponseDto.EditInfoDto getChallengeEditInfo(User user, Long challengeId);
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -200,10 +200,14 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 버튼 상태 결정
 		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
 
+        // 현재 유저가 방장인지 여부
+        boolean isOwner = (owner != null) && owner.getId().equals(user.getId());
+
 		// DTO 변환 및 반환
 		return challengeConverter.toHeaderInfoDto(
 				challenge, owner, isOwnerActive, startDate, endDate, remainDays,
-				isParticipant, isLiked, buttonStatus
+				isParticipant, isLiked, buttonStatus,
+                isOwner
 		);
 	}
 
@@ -493,6 +497,63 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return challengeConverter.toJoinResponseDto(challenge);
 	}
 
+    // 챌린지 나가기
+    @Override
+    @Transactional
+    public ChallengeResponseDto.LeaveChallengeDto leaveChallenge(User user, Long challengeId) {
+        // 참가자 수 정합성 보장을 위한 락 조회 (참가 로직과 동일)
+        Challenge challenge = findChallengeForUpdate(challengeId);
+
+        // 내 참여 정보 조회
+        UserChallenge userChallenge = userChallengeRepository.findByUserAndChallenge(user, challenge)
+                .orElseThrow(() -> new GlobalException(ErrorCode.USER_CHALLENGE_NOT_FOUND));
+
+        // 비즈니스 룰 검증 (방장 여부, 참여 상태, 시작일 전 여부)
+        validateLeaveRequest(challenge, userChallenge);
+
+        // 현재 라운드의 내 RoundRecord 삭제 (아직 시작 전이라 라운드는 1개, 인증 기록도 없음)
+        Round currentRound = challenge.getCurrentRound();
+        if (currentRound != null) {
+            roundRecordRepository.findByUserChallengeAndRoundId(userChallenge, currentRound.getId())
+                    .ifPresent(roundRecordRepository::delete);
+        }
+
+        // UserChallenge 삭제 (상태값으로 남기지 않고 참가 이력 자체를 제거)
+        userChallengeRepository.delete(userChallenge);
+
+        // 참가자 수 감소 (참가 로직의 반대)
+        challenge.decreaseCurrentParticipants();
+
+        // challenge_statics 재집계 (JOINED 기준 전체 재계산이라 join과 동일하게 재사용 가능)
+        challengeStaticsService.updateChallengeStatics(challenge);
+
+        return challengeConverter.toLeaveResponseDto(challenge);
+    }
+
+    /**
+     * 챌린지 나가기 요청에 대한 비즈니스 검증 로직
+     * - 참여 상태(JOINED)가 아니면 나가기 불가
+     * - 방장(OWNER)은 나가기 불가
+     * - 챌린지가 시작 전(UPCOMING)일 때만 나가기 가능
+     */
+    private void validateLeaveRequest(Challenge challenge, UserChallenge userChallenge) {
+
+        // 참여 중(JOINED) 상태가 아니면 나가기 불가
+        if (userChallenge.getStatus() != ChallengeJoinStatus.JOINED) {
+            throw new GlobalException(ErrorCode.USER_CHALLENGE_NOT_FOUND);
+        }
+
+        // 방장은 나가기 불가 (수정/삭제만 가능)
+        if (userChallenge.getRole() == UserChallengeRole.OWNER) {
+            throw new GlobalException(ErrorCode.CHALLENGE_LEAVE_FORBIDDEN_OWNER);
+        }
+
+        // 챌린지 시작 전(UPCOMING)까지만 나가기 가능
+        if (challenge.getStatus() != ChallengeStatus.UPCOMING) {
+            throw new GlobalException(ErrorCode.CHALLENGE_LEAVE_PERIOD_EXPIRED);
+        }
+    }
+
 	private void createRoundRecordOrFail(Challenge challenge, UserChallenge userChallenge) {
 		Round currentRound = challenge.getCurrentRound(); //
 
@@ -633,6 +694,23 @@ public class ChallengeServiceImpl implements ChallengeService {
 				})
 				.toList();
 	}
+
+    // 챌린지 수정용 상세 정보 조회
+    @Override
+    @Transactional(readOnly = true)
+    public ChallengeResponseDto.EditInfoDto getChallengeEditInfo(User user, Long challengeId) {
+        // 챌린지 조회 (요일 정보 포함)
+        Challenge challenge = findChallengeWithDays(challengeId);
+
+        // 방장 권한 검증 (updateChallenge와 동일한 검증 재사용)
+        validateOwner(user, challengeId);
+
+        // 수정 가능 기간 검증 (한국 시간 기준: 시작일 전날 23:59:59까지, updateChallenge와 동일한 검증 재사용)
+        validateUpdatePeriod(challenge);
+
+        return challengeConverter.toEditInfoDto(challenge);
+    }
+
     @Override
     @Transactional
     public ChallengeResponseDto.UpdateChallengeDto updateChallenge(

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -548,10 +548,7 @@ public class ChallengeServiceImpl implements ChallengeService {
             throw new GlobalException(ErrorCode.CHALLENGE_LEAVE_FORBIDDEN_OWNER);
         }
 
-        // 챌린지 시작 전(UPCOMING)까지만 나가기 가능
-        if (challenge.getStatus() != ChallengeStatus.UPCOMING) {
-            throw new GlobalException(ErrorCode.CHALLENGE_LEAVE_PERIOD_EXPIRED);
-        }
+        validateBeforeStartDate(challenge, ErrorCode.CHALLENGE_LEAVE_PERIOD_EXPIRED);
     }
 
 	private void createRoundRecordOrFail(Challenge challenge, UserChallenge userChallenge) {
@@ -806,14 +803,26 @@ public class ChallengeServiceImpl implements ChallengeService {
      */
     private void validateUpdatePeriod(Challenge challenge) {
         // 한국 시간 기준 현재 날짜
+        validateBeforeStartDate(challenge, ErrorCode.CHALLENGE_UPDATE_PERIOD_EXPIRED);
+    }
+
+    /**
+     * 챌린지 시작일 전(KST 기준)인지 검증하는 공통 헬퍼
+     * - 수정(update), 나가기(leave) 등 "챌린지 시작일 전까지만 가능한" 액션에서 공통으로 사용
+     * - challenge.getStatus()(UPCOMING/ONGOING 등)는 ChallengeScheduler의 일배치(자정)로만 갱신되어
+     *   실제 날짜와 시간차가 생길 수 있으므로, 상태값 대신 KST 날짜를 startDate와 직접 비교한다.
+     * - 한국 시간(KST, Asia/Seoul) 기준, 시작일 전날 23:59:59까지만 허용, 시작일 당일부터 예외 발생
+     */
+    private void validateBeforeStartDate(Challenge challenge, ErrorCode errorCode) {
+        // 한국 시간 기준 현재 날짜
         LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
         // 챌린지 시작일 (startDate는 LocalDateTime으로 저장되어 있으므로 toLocalDate() 변환)
         LocalDate startDate = challenge.getStartDate().toLocalDate();
 
-        // 시작일 당일 또는 이후라면 수정 불가
+        // 시작일 당일 또는 이후라면 예외 발생
         if (!todayKst.isBefore(startDate)) {
-            throw new GlobalException(ErrorCode.CHALLENGE_UPDATE_PERIOD_EXPIRED);
+            throw new GlobalException(errorCode);
         }
     }
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -201,7 +201,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
 
         // 현재 유저가 방장인지 여부
-        boolean isOwner = (owner != null) && owner.getId().equals(user.getId());
+        boolean isOwner = Objects.equals(owner != null ? owner.getId() : null, user.getId());
 
 		// DTO 변환 및 반환
 		return challengeConverter.toHeaderInfoDto(

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -730,7 +730,7 @@ public class ChallengeServiceImpl implements ChallengeService {
         // 공개/비공개 처리
         boolean isPublic = req.getIsPublic();
         boolean isViewerMode = isPublic && req.getIsViewerMode();
-        String password = isPublic ? null : req.getPassword();
+        String password = resolveUpdatedPassword(challenge, req);
 
         // Challenge 필드 업데이트
         challenge.update(
@@ -853,10 +853,21 @@ public class ChallengeServiceImpl implements ChallengeService {
 
         // 공개/비공개 및 비밀번호, 관찰자 모드 검증
         if (!req.getIsPublic()) {
-            // 비공개인데 비밀번호가 없거나 4자리 숫자가 아닌 경우
-            if (req.getPassword() == null || !req.getPassword().matches("^\\d{4}$")) {
+            boolean isPasswordProvided = req.getPassword() != null && !req.getPassword().isBlank();
+            boolean hadPasswordBefore = !challenge.getIsPublic()
+                    && challenge.getPassword() != null
+                    && !challenge.getPassword().isBlank();
+
+            if (isPasswordProvided) {
+                // 새 비밀번호를 입력한 경우 형식 검증 (4자리 숫자)
+                if (!req.getPassword().matches("^\\d{4}$")) {
+                    throw new GlobalException(ErrorCode.CHALLENGE_PRIVATE_PASSWORD_REQUIRED);
+                }
+            } else if (!hadPasswordBefore) {
+                // 미입력인데 기존 비밀번호도 없는 경우(신규로 비공개 전환 등)는 비밀번호 필수
                 throw new GlobalException(ErrorCode.CHALLENGE_PRIVATE_PASSWORD_REQUIRED);
             }
+            // 미입력 + 기존 비밀번호 있음 -> 기존 비밀번호를 유지하므로 통과
             // 비공개 챌린지인데 관찰자 모드를 설정한 경우
             if (req.getIsViewerMode()) {
                 throw new GlobalException(ErrorCode.CHALLENGE_PRIVATE_VIEWER_MODE_NOT_ALLOWED);
@@ -867,6 +878,20 @@ public class ChallengeServiceImpl implements ChallengeService {
                 throw new GlobalException(ErrorCode.CHALLENGE_PUBLIC_PASSWORD_INPUT);
             }
         }
+    }
+
+    /**
+     * 챌린지 수정 기능 - 수정 요청의 비밀번호 필드를 실제 저장할 비밀번호로 변환
+     * - 공개 전환 시 비밀번호는 null
+     * - 비공개이면서 새 비밀번호가 입력된 경우 그 값으로 교체 (형식은 validateUpdateRequest에서 이미 검증됨)
+     * - 비공개이면서 비밀번호 미입력인 경우 기존 비밀번호 유지 (validateUpdateRequest를 통과했다면 기존 비밀번호가 반드시 존재함)
+     */
+    private String resolveUpdatedPassword(Challenge challenge, ChallengeRequestDto.UpdateChallengeDto req) {
+        if (req.getIsPublic()) {
+            return null;
+        }
+        boolean isPasswordProvided = req.getPassword() != null && !req.getPassword().isBlank();
+        return isPasswordProvided ? req.getPassword() : challenge.getPassword();
     }
 
 	/**

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -60,6 +60,8 @@ public enum ErrorCode implements BaseCode{
     CHALLENGE_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "CHALLENGE4032", "챌린지 수정 권한이 없습니다. 방장만 수정할 수 있습니다."),
     CHALLENGE_UPDATE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CHALLENGE40017", "챌린지 시작일 이후에는 수정할 수 없습니다."),
     CHALLENGE_MAX_PARTICIPANTS_BELOW_CURRENT(HttpStatus.BAD_REQUEST, "CHALLENGE40018", "최대 참여 인원은 현재 참여 인원보다 적을 수 없습니다."),
+    CHALLENGE_LEAVE_FORBIDDEN_OWNER(HttpStatus.FORBIDDEN, "CHALLENGE4033", "방장은 챌린지에서 나갈 수 없습니다."),
+    CHALLENGE_LEAVE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CHALLENGE40019", "챌린지 시작일 이후에는 나갈 수 없습니다."),
     // challenge wait
     CHALLENGE_WAIT_ALREADY_EXIST(HttpStatus.CONFLICT, "WAIT4091", "이미 알림 신청을 완료한 챌린지입니다."),
     CHALLENGE_WAIT_NOT_FOUND(HttpStatus.NOT_FOUND, "WAIT4041", "알림 신청 내역을 찾을 수 없습니다."),

--- a/src/main/java/com/hrr/backend/global/response/SuccessCode.java
+++ b/src/main/java/com/hrr/backend/global/response/SuccessCode.java
@@ -15,6 +15,7 @@ public enum SuccessCode implements BaseCode {
 
     // challenge
     CHALLENGE_UPDATE_OK(HttpStatus.OK, "CHALLENGE2001", "챌린지가 성공적으로 수정되었습니다."),
+    CHALLENGE_LEAVE_OK(HttpStatus.OK, "CHALLENGE2002", "챌린지에서 나갔습니다."),
 
     // comment
     COMMENT_POST_OK(HttpStatus.OK, "COMMENT2001","댓글이 작성되었습니다."),

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -421,7 +421,7 @@ class ChallengeServiceInfoTest {
     }
 
     private void mockConverter(ActionButtonStatus expectedStatus) {
-        given(challengeConverter.toHeaderInfoDto(any(), any(), anyBoolean(), any(), any(), anyLong(), anyBoolean(), anyBoolean(), any()))
+        given(challengeConverter.toHeaderInfoDto(any(), any(), anyBoolean(), any(), any(), anyLong(), anyBoolean(), anyBoolean(), any(), anyBoolean()))
                 .willAnswer(invocation -> ChallengeResponseDto.HeaderInfoDto.builder()
                         .actionButtonStatus(invocation.getArgument(8))
                         .build());


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #341 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

기존 챌린지는 한 번 참가하면 라운드 끝나기 전까지 중도 포기 불가
1. 챌린지 나가기 기능: 챌린지 시작일 전까지 참가자가 자유롭게 나갈 수 있음
2. 챌린지 수정용 상세조회: 값들을 미리 채워서 보여줄 조회 API가 없었으니 해당 API를 추가해서 동일한 폼 플로우로 수정 화면을 그리기 위해 기존 정보를 전부 내려줌

- 참가기록 처리 방식: 참여 이력 없어서 상태값으로 남겨두기보다 아예 삭제로 생각함
- 방장의 나가기 불가
- 비밀번호 노출 이슈: 방장이 수정하는거라서 괜찮겠다 했는데 코드래빗이 권한 검증과 평문 비밀번호 노출은 서로 다른 보안 영역이라고 해서 해당 부분을 반영했음(비밀번호 해시화 완료)
-

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="1332" height="546" alt="스크린샷 2026-07-22 131435" src="https://github.com/user-attachments/assets/5fb39d0d-71f6-44f2-a32a-772d1bd53933" />
<img width="1340" height="912" alt="스크린샷 2026-07-22 131444" src="https://github.com/user-attachments/assets/a1f2f7fd-7db7-4770-9b0f-791d2e29226c" />
<img width="1360" height="508" alt="스크린샷 2026-07-22 131512" src="https://github.com/user-attachments/assets/927dee6f-62fe-4f0a-88a8-e7e23f31b76c" />
<img width="1340" height="564" alt="스크린샷 2026-07-22 131520" src="https://github.com/user-attachments/assets/f777eeee-5f80-4665-a700-5365649d69bb" />
<img width="1352" height="508" alt="스크린샷 2026-07-22 131537" src="https://github.com/user-attachments/assets/a7515b4a-0f2d-4fc3-a30b-582b8f750647" />

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 수정 화면에서 필요한 상세 정보를 조회할 수 있습니다.
  * 챌린지 참가자는 시작일 전까지 챌린지에서 나갈 수 있습니다.
  * 챌린지 헤더에서 현재 사용자가 방장인지 확인할 수 있습니다.
* **오류 안내**
  * 방장 또는 시작일 이후에는 챌린지에서 나갈 수 없도록 안내 메시지가 제공됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->