### PR TITLE
[FEAT] 챌린지 프로필 연장 상태 조회 기능 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 
 import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
+import com.hrr.backend.domain.challenge.entity.enums.ExtensionStatus;
 import com.hrr.backend.global.s3.S3UrlUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -132,7 +133,8 @@ public class ChallengeConverter {
     public ChallengeResponseDto.ChallengeProfileDto toProfileDto(
             Challenge challenge,
             boolean isParticipating,
-            List<ChallengeDays> verifiedDays
+            List<ChallengeDays> verifiedDays,
+            ExtensionStatus extensionStatus
     ) {
         // Entity의 ChallengeDayJoin 리스트를 Enum 리스트로 변환
         List<ChallengeDays> targetDays = challenge.getChallengeDays().stream()
@@ -155,6 +157,7 @@ public class ChallengeConverter {
                 .verifyStartTime(challenge.getVerifyStartTime())
                 .verifyEndTime(challenge.getVerifyEndTime())
                 .verifiedDaysThisWeek(sortedVerifiedDays)// 미참여시 null
+                .extensionStatus(extensionStatus)
                 .build();
     }
 

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
+import com.hrr.backend.domain.challenge.entity.enums.ExtensionStatus;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 
 import com.hrr.backend.global.common.enums.VerificationType;
@@ -213,6 +214,9 @@ public class ChallengeResponseDto {
 
 		@Schema(description = "이번 주 인증 완료 요일 (참여 중일 때만 값 있음, 미참여시 null)", example = "[\"MONDAY\"]")
 		private List<ChallengeDays> verifiedDaysThisWeek;
+
+		@Schema(description = "연장 요청 상태 (NONE, PENDING, COMPLETED)", example = "PENDING")
+		private ExtensionStatus extensionStatus;
 	}
 
 	@Getter

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ExtensionStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ExtensionStatus.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.challenge.entity.enums;
+
+public enum ExtensionStatus {
+    NONE,
+    PENDING,
+    COMPLETED
+}

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ExtensionStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ExtensionStatus.java
@@ -1,7 +1,7 @@
 package com.hrr.backend.domain.challenge.entity.enums;
 
 public enum ExtensionStatus {
-    NONE,
-    PENDING,
-    COMPLETED
+    NONE,       // 연장 가능 기간이 아니거나 연장 대상이 아님
+    PENDING,    // 연장 가능 기간이며 다음 라운드 참여 여부를 아직 선택하지 않음
+    COMPLETED   // 다음 라운드 참여 여부를 선택 완료함
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -19,12 +19,14 @@ import com.hrr.backend.domain.challenge.entity.ChallengeLike; // Import 추가
 import com.hrr.backend.domain.challenge.entity.ChallengeWait;
 import com.hrr.backend.domain.challenge.event.ChallengeCreatedEvent;
 import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
+import com.hrr.backend.domain.challenge.entity.enums.ExtensionStatus;
 import com.hrr.backend.domain.challenge.repository.ChallengeLikeRepository; // Import 추가
 import com.hrr.backend.domain.challenge.repository.ChallengeWaitRepository;
 import com.hrr.backend.domain.notification.event.ChallengeUpdatedEvent;
 import com.hrr.backend.domain.round.converter.RoundConverter;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
 import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.round.repository.RoundRepository;
 import com.hrr.backend.domain.user.converter.UserChallengeConverter;
@@ -99,6 +101,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 	private static final String TODAY_CHALLENGE_RANKING_KEY = "today:challenge:clicks";
 
 	private final S3UrlUtil s3UrlUtil;
+
+	private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
 
 	@Override
 	public SliceResponseDto<ChallengeResponseDto.InfoDto> getChallengeList(
@@ -218,11 +222,13 @@ public class ChallengeServiceImpl implements ChallengeService {
 		Challenge challenge = findChallengeWithDays(challengeId);
 
 		// 참여 여부 확인
-		boolean isParticipating = userChallengeRepository.findByUserAndChallenge(user, challenge)
+		Optional<UserChallenge> userChallengeOptional = userChallengeRepository.findByUserAndChallenge(user, challenge);
+		boolean isParticipating = userChallengeOptional
 				.map(uc -> uc.getStatus() == ChallengeJoinStatus.JOINED)
 				.orElse(false);
 
 		List<ChallengeDays> verifiedDaysThisWeek = null;
+		ExtensionStatus extensionStatus = ExtensionStatus.NONE;
 
 		// 참여 중일 때만 계산
 		if (isParticipating) {
@@ -246,9 +252,34 @@ public class ChallengeServiceImpl implements ChallengeService {
 					.map(v -> ChallengeDays.from(v.getCreatedAt().getDayOfWeek()))
 					.distinct()
 					.toList();
+
+			extensionStatus = calculateExtensionStatus(userChallengeOptional.get(), challenge.getCurrentRound());
 		}
 
-		return challengeConverter.toProfileDto(challenge, isParticipating, verifiedDaysThisWeek);
+		return challengeConverter.toProfileDto(challenge, isParticipating, verifiedDaysThisWeek, extensionStatus);
+	}
+
+	private ExtensionStatus calculateExtensionStatus(UserChallenge userChallenge, Round currentRound) {
+		if (currentRound == null || !isExtensionPeriodOpen(currentRound, LocalDate.now(KOREA_ZONE))) {
+			return ExtensionStatus.NONE;
+		}
+
+		return roundRecordRepository.findByUserChallengeAndRoundId(userChallenge, currentRound.getId())
+				.map(roundRecord -> roundRecord.getNextRoundIntent() == NextRoundIntent.UNDECIDED
+						? ExtensionStatus.PENDING
+						: ExtensionStatus.COMPLETED)
+				.orElse(ExtensionStatus.NONE);
+	}
+
+	private boolean isExtensionPeriodOpen(Round currentRound, LocalDate today) {
+		if (today.isBefore(currentRound.getStartDate()) || today.isAfter(currentRound.getEndDate())) {
+			return false;
+		}
+
+		LocalDate decisionOpenDate = currentRound.getEndDate().minusDays(3);
+		LocalDate decisionCloseDate = currentRound.getEndDate().minusDays(2);
+
+		return !today.isBefore(decisionOpenDate) && !today.isAfter(decisionCloseDate);
 	}
 
 	@Override

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -259,6 +259,11 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return challengeConverter.toProfileDto(challenge, isParticipating, verifiedDaysThisWeek, extensionStatus);
 	}
 
+	/**
+	 * 현재 라운드의 연장 상태 계산
+	 * 연장 가능 기간(D-3 ~ D-2)에만 상태 노출
+	 * 미응답은 PENDING, 응답 완료는 COMPLETED를 반환
+	 */
 	private ExtensionStatus calculateExtensionStatus(UserChallenge userChallenge, Round currentRound) {
 		if (currentRound == null || !isExtensionPeriodOpen(currentRound, LocalDate.now(KOREA_ZONE))) {
 			return ExtensionStatus.NONE;
@@ -271,6 +276,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 				.orElse(ExtensionStatus.NONE);
 	}
 
+	/**
+	 * 현재 날짜가 연장 의사 결정 기간(D-3 ~ D-2)인지 확인
+	 */
 	private boolean isExtensionPeriodOpen(Round currentRound, LocalDate today) {
 		if (today.isBefore(currentRound.getStartDate()) || today.isAfter(currentRound.getEndDate())) {
 			return false;

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceProfileTest.java
@@ -4,7 +4,12 @@ import com.hrr.backend.domain.challenge.converter.ChallengeConverter;
 import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
+import com.hrr.backend.domain.challenge.entity.enums.ExtensionStatus;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.entity.RoundRecord;
+import com.hrr.backend.domain.round.entity.enums.NextRoundIntent;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
 import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
@@ -23,8 +28,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.DayOfWeek;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.ZoneId;
 import java.time.temporal.TemporalAdjusters;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +41,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
@@ -44,6 +52,7 @@ class ChallengeServiceProfileTest {
 
     @Mock private ChallengeRepository challengeRepository;
     @Mock private UserChallengeRepository userChallengeRepository;
+    @Mock private RoundRecordRepository roundRecordRepository;
     @Mock private VerificationRepository verificationRepository;
 
     @Mock private S3UrlUtil s3UrlUtil;
@@ -86,6 +95,7 @@ class ChallengeServiceProfileTest {
         assertThat(result.getTargetDays()).contains(ChallengeDays.MONDAY, ChallengeDays.THURSDAY); // 목표는 2개
         assertThat(result.getVerifiedDaysThisWeek()).hasSize(1); // 인증은 1개
         assertThat(result.getVerifiedDaysThisWeek()).containsOnly(ChallengeDays.MONDAY); // 월요일만 포함
+        assertThat(result.getExtensionStatus()).isEqualTo(ExtensionStatus.NONE);
     }
 
     @Test
@@ -182,6 +192,8 @@ class ChallengeServiceProfileTest {
         // Then
         assertThat(result.getIsParticipating()).isFalse();
         assertThat(result.getVerifiedDaysThisWeek()).isNull();
+        assertThat(result.getExtensionStatus()).isEqualTo(ExtensionStatus.NONE);
+        verify(roundRecordRepository, never()).findByUserChallengeAndRoundId(any(), any());
     }
 
     @Test
@@ -228,14 +240,87 @@ class ChallengeServiceProfileTest {
         assertThat(capturedEnd.getDayOfWeek()).isEqualTo(DayOfWeek.SATURDAY);
     }
 
+    @Test
+    @DisplayName("7. [연장 기간/미응답] 참여 중이고 현재 라운드 연장 가능 기간이며 응답 전이면 PENDING")
+    void getChallengeProfile_ExtensionPeriod_Undecided_Pending() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Round currentRound = createExtensionOpenRound();
+        Challenge challenge = createChallenge(challengeId, "연장 미응답 테스트", List.of(ChallengeDays.MONDAY), currentRound);
+        UserChallenge userChallenge = mockParticipating(user, challenge);
+
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findWeeklyVerifications(any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
+        given(roundRecordRepository.findByUserChallengeAndRoundId(userChallenge, currentRound.getId()))
+                .willReturn(Optional.of(createRoundRecord(userChallenge, currentRound, NextRoundIntent.UNDECIDED)));
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getExtensionStatus()).isEqualTo(ExtensionStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("8. [연장 기간/응답 완료] 참여 중이고 현재 라운드 연장 가능 기간이며 이미 응답했으면 COMPLETED")
+    void getChallengeProfile_ExtensionPeriod_Responded_Completed() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Round currentRound = createExtensionOpenRound();
+        Challenge challenge = createChallenge(challengeId, "연장 응답 완료 테스트", List.of(ChallengeDays.MONDAY), currentRound);
+        UserChallenge userChallenge = mockParticipating(user, challenge);
+
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findWeeklyVerifications(any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
+        given(roundRecordRepository.findByUserChallengeAndRoundId(userChallenge, currentRound.getId()))
+                .willReturn(Optional.of(createRoundRecord(userChallenge, currentRound, NextRoundIntent.CONTINUE)));
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getExtensionStatus()).isEqualTo(ExtensionStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("9. [연장 기간 외] 참여 중이어도 연장 가능 기간이 아니면 NONE")
+    void getChallengeProfile_NotExtensionPeriod_None() {
+        // Given
+        Long challengeId = 1L;
+        User user = User.builder().id(100L).build();
+        Round currentRound = createExtensionClosedRound();
+        Challenge challenge = createChallenge(challengeId, "연장 기간 외 테스트", List.of(ChallengeDays.MONDAY), currentRound);
+
+        mockParticipating(user, challenge);
+        given(challengeRepository.findByIdWithDays(challengeId)).willReturn(Optional.of(challenge));
+        given(verificationRepository.findWeeklyVerifications(any(), any(), any(), any(), any()))
+                .willReturn(Collections.emptyList());
+
+        // When
+        ChallengeResponseDto.ChallengeProfileDto result = challengeService.getChallengeProfile(user, challengeId);
+
+        // Then
+        assertThat(result.getExtensionStatus()).isEqualTo(ExtensionStatus.NONE);
+        verify(roundRecordRepository, never()).findByUserChallengeAndRoundId(any(), any());
+    }
+
     // 챌린지 생성 헬퍼
     private Challenge createChallenge(Long id, String title, List<ChallengeDays> targetDays) {
+        return createChallenge(id, title, targetDays, null);
+    }
+
+    private Challenge createChallenge(Long id, String title, List<ChallengeDays> targetDays, Round currentRound) {
         Challenge challenge = Challenge.builder()
                 .id(id)
                 .title(title)
                 .rule("규칙")
                 .verifyStartTime(LocalTime.of(9, 0))
                 .verifyEndTime(LocalTime.of(18, 0))
+                .currentRound(currentRound)
                 .build();
 
         // 목표 요일 추가
@@ -264,12 +349,13 @@ class ChallengeServiceProfileTest {
     }
 
     // 참여 상태 Mocking
-    private void mockParticipating(User user, Challenge challenge) {
+    private UserChallenge mockParticipating(User user, Challenge challenge) {
         UserChallenge uc = UserChallenge.builder()
                 .id(10L).user(user).challenge(challenge)
                 .status(ChallengeJoinStatus.JOINED)
                 .build();
         given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(uc));
+        return uc;
     }
 
     // Repository 호출 Mocking (Common)
@@ -283,5 +369,31 @@ class ChallengeServiceProfileTest {
                 any(LocalDateTime.class),
                 eq(VerificationStatus.COMPLETED)
         )).willReturn(verifications);
+    }
+
+    private Round createExtensionOpenRound() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return Round.builder()
+                .id(20L)
+                .startDate(today.minusDays(1))
+                .endDate(today.plusDays(3))
+                .build();
+    }
+
+    private Round createExtensionClosedRound() {
+        LocalDate today = LocalDate.now(ZoneId.of("Asia/Seoul"));
+        return Round.builder()
+                .id(20L)
+                .startDate(today.minusDays(1))
+                .endDate(today.plusDays(5))
+                .build();
+    }
+
+    private RoundRecord createRoundRecord(UserChallenge userChallenge, Round round, NextRoundIntent intent) {
+        return RoundRecord.builder()
+                .userChallenge(userChallenge)
+                .round(round)
+                .nextRoundIntent(intent)
+                .build();
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> Close #349 

---

## ✨ 작업 내용 (Summary)

- 챌린지 프로필 조회 응답에 `extensionStatus` 필드를 추가했습니다.
- 연장 가능 기간(D-3 ~ D-2) 여부를 판단하는 로직을 구현했습니다.
- `RoundRecord.nextRoundIntent`를 기반으로 연장 상태(NONE, PENDING, COMPLETED)를 계산하도록 구현했습니다.
- 연장 상태 계산 로직 및 `ExtensionStatus` enum에 주석을 추가했습니다.
- 연장 상태 관련 단위 테스트를 추가했습니다.

---

## ✅ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

* **테스트 환경:** 로컬
* **테스트 방법:** 단위 테스트(JUnit) 및 Postman API 테스트
* **결과 요약:**
  * 연장 가능 기간이 아닌 경우 `NONE` 반환 확인
  * 연장 가능 기간 + `UNDECIDED`인 경우 `PENDING` 반환 확인
  * 연장 가능 기간 + `CONTINUE`인 경우 `COMPLETED` 반환 확인
  * 기존 챌린지 프로필 조회 기능 정상 동작 확인

---

## 📸 스크린샷

> 필요 시 첨부

| 미참여 챌린지 | 연장 기간 아님 |
|---|---|
| <img width="1322" height="776" alt="image" src="https://github.com/user-attachments/assets/3eebe083-06ab-4010-b4cd-81330939b03a" /> |  <img width="1324" height="780" alt="image" src="https://github.com/user-attachments/assets/bdbe9aeb-3084-489b-b27a-fb68988c6c0e" /> |

| 연장 기간 + 응답 안 함 | 연장 기간 + 응답 완료 |
|---|---|
| <img width="1324" height="780" alt="image" src="https://github.com/user-attachments/assets/d83bf774-1a5f-4872-9e5a-167739703d64" /> |  <img width="1334" height="770" alt="image" src="https://github.com/user-attachments/assets/62be15d4-b318-4261-b25a-a61bbfe3e042" /> |

---

## 💬 리뷰 요구사항

- 연장 가능 기간(D-3 ~ D-2) 계산 로직이 요구사항에 맞게 구현되었는지 확인 부탁드립니다.
- `extensionStatus` 계산 로직과 응답 구조가 적절한지 함께 검토 부탁드립니다.

---

## 📎 참고 자료

-

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 프로필에 연장 상태 정보를 제공합니다.
  * 연장 상태를 `NONE`, `PENDING`, `COMPLETED`로 구분해 표시합니다.
  * 연장 가능 기간과 다음 라운드 참여 의사에 따라 상태가 자동으로 결정됩니다.

* **버그 수정**
  * 미참여자 및 연장 기간 외 사용자에게 올바른 기본 상태를 제공합니다.

* **테스트**
  * 연장 상태별 프로필 응답 시나리오를 검증했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->