### PR TITLE
[Feat] 챌린지 빈자리 알림 신청 상태 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -164,7 +164,7 @@ public class ChallengeResponseDto {
 		private Boolean isLiked;
 
 		// 하단 버튼 상태
-		@Schema(description = "하단 버튼 상태 (JOIN, DISABLED, WAITLIST, CERTIFY_AVAILABLE, CERTIFIED)", example = "CERTIFIED")
+		@Schema(description = "하단 버튼 상태 (AVAILABLE, DONE, UPCOMING, NOT_DAY, NOT_TIME, JOIN, WAITLIST, WAITLISTED, FINISHED, MAX_LIMIT_EXCEEDED, REJECT)", example = "AVAILABLE")
 		private ActionButtonStatus actionButtonStatus;
 
 		// 방장 정보

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -164,7 +164,7 @@ public class ChallengeResponseDto {
 		private Boolean isLiked;
 
 		// 하단 버튼 상태
-		@Schema(description = "하단 버튼 상태 (AVAILABLE, DONE, UPCOMING, NOT_DAY, NOT_TIME, JOIN, WAITLIST, WAITLISTED, FINISHED, MAX_LIMIT_EXCEEDED)", example = "AVAILABLE")
+		@Schema(description = "하단 버튼 상태 (AVAILABLE, DONE, UPCOMING, NOT_DAY, NOT_TIME, JOIN, WAITLIST, WAITLISTED, FINISHED, MAX_LIMIT_EXCEEDED, WITHDRAWN)", example = "AVAILABLE")
 		private ActionButtonStatus actionButtonStatus;
 
 		// 방장 정보

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -164,7 +164,7 @@ public class ChallengeResponseDto {
 		private Boolean isLiked;
 
 		// 하단 버튼 상태
-		@Schema(description = "하단 버튼 상태 (AVAILABLE, DONE, UPCOMING, NOT_DAY, NOT_TIME, JOIN, WAITLIST, WAITLISTED, FINISHED, MAX_LIMIT_EXCEEDED, REJECT)", example = "AVAILABLE")
+		@Schema(description = "하단 버튼 상태 (AVAILABLE, DONE, UPCOMING, NOT_DAY, NOT_TIME, JOIN, WAITLIST, WAITLISTED, FINISHED, MAX_LIMIT_EXCEEDED)", example = "AVAILABLE")
 		private ActionButtonStatus actionButtonStatus;
 
 		// 방장 정보

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -16,6 +16,7 @@ public enum ActionButtonStatus {
     // 2. 미참여자용 상태
     JOIN("참가하기"),
     WAITLIST("빈자리 알림 받기"),
+    WAITLISTED("빈자리 알림 신청 완료"),
 
     // 3. 제한 상태 (DISABLED 세분화)
     FINISHED("종료된 챌린지"),

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -20,8 +20,7 @@ public enum ActionButtonStatus {
 
     // 3. 제한 상태 (DISABLED 세분화)
     FINISHED("종료된 챌린지"),
-    MAX_LIMIT_EXCEEDED("참여 개수 초과"),
-    REJECT("참가 신청 불가");
+    MAX_LIMIT_EXCEEDED("참여 개수 초과");
 
     private final String description;
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/entity/enums/ActionButtonStatus.java
@@ -20,7 +20,8 @@ public enum ActionButtonStatus {
 
     // 3. 제한 상태 (DISABLED 세분화)
     FINISHED("종료된 챌린지"),
-    MAX_LIMIT_EXCEEDED("참여 개수 초과");
+    MAX_LIMIT_EXCEEDED("참여 개수 초과"),
+    WITHDRAWN("참여할 수 없는 챌린지");
 
     private final String description;
 }

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -107,6 +107,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 	private final S3UrlUtil s3UrlUtil;
 
 	private static final ZoneId KOREA_ZONE = ZoneId.of("Asia/Seoul");
+	private static final long MAX_ACTIVE_CHALLENGE_COUNT = 5L;
 
 	@Override
 	public SliceResponseDto<ChallengeResponseDto.InfoDto> getChallengeList(
@@ -188,7 +189,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		}
 
 		// 챌린지 참여 개수 조회
-		boolean isMaxJoined = challengeRepository.countByUserIdAndStatus(user.getId(), ChallengeJoinStatus.JOINED) >= 5;
+		boolean isMaxJoined = hasReachedActiveChallengeLimit(user);
 
 		// 좋아요 여부 조회
 		boolean isLiked = challengeLikeRepository.existsByUserAndChallenge(user, challenge);
@@ -636,6 +637,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 			throw new GlobalException(ErrorCode.CHALLENGE_WAIT_ALREADY_EXIST);
 		}
 
+		validateActiveChallengeLimit(user);
+
 		// 자리가 남아있는 경우 대기 신청 불가
 		if (challenge.getCurrentParticipants() < challenge.getMaxParticipants()) {
 			throw new GlobalException(ErrorCode.CHALLENGE_NOT_FULL);
@@ -946,10 +949,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 	 */
 	private void validateCreateRequest(User owner, ChallengeRequestDto.CreateChallengeDto req) {
 
-		// 참가 중인 챌린지가 5개일 경우 요청 거절
-		if (challengeRepository.countByUserIdAndStatus(owner.getId(), ChallengeJoinStatus.JOINED) >= 5) {
-			throw new GlobalException(ErrorCode.MAX_CHALLENGE_EXCEEDED);
-		}
+		validateActiveChallengeLimit(owner);
 
         LocalDate todayKst = LocalDate.now(ZoneId.of("Asia/Seoul"));
 
@@ -987,10 +987,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 	 */
 	private void validateJoinRequest(Challenge challenge, User user, String inputPassword) {
 
-		// 참가 중인 챌린지가 5개일 경우 요청 거절
-		if (challengeRepository.countByUserIdAndStatus(user.getId(), ChallengeJoinStatus.JOINED) >= 5) {
-			throw new GlobalException(ErrorCode.MAX_CHALLENGE_EXCEEDED);
-		}
+		validateActiveChallengeLimit(user);
 
 		// 상태 검증 (종료만 아니면 모두 참여 가능)
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
@@ -1025,6 +1022,16 @@ public class ChallengeServiceImpl implements ChallengeService {
 			log.error("[Data Error] 챌린지의 현재 라운드(CurrentRound)가 null입니다. challengeId={}", challenge.getId());
 			throw new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR);
 		}
+	}
+
+	private void validateActiveChallengeLimit(User user) {
+		if (hasReachedActiveChallengeLimit(user)) {
+			throw new GlobalException(ErrorCode.MAX_CHALLENGE_EXCEEDED);
+		}
+	}
+
+	private boolean hasReachedActiveChallengeLimit(User user) {
+		return challengeRepository.countByUserIdAndStatus(user.getId(), ChallengeJoinStatus.JOINED) >= MAX_ACTIVE_CHALLENGE_COUNT;
 	}
 
 	// 챌린지 일반 조회용
@@ -1109,19 +1116,24 @@ public class ChallengeServiceImpl implements ChallengeService {
 			return isCertifiedToday ? ActionButtonStatus.DONE : ActionButtonStatus.AVAILABLE;
 		}
 
-		// 3. 미참여자이면서 참여가 제한되는 경우
+		// 3. 만석인 챌린지에 이미 빈자리 알림을 신청한 경우
+		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
+			if (challengeWaitRepository.existsByUserAndChallenge(user, challenge)) {
+				return ActionButtonStatus.WAITLISTED;
+			}
+		}
+
+		// 4. 미참여자이면서 참여가 제한되는 경우
 		if (isMaxJoined) {
 			return ActionButtonStatus.MAX_LIMIT_EXCEEDED;
 		}
 
-		// 4. 미참여자 정원 체크
+		// 5. 미참여자 정원 체크
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
-			return challengeWaitRepository.existsByUserAndChallenge(user, challenge)
-					? ActionButtonStatus.WAITLISTED
-					: ActionButtonStatus.WAITLIST;
+			return ActionButtonStatus.WAITLIST;
 		}
 
-		// 5. 그 외 참여 가능
+		// 6. 그 외 참여 가능
 		return ActionButtonStatus.JOIN;
 	}
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -206,7 +206,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
-		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
+		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, user, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
 
         // 현재 유저가 방장인지 여부
         boolean isOwner = Objects.equals(owner != null ? owner.getId() : null, user.getId());
@@ -1087,7 +1087,7 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-	private ActionButtonStatus resolveButtonStatus(Challenge challenge, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined, boolean isKicked) {
+	private ActionButtonStatus resolveButtonStatus(Challenge challenge, User user, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined, boolean isKicked) {
 
 		// 1. 챌린지 자체가 종료된 경우
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
@@ -1125,7 +1125,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 		// 5. 미참여자 정원 체크
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
-			return ActionButtonStatus.WAITLIST;
+			return challengeWaitRepository.existsByUserAndChallenge(user, challenge)
+					? ActionButtonStatus.WAITLISTED
+					: ActionButtonStatus.WAITLIST;
 		}
 
 		// 6. 그 외 참여 가능

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -174,7 +174,6 @@ public class ChallengeServiceImpl implements ChallengeService {
 		// 유저 상태 확인 (참여 여부, 오늘 인증 여부)
 		boolean isParticipant = false;
 		boolean isCertifiedToday = false;
-		boolean isKicked = false; // 강퇴 여부 플래그 추가
 
         // 유저가 참여 중인지 확인
         Optional<UserChallenge> ucOp = userChallengeRepository.findByUserAndChallenge(user, challenge);
@@ -185,9 +184,6 @@ public class ChallengeServiceImpl implements ChallengeService {
 			if (uc.getStatus() == ChallengeJoinStatus.JOINED && challenge.getStatus() != ChallengeStatus.FINISHED) {
 				isParticipant = true;
 				isCertifiedToday = checkTodayVerification(uc.getId(), challenge);
-			}
-			else if (uc.getStatus() == ChallengeJoinStatus.KICKED) {
-				isKicked = true;
 			}
 		}
 
@@ -206,7 +202,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
-		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, user, isParticipant, isCertifiedToday, isMaxJoined, isKicked);
+		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, user, isParticipant, isCertifiedToday, isMaxJoined);
 
         // 현재 유저가 방장인지 여부
         boolean isOwner = Objects.equals(owner != null ? owner.getId() : null, user.getId());
@@ -1087,19 +1083,14 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-	private ActionButtonStatus resolveButtonStatus(Challenge challenge, User user, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined, boolean isKicked) {
+	private ActionButtonStatus resolveButtonStatus(Challenge challenge, User user, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
 
 		// 1. 챌린지 자체가 종료된 경우
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
 			return ActionButtonStatus.FINISHED;
 		}
 
-		// 2. 강퇴된 유저의 경우
-		if (isKicked) {
-			return ActionButtonStatus.REJECT;
-		}
-
-		// 3. 참여자인 경우 (인증 관련 분기)
+		// 2. 참여자인 경우 (인증 관련 분기)
 		if (isParticipant) {
 			Round currentRound = challenge.getCurrentRound();
 
@@ -1118,19 +1109,19 @@ public class ChallengeServiceImpl implements ChallengeService {
 			return isCertifiedToday ? ActionButtonStatus.DONE : ActionButtonStatus.AVAILABLE;
 		}
 
-		// 4. 미참여자이면서 참여가 제한되는 경우
+		// 3. 미참여자이면서 참여가 제한되는 경우
 		if (isMaxJoined) {
 			return ActionButtonStatus.MAX_LIMIT_EXCEEDED;
 		}
 
-		// 5. 미참여자 정원 체크
+		// 4. 미참여자 정원 체크
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
 			return challengeWaitRepository.existsByUserAndChallenge(user, challenge)
 					? ActionButtonStatus.WAITLISTED
 					: ActionButtonStatus.WAITLIST;
 		}
 
-		// 6. 그 외 참여 가능
+		// 5. 그 외 참여 가능
 		return ActionButtonStatus.JOIN;
 	}
 

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -187,6 +187,9 @@ public class ChallengeServiceImpl implements ChallengeService {
 				isCertifiedToday = checkTodayVerification(uc.getId(), challenge);
 			}
 		}
+		boolean isWithdrawn = ucOp
+				.map(uc -> uc.getStatus() == ChallengeJoinStatus.KICKED)
+				.orElse(false);
 
 		// 챌린지 참여 개수 조회
 		boolean isMaxJoined = hasReachedActiveChallengeLimit(user);
@@ -203,7 +206,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 		boolean isOwnerActive = (owner != null) && (owner.getUserStatus() == UserStatus.ACTIVE);
 
 		// 버튼 상태 결정
-		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, user, isParticipant, isCertifiedToday, isMaxJoined);
+		ActionButtonStatus buttonStatus = resolveButtonStatus(challenge, user, isParticipant, isCertifiedToday, isMaxJoined, isWithdrawn);
 
         // 현재 유저가 방장인지 여부
         boolean isOwner = Objects.equals(owner != null ? owner.getId() : null, user.getId());
@@ -515,7 +518,7 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 		UserChallenge userChallenge;
 		if (existingUcOp.isPresent()) {
-			// 기존 기록이 있다면 (validateJoinRequest를 통과했으므로 CANCELLED/DROPPED 상태임) 상태만 JOINED로 변경
+			// 기존 기록이 있다면 (CANCELLED/DROPPED) 재사용해 유니크 제약 충돌을 방지
 			userChallenge = existingUcOp.get();
 			userChallenge.updateStatus(ChallengeJoinStatus.JOINED);
 		} else {
@@ -986,9 +989,6 @@ public class ChallengeServiceImpl implements ChallengeService {
 	 * 챌린지 참가 요청에 대한 비즈니스 검증 로직
 	 */
 	private void validateJoinRequest(Challenge challenge, User user, String inputPassword) {
-
-		validateActiveChallengeLimit(user);
-
 		// 상태 검증 (종료만 아니면 모두 참여 가능)
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
 			throw new GlobalException(ErrorCode.CHALLENGE_NOT_RECRUITING);
@@ -1003,6 +1003,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 				throw new GlobalException(ErrorCode.CHALLENGE_KICKED_USER);
 			}
 		});
+
+		validateActiveChallengeLimit(user);
 
 		// 정원 초과 검증
 		if (challenge.getCurrentParticipants() >= challenge.getMaxParticipants()) {
@@ -1090,11 +1092,15 @@ public class ChallengeServiceImpl implements ChallengeService {
      * 하단 버튼의 상태(ActionButtonStatus)를 결정하는 핵심 로직
      * (기획 따라 변경 가능)
      */
-	private ActionButtonStatus resolveButtonStatus(Challenge challenge, User user, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined) {
+	private ActionButtonStatus resolveButtonStatus(Challenge challenge, User user, boolean isParticipant, boolean isCertifiedToday, boolean isMaxJoined, boolean isWithdrawn) {
 
 		// 1. 챌린지 자체가 종료된 경우
 		if (challenge.getStatus() == ChallengeStatus.FINISHED) {
 			return ActionButtonStatus.FINISHED;
+		}
+
+		if (isWithdrawn) {
+			return ActionButtonStatus.WITHDRAWN;
 		}
 
 		// 2. 참여자인 경우 (인증 관련 분기)

--- a/src/main/java/com/hrr/backend/global/response/ErrorCode.java
+++ b/src/main/java/com/hrr/backend/global/response/ErrorCode.java
@@ -56,7 +56,7 @@ public enum ErrorCode implements BaseCode{
     USER_FAVOR_REQUIRED_FIELD_MISSING(HttpStatus.BAD_REQUEST, "CHALLENGE40014", "필수 선호 정보가 누락되었습니다."),
     CHALLENGE_CALCULATE_EMBEDDING(HttpStatus.BAD_REQUEST, "CHALLENGE40015", "챌린지 임베딩 계산 중 오류가 발생했습니다."),
     EMBEDDING_API_ERROR(HttpStatus.BAD_REQUEST, "CHALLENGE40016", "임베딩 API로부터 유효하지 않은 응답을 받았습니다."),
-    CHALLENGE_KICKED_USER(HttpStatus.FORBIDDEN, "CHALLENGE4031", "참가 자격이 제한된 챌린지입니다."),
+    CHALLENGE_KICKED_USER(HttpStatus.FORBIDDEN, "CHALLENGE4031", "회원 탈퇴 이력이 있어 참가할 수 없는 챌린지입니다."),
     CHALLENGE_UPDATE_FORBIDDEN(HttpStatus.FORBIDDEN, "CHALLENGE4032", "챌린지 수정 권한이 없습니다. 방장만 수정할 수 있습니다."),
     CHALLENGE_UPDATE_PERIOD_EXPIRED(HttpStatus.BAD_REQUEST, "CHALLENGE40017", "챌린지 시작일 이후에는 수정할 수 없습니다."),
     CHALLENGE_MAX_PARTICIPANTS_BELOW_CURRENT(HttpStatus.BAD_REQUEST, "CHALLENGE40018", "최대 참여 인원은 현재 참여 인원보다 적을 수 없습니다."),

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -371,8 +371,8 @@ class ChallengeServiceInfoTest {
     }
 
     @Test
-    @DisplayName("상황 16: 진행 중 + 강퇴(KICKED)된 유저는 재참여 불가하므로 REJECT")
-    void ongoing_kickedUser_returns_REJECT() {
+    @DisplayName("상황 16: 진행 중 + 기존 퇴출(KICKED) 기록이 있는 유저는 일반 미참여자로 처리되어 JOIN")
+    void ongoing_kickedUser_returns_JOIN() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
@@ -382,10 +382,69 @@ class ChallengeServiceInfoTest {
 
         mockFetchingChallenge(challengeId, challenge);
         mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
-        mockConverter(ActionButtonStatus.REJECT);
+        mockConverter(ActionButtonStatus.JOIN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.REJECT);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
+    }
+
+    @Test
+    @DisplayName("상황 17: 진행 중 + 기존 퇴출(KICKED) 기록 + 만석 + 빈자리 알림 미신청 -> WAITLIST")
+    void ongoing_kickedUser_full_notWaitRegistered_returns_WAITLIST() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 30, 30);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(false);
+        mockConverter(ActionButtonStatus.WAITLIST);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLIST);
+    }
+
+    @Test
+    @DisplayName("상황 18: 진행 중 + 기존 퇴출(KICKED) 기록 + 만석 + 빈자리 알림 신청 완료 -> WAITLISTED")
+    void ongoing_kickedUser_full_waitRegistered_returns_WAITLISTED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 30, 30);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(true);
+        mockConverter(ActionButtonStatus.WAITLISTED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLISTED);
+    }
+
+    @Test
+    @DisplayName("상황 19: 진행 중 + 기존 퇴출(KICKED) 기록 + 참여 개수 제한 -> MAX_LIMIT_EXCEEDED")
+    void ongoing_kickedUser_maxJoined_returns_MAX_LIMIT_EXCEEDED() {
+        Long challengeId = 1L;
+        Long userId = 10L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+
+        given(user.getId()).willReturn(userId);
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 5, 10);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
+        given(challengeRepository.countByUserIdAndStatus(userId, ChallengeJoinStatus.JOINED)).willReturn(5L);
+        mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
     }
     /**
      * Helper Methods

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -371,8 +371,8 @@ class ChallengeServiceInfoTest {
     }
 
     @Test
-    @DisplayName("상황 16: 진행 중 + 기존 퇴출(KICKED) 기록이 있는 유저는 일반 미참여자로 처리되어 JOIN")
-    void ongoing_kickedUser_returns_JOIN() {
+    @DisplayName("상황 16: 진행 중 + 회원 탈퇴 이력(KICKED) 유저 -> WITHDRAWN")
+    void ongoing_kickedUser_returns_WITHDRAWN() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
@@ -382,15 +382,15 @@ class ChallengeServiceInfoTest {
 
         mockFetchingChallenge(challengeId, challenge);
         mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
-        mockConverter(ActionButtonStatus.JOIN);
+        mockConverter(ActionButtonStatus.WITHDRAWN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.JOIN);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WITHDRAWN);
     }
 
     @Test
-    @DisplayName("상황 17: 진행 중 + 기존 퇴출(KICKED) 기록 + 만석 + 빈자리 알림 미신청 -> WAITLIST")
-    void ongoing_kickedUser_full_notWaitRegistered_returns_WAITLIST() {
+    @DisplayName("상황 17: 진행 중 + 회원 탈퇴 이력(KICKED) + 만석 + 빈자리 알림 신청 완료 -> WITHDRAWN 우선")
+    void ongoing_kickedUser_full_waitRegistered_returns_WITHDRAWN() {
         Long challengeId = 1L;
         User user = mock(User.class);
         Challenge challenge = createChallengeBase();
@@ -400,30 +400,11 @@ class ChallengeServiceInfoTest {
 
         mockFetchingChallenge(challengeId, challenge);
         mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
-        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(false);
-        mockConverter(ActionButtonStatus.WAITLIST);
+        mockConverter(ActionButtonStatus.WITHDRAWN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLIST);
-    }
-
-    @Test
-    @DisplayName("상황 18: 진행 중 + 기존 퇴출(KICKED) 기록 + 만석 + 빈자리 알림 신청 완료 -> WAITLISTED")
-    void ongoing_kickedUser_full_waitRegistered_returns_WAITLISTED() {
-        Long challengeId = 1L;
-        User user = mock(User.class);
-        Challenge challenge = createChallengeBase();
-
-        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 30, 30);
-        setRoundDate(challenge, LocalDate.now());
-
-        mockFetchingChallenge(challengeId, challenge);
-        mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
-        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(true);
-        mockConverter(ActionButtonStatus.WAITLISTED);
-
-        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLISTED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WITHDRAWN);
+        verify(challengeWaitRepository, never()).existsByUserAndChallenge(user, challenge);
     }
 
     @Test
@@ -450,8 +431,8 @@ class ChallengeServiceInfoTest {
     }
 
     @Test
-    @DisplayName("상황 19: 진행 중 + 기존 퇴출(KICKED) 기록 + 참여 개수 제한 -> MAX_LIMIT_EXCEEDED")
-    void ongoing_kickedUser_maxJoined_returns_MAX_LIMIT_EXCEEDED() {
+    @DisplayName("상황 19: 진행 중 + 회원 탈퇴 이력(KICKED) + 참여 개수 제한 -> WITHDRAWN 우선")
+    void ongoing_kickedUser_maxJoined_returns_WITHDRAWN() {
         Long challengeId = 1L;
         Long userId = 10L;
         User user = mock(User.class);
@@ -464,10 +445,10 @@ class ChallengeServiceInfoTest {
         mockFetchingChallenge(challengeId, challenge);
         mockParticipantWithStatus(user, challenge, ChallengeJoinStatus.KICKED);
         given(challengeRepository.countByUserIdAndStatus(userId, ChallengeJoinStatus.JOINED)).willReturn(5L);
-        mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+        mockConverter(ActionButtonStatus.WITHDRAWN);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
-        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WITHDRAWN);
     }
 
     @Test

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -8,6 +8,7 @@ import com.hrr.backend.domain.challenge.entity.enums.ActionButtonStatus;
 import com.hrr.backend.domain.challenge.repository.ChallengeDayJoinRepository;
 import com.hrr.backend.domain.challenge.repository.ChallengeLikeRepository;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.challenge.repository.ChallengeWaitRepository;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.UserChallenge;
@@ -51,6 +52,7 @@ class ChallengeServiceInfoTest {
     @Mock private UserChallengeRepository userChallengeRepository;
     @Mock private VerificationRepository verificationRepository;
     @Mock private ChallengeLikeRepository challengeLikeRepository;
+    @Mock private ChallengeWaitRepository challengeWaitRepository;
     @Mock private ChallengeConverter challengeConverter;
     @Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
     @Mock private S3UrlUtil s3UrlUtil;
@@ -189,10 +191,30 @@ class ChallengeServiceInfoTest {
 
         mockFetchingChallenge(challengeId, challenge);
         mockGuest(user, challenge);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(false);
         mockConverter(ActionButtonStatus.WAITLIST);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLIST);
+    }
+
+    @Test
+    @DisplayName("상황 7-1: 미참여자 + 모집중 + 만석 + 빈자리 알림 신청 완료 -> WAITLISTED")
+    void guest_recruiting_full_waitRegistered_returns_WAITLISTED() {
+        Long challengeId = 1L;
+        User user = mock(User.class);
+        Challenge challenge = mock(Challenge.class);
+
+        setChallengeStatus(challenge, ChallengeStatus.RECRUITING, 30, 30);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockGuest(user, challenge);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(true);
+        mockConverter(ActionButtonStatus.WAITLISTED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLISTED);
     }
 
     @Test

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceInfoTest.java
@@ -427,6 +427,29 @@ class ChallengeServiceInfoTest {
     }
 
     @Test
+    @DisplayName("상황 18-1: 진행 중 + 참여 개수 제한 + 기존 빈자리 알림 신청 완료 -> WAITLISTED")
+    void ongoing_guest_maxJoined_waitRegistered_returns_WAITLISTED() {
+        Long challengeId = 1L;
+        Long userId = 10L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+
+        given(user.getId()).willReturn(userId);
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 30, 30);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockGuest(user, challenge);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(true);
+        given(challengeRepository.countByUserIdAndStatus(userId, ChallengeJoinStatus.JOINED)).willReturn(5L);
+        mockConverter(ActionButtonStatus.WAITLISTED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.WAITLISTED);
+    }
+
+    @Test
     @DisplayName("상황 19: 진행 중 + 기존 퇴출(KICKED) 기록 + 참여 개수 제한 -> MAX_LIMIT_EXCEEDED")
     void ongoing_kickedUser_maxJoined_returns_MAX_LIMIT_EXCEEDED() {
         Long challengeId = 1L;
@@ -444,6 +467,29 @@ class ChallengeServiceInfoTest {
         mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
 
         ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+        assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("상황 20: 진행 중 + 참여 개수 제한 + 만석 + 빈자리 알림 미신청 -> MAX_LIMIT_EXCEEDED")
+    void ongoing_guest_maxJoined_full_notWaitRegistered_returns_MAX_LIMIT_EXCEEDED() {
+        Long challengeId = 1L;
+        Long userId = 10L;
+        User user = mock(User.class);
+        Challenge challenge = createChallengeBase();
+
+        given(user.getId()).willReturn(userId);
+        setChallengeStatus(challenge, ChallengeStatus.ONGOING, 30, 30);
+        setRoundDate(challenge, LocalDate.now());
+
+        mockFetchingChallenge(challengeId, challenge);
+        mockGuest(user, challenge);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(false);
+        given(challengeRepository.countByUserIdAndStatus(userId, ChallengeJoinStatus.JOINED)).willReturn(5L);
+        mockConverter(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
+
+        ChallengeResponseDto.HeaderInfoDto result = challengeService.getChallengeHeaderInfo(challengeId, user);
+
         assertThat(result.getActionButtonStatus()).isEqualTo(ActionButtonStatus.MAX_LIMIT_EXCEEDED);
     }
     /**

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
@@ -129,7 +129,7 @@ class ChallengeServiceJoinTest {
     }
 
     @Test
-    @DisplayName("가입 상황 3: 강퇴(KICKED) 유저 재참여 시도 -> CHALLENGE_KICKED_USER 예외 발생")
+    @DisplayName("가입 상황 3: 회원 탈퇴 이력(KICKED) 유저 참여 시도 -> CHALLENGE_KICKED_USER 예외 발생")
     void join_KickedUser_Throws_Exception() {
         // [Given]
         Long challengeId = 1L;
@@ -144,6 +144,9 @@ class ChallengeServiceJoinTest {
                 challengeService.joinChallenge(user, challengeId, joinReq)
         );
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_KICKED_USER);
+        verify(kickedUc, never()).updateStatus(any());
+        verify(userChallengeRepository, never()).save(any(UserChallenge.class));
+        verify(challenge, never()).increaseCurrentParticipants();
     }
 
     @Test
@@ -193,6 +196,29 @@ class ChallengeServiceJoinTest {
                 challengeService.joinChallenge(user, challengeId, joinReq)
         );
         assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_FULL);
+    }
+
+    @Test
+    @DisplayName("가입 상황 6-1: 회원 탈퇴 이력(KICKED) 유저는 정원 및 최대 참여 개수와 무관하게 CHALLENGE_KICKED_USER 예외 발생")
+    void join_KickedUser_ReturnsKickedExceptionBeforeCapacityAndLimit() {
+        // [Given]
+        Long challengeId = 1L;
+        given(challengeRepository.findByIdForUpdate(challengeId)).willReturn(Optional.of(challenge));
+
+        UserChallenge kickedUc = mock(UserChallenge.class);
+        given(kickedUc.getStatus()).willReturn(ChallengeJoinStatus.KICKED);
+        given(userChallengeRepository.findByUserAndChallenge(user, challenge)).willReturn(Optional.of(kickedUc));
+        lenient().when(challenge.getCurrentParticipants()).thenReturn(10);
+        lenient().when(challenge.getMaxParticipants()).thenReturn(10);
+
+        // [When & Then]
+        GlobalException exception = assertThrows(GlobalException.class, () ->
+                challengeService.joinChallenge(user, challengeId, joinReq)
+        );
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_KICKED_USER);
+        verify(challengeRepository, never()).countByUserIdAndStatus(any(), any());
+        verify(kickedUc, never()).updateStatus(any());
+        verify(challenge, never()).increaseCurrentParticipants();
     }
 
     @Test

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceJoinTest.java
@@ -5,6 +5,7 @@ import com.hrr.backend.domain.challenge.dto.ChallengeRequestDto;
 import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.point.service.PointService;
 import com.hrr.backend.domain.round.converter.RoundConverter;
 import com.hrr.backend.domain.round.entity.Round;
 import com.hrr.backend.domain.round.repository.RoundRecordRepository;
@@ -45,6 +46,7 @@ class ChallengeServiceJoinTest {
     @Mock private ChallengeConverter challengeConverter;
     @Mock private RoundConverter roundConverter;
     @Mock private ChallengeStaticsService challengeStaticsService;
+    @Mock private PointService pointService;
 
     private User user;
     private Challenge challenge;

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceWaitTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceWaitTest.java
@@ -1,0 +1,120 @@
+package com.hrr.backend.domain.challenge.service;
+
+import com.hrr.backend.domain.challenge.entity.Challenge;
+import com.hrr.backend.domain.challenge.entity.ChallengeWait;
+import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.challenge.repository.ChallengeWaitRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus;
+import com.hrr.backend.domain.user.repository.UserChallengeRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ChallengeServiceWaitTest {
+
+    @InjectMocks
+    private ChallengeServiceImpl challengeService;
+
+    @Mock private ChallengeRepository challengeRepository;
+    @Mock private UserChallengeRepository userChallengeRepository;
+    @Mock private ChallengeWaitRepository challengeWaitRepository;
+
+    private User user;
+    private Challenge challenge;
+
+    @BeforeEach
+    void setUp() {
+        user = org.mockito.Mockito.mock(User.class);
+        challenge = org.mockito.Mockito.mock(Challenge.class);
+
+        lenient().when(user.getId()).thenReturn(10L);
+    }
+
+    @Test
+    @DisplayName("빈자리 알림 신청: 최대 참여 개수 미도달 + 만석이면 신청 성공")
+    void registerChallengeWait_underMaxLimitAndFull_savesWait() {
+        Long challengeId = 1L;
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.existsByUserAndChallengeAndStatus(user, challenge, ChallengeJoinStatus.JOINED))
+                .willReturn(false);
+        given(challengeRepository.countByUserIdAndStatus(10L, ChallengeJoinStatus.JOINED)).willReturn(4L);
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(false);
+        given(challenge.getCurrentParticipants()).willReturn(10);
+        given(challenge.getMaxParticipants()).willReturn(10);
+
+        challengeService.registerChallengeWait(user, challengeId);
+
+        ArgumentCaptor<ChallengeWait> captor = ArgumentCaptor.forClass(ChallengeWait.class);
+        verify(challengeWaitRepository).save(captor.capture());
+        assertThat(captor.getValue().getUser()).isEqualTo(user);
+        assertThat(captor.getValue().getChallenge()).isEqualTo(challenge);
+    }
+
+    @Test
+    @DisplayName("빈자리 알림 신청: 최대 참여 개수 도달 + 만석이면 MAX_CHALLENGE_EXCEEDED 예외")
+    void registerChallengeWait_atMaxLimitAndFull_throwsMaxChallengeExceeded() {
+        Long challengeId = 1L;
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.existsByUserAndChallengeAndStatus(user, challenge, ChallengeJoinStatus.JOINED))
+                .willReturn(false);
+        given(challengeRepository.countByUserIdAndStatus(10L, ChallengeJoinStatus.JOINED)).willReturn(5L);
+
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> challengeService.registerChallengeWait(user, challengeId));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.MAX_CHALLENGE_EXCEEDED);
+        verify(challengeWaitRepository, never()).save(org.mockito.Mockito.any(ChallengeWait.class));
+    }
+
+    @Test
+    @DisplayName("빈자리 알림 신청: 참여 개수 제한 검증 실패 시 ChallengeWait가 저장되지 않는다")
+    void registerChallengeWait_limitValidationFails_doesNotSaveWait() {
+        Long challengeId = 1L;
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(userChallengeRepository.existsByUserAndChallengeAndStatus(user, challenge, ChallengeJoinStatus.JOINED))
+                .willReturn(false);
+        given(challengeRepository.countByUserIdAndStatus(10L, ChallengeJoinStatus.JOINED)).willReturn(5L);
+
+        assertThrows(GlobalException.class, () -> challengeService.registerChallengeWait(user, challengeId));
+
+        verify(challengeWaitRepository, never()).save(org.mockito.Mockito.any(ChallengeWait.class));
+        verify(challengeWaitRepository).existsByUserAndChallenge(user, challenge);
+    }
+
+    @Test
+    @DisplayName("빈자리 알림 신청: 이미 신청한 사용자가 최대 참여 개수 도달 후 재요청하면 중복 신청 예외")
+    void registerChallengeWait_alreadyWaitedAndAtMaxLimit_throwsAlreadyExistWithoutSaving() {
+        Long challengeId = 1L;
+
+        given(challengeRepository.findById(challengeId)).willReturn(Optional.of(challenge));
+        given(challengeWaitRepository.existsByUserAndChallenge(user, challenge)).willReturn(true);
+
+        GlobalException exception = assertThrows(GlobalException.class,
+                () -> challengeService.registerChallengeWait(user, challengeId));
+
+        assertThat(exception.getErrorCode()).isEqualTo(ErrorCode.CHALLENGE_WAIT_ALREADY_EXIST);
+        verify(challengeRepository, never()).countByUserIdAndStatus(10L, ChallengeJoinStatus.JOINED);
+        verify(challengeWaitRepository, never()).save(org.mockito.Mockito.any(ChallengeWait.class));
+    }
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈

Close #353

## ✨ 작업 내용 (Summary)

챌린지 상세 조회 API에서 빈자리 알림 신청 여부를 구분할 수 있도록 액션 버튼 상태를 개선했습니다.

- 빈자리 알림 신청 완료 상태인 `WAITLISTED` 추가
- 만석인 챌린지의 미참여자 상태 분기
  - 빈자리 알림 미신청: `WAITLIST`
  - 빈자리 알림 신청 완료: `WAITLISTED`
- 빈자리 알림 신규 신청 시 최대 챌린지 참여 개수 제한 적용
- 최대 참여 개수에 도달하더라도 기존 빈자리 알림 신청은 `WAITLISTED`로 표시
- 퇴출 기능 제거에 따라 기존 `REJECT` 상태 제거
- 회원 탈퇴 처리 이력이 있는 `KICKED` 사용자를 위한 `WITHDRAWN` 상태 추가
- `KICKED` 사용자의 챌린지 재참여 차단
- 생성·참가·상세 조회·빈자리 알림 등록에서 동일한 참여 개수 제한 기준 재사용
- Swagger Enum 설명 및 관련 테스트 코드 수정

---

## ✅ 변경 사항 체크리스트

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

- **테스트 환경:** 로컬
- **테스트 방법:** Gradle 단위 테스트
- **실행 명령어:** `./gradlew test --tests 'com.hrr.backend.domain.challenge.service.ChallengeServiceWaitTest' --tests 'com.hrr.backend.domain.challenge.service.ChallengeServiceInfoTest' --tests 'com.hrr.backend.domain.challenge.service.ChallengeServiceJoinTest'`
- **결과 요약:**
  - `ChallengeServiceWaitTest`, `ChallengeServiceInfoTest`, `ChallengeServiceJoinTest` 전체 통과
  - 만석 상태에서 빈자리 알림 미신청 사용자가 `WAITLIST`를 반환하는 케이스 검증
  - 빈자리 알림 신청 사용자가 `WAITLISTED`를 반환하는 케이스 검증
  - 최대 참여 개수 도달 사용자의 신규 빈자리 알림 신청 차단 검증
  - 최대 참여 개수 도달 후에도 기존 대기 신청은 `WAITLISTED`로 표시되는 케이스 검증
  - 중복 빈자리 알림 신청 시 추가 데이터가 저장되지 않는 케이스 검증
  - `KICKED` 사용자가 상세 조회에서 `WITHDRAWN`을 반환하는 케이스 검증
  - `KICKED` 사용자의 챌린지 재참여 차단 및 참가 인원·참여 상태 미변경 검증
  - `KICKED` 차단이 정원 및 최대 참여 개수 조건보다 우선 적용되는 케이스 검증

---

## 📸 스크린샷

| 챌린지 대기 신청 | 챌린지 대기 신청 취소 |
|---|---|
|<img width="1334" height="400" alt="image" src="https://github.com/user-attachments/assets/210d814d-ff11-4488-bbaa-c32cd221aed2" />|<img width="1330" height="406" alt="image" src="https://github.com/user-attachments/assets/d2bf1ac8-4dbf-4cda-ab32-5d977f83574c" />|

| 챌린지 대기 신청 전 챌린지 상태 | 챌린지 대기 신청 후 챌린지 상태 |
|---|---|
|<img width="1324" height="972" alt="image" src="https://github.com/user-attachments/assets/89152036-700b-4ea8-a89b-d7cadc042c58" />|<img width="1326" height="962" alt="image" src="https://github.com/user-attachments/assets/b366032b-a585-4ebd-931a-900e4ad0d2a5" />|

| 회원 탈퇴 이력이 있는 사용자 |
|---|
|<img width="662" height="492" alt="image" src="https://github.com/user-attachments/assets/711b3bcd-9f3f-4b8c-b2d1-2f488266a47d" />|

---

## 💬 리뷰 요구사항

- 만석인 미참여자의 빈자리 알림 신청 여부에 따라 `WAITLIST`와 `WAITLISTED`가 올바르게 구분되는지 확인 부탁드립니다.
- 최대 참여 개수에 도달한 사용자의 신규 빈자리 알림 신청이 차단되는지 확인 부탁드립니다.
- 최대 참여 개수에 도달하더라도 기존 빈자리 알림 신청은 `WAITLISTED`로 표시되는지 확인 부탁드립니다.
- 회원 탈퇴 처리 이력이 있는 `KICKED` 사용자가 `WITHDRAWN` 상태로 표시되고 재참여할 수 없는지 확인 부탁드립니다.
- 액션 버튼 상태 우선순위가 다음과 같이 적용되는지 확인 부탁드립니다.
  1. `FINISHED`
  2. `WITHDRAWN`
  3. 참여자 인증 상태: `UPCOMING` → `NOT_DAY` → `NOT_TIME` → `DONE` / `AVAILABLE`
  4. 만석이며 기존 빈자리 알림 신청: `WAITLISTED`
  5. 최대 참여 개수 도달: `MAX_LIMIT_EXCEEDED`
  6. 만석이며 빈자리 알림 미신청: `WAITLIST`
  7. 그 외: `JOIN`

---

## 📎 참고 자료

### 추가된 상태

| Enum | 버튼 문구 | 발생 조건 |
| --- | --- | --- |
| `WAITLISTED` | 빈자리 알림 신청 완료 | 챌린지가 만석이며 사용자가 빈자리 알림을 이미 신청한 경우 |
| `WITHDRAWN` | 참여할 수 없는 챌린지 | 회원 탈퇴 처리로 기존 참여 기록이 `KICKED` 상태인 경우 |

### 제거된 상태

- 퇴출 기능 제거에 따라 `ActionButtonStatus.REJECT` 제거
- 챌린지 상세 조회의 기존 `REJECT` 반환 분기 제거
- Swagger 설명과 테스트 코드에서 `REJECT` 관련 내용 제거

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 챌린지 정원 초과 시 빈자리 알림 신청 상태를 구분해 표시합니다.
  * 빈자리 알림을 신청한 경우 `WAITLISTED` 상태가 제공됩니다.
  * 챌린지 참여 버튼 상태 안내가 최신 상태 목록으로 업데이트되었습니다.

* **버그 수정**
  * 기존 참여 제한 사용자도 상황에 맞는 참여·대기 상태가 표시되도록 개선했습니다.
  * 대기 신청 가능 여부와 신청 완료 여부를 정확히 반영합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->