### PR TITLE
[Feat] 챌린지 라운드 목록에 참여 여부 추가

### DIFF
--- a/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/controller/ChallengeController.java
@@ -188,11 +188,13 @@ public class ChallengeController {
 	}
 
 	@GetMapping("/{challengeId}/rounds")
-	@Operation(summary = "챌린지 라운드 목록 조회", description = "챌린지의 전체 라운드 목록(1R, 2R...)을 회차순으로 반환합니다. 현재 진행 중인 라운드는 isCurrentRound=true로 표시됩니다.")
+	@Operation(summary = "챌린지 라운드 목록 조회", description = "챌린지의 전체 라운드 목록(1R, 2R...)을 회차순으로 반환합니다. 현재 진행 중인 라운드는 isCurrentRound=true, 로그인한 사용자의 라운드 기록이 있는 라운드는 isParticipated=true로 표시됩니다.")
 	public ApiResponse<List<ChallengeResponseDto.RoundDto>> getChallengeRounds(
+			@Parameter(hidden = true)
+			@AuthenticationPrincipal CustomUserDetails userDetails,
 			@PathVariable("challengeId") Long challengeId
 	) {
-		List<ChallengeResponseDto.RoundDto> response = challengeService.getChallengeRounds(challengeId);
+		List<ChallengeResponseDto.RoundDto> response = challengeService.getChallengeRounds(userDetails.getUser(), challengeId);
 
 		return ApiResponse.onSuccess(SuccessCode.OK, response);
 	}

--- a/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/converter/ChallengeConverter.java
@@ -162,10 +162,11 @@ public class ChallengeConverter {
     }
 
     // Round 엔티티 -> RoundDto 변환
-    public ChallengeResponseDto.RoundDto toRoundDto(Round round, boolean isCurrentRound) {
+    public ChallengeResponseDto.RoundDto toRoundDto(Round round, boolean isCurrentRound, boolean isParticipated) {
         return ChallengeResponseDto.RoundDto.builder()
                 .roundNumber(round.getRoundNumber())
                 .isCurrentRound(isCurrentRound)
+                .isParticipated(isParticipated)
                 .build();
     }
 

--- a/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/dto/ChallengeResponseDto.java
@@ -230,6 +230,9 @@ public class ChallengeResponseDto {
 
 		@Schema(description = "현재 진행 중인 라운드인지 여부 (TRUE일 경우 UI 강조)", example = "true")
 		private Boolean isCurrentRound;
+
+		@Schema(description = "로그인한 사용자의 해당 라운드 기록 존재 여부", example = "true")
+		private Boolean isParticipated;
 	}
 
     @Getter

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeService.java
@@ -62,7 +62,7 @@ public interface ChallengeService {
 	ChallengeResponseDto.ChallengeLikeDto unlikeChallenge(User user, Long challengeId);
 
 	// 챌린지 라운드 목록 조회
-	List<ChallengeResponseDto.RoundDto> getChallengeRounds(Long challengeId);
+	List<ChallengeResponseDto.RoundDto> getChallengeRounds(User user, Long challengeId);
 
     // 챌린지 수정 기능
     ChallengeResponseDto.UpdateChallengeDto updateChallenge(

--- a/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImpl.java
@@ -722,12 +722,18 @@ public class ChallengeServiceImpl implements ChallengeService {
 
 	@Override
 	@Transactional(readOnly = true)
-	public List<ChallengeResponseDto.RoundDto> getChallengeRounds(Long challengeId) {
+	public List<ChallengeResponseDto.RoundDto> getChallengeRounds(User user, Long challengeId) {
 		// 챌린지 조회
 		Challenge challenge = findChallenge(challengeId);
 
 		// 라운드 목록 조회
 		List<Round> rounds = roundRepository.findAllByChallengeIdOrderByRoundNumberAsc(challengeId);
+		Set<Integer> participatedRoundNumbers = roundRecordRepository.findParticipatedRoundNumbers(
+						user.getId(),
+						challengeId
+				)
+				.stream()
+				.collect(Collectors.toSet());
 
 		// 현재 라운드 ID 추출 (Null Safe)
 		Long currentRoundId = (challenge.getCurrentRound() != null)
@@ -738,7 +744,8 @@ public class ChallengeServiceImpl implements ChallengeService {
 		return rounds.stream()
 				.map(round -> {
 					boolean isCurrent = round.getId().equals(currentRoundId);
-					return challengeConverter.toRoundDto(round, isCurrent);
+					boolean isParticipated = participatedRoundNumbers.contains(round.getRoundNumber());
+					return challengeConverter.toRoundDto(round, isCurrent, isParticipated);
 				})
 				.toList();
 	}

--- a/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
+++ b/src/main/java/com/hrr/backend/domain/round/repository/RoundRecordRepository.java
@@ -68,6 +68,19 @@ public interface RoundRecordRepository extends JpaRepository<RoundRecord, Long> 
     @Query("SELECT COALESCE(SUM(r.verificationCount), 0) FROM RoundRecord r WHERE r.userChallenge.id = :userChallengeId")
     Long sumVerificationCountByUserChallengeId(@Param("userChallengeId") Long userChallengeId);
 
+    @Query("""
+    SELECT DISTINCT r.roundNumber
+    FROM RoundRecord rr
+    JOIN rr.round r
+    JOIN rr.userChallenge uc
+    WHERE uc.user.id = :userId
+    AND uc.challenge.id = :challengeId
+""")
+    List<Integer> findParticipatedRoundNumbers(
+            @Param("userId") Long userId,
+            @Param("challengeId") Long challengeId
+    );
+
     /**
      * 알림 발송 대상자 및 설정 정보 일괄 조회
      */

--- a/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImplTest.java
+++ b/src/test/java/com/hrr/backend/domain/challenge/service/ChallengeServiceImplTest.java
@@ -19,9 +19,17 @@ import org.springframework.data.redis.core.DefaultTypedTuple;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ZSetOperations;
 
+import com.hrr.backend.domain.challenge.converter.ChallengeConverter;
 import com.hrr.backend.domain.challenge.dto.ChallengeResponseDto;
+import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.repository.ChallengeDayJoinRepository;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.round.entity.Round;
+import com.hrr.backend.domain.round.repository.RoundRecordRepository;
+import com.hrr.backend.domain.round.repository.RoundRepository;
+import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.s3.S3UrlUtil;
 
 @ExtendWith(MockitoExtension.class)
@@ -31,6 +39,9 @@ class ChallengeServiceImplTest {
 	@Mock private RedisTemplate<String, String> redisTemplate;
 	@Mock private ZSetOperations<String, String> zSetOperations;
 	@Mock private ChallengeDayJoinRepository challengeDayJoinRepository;
+	@Mock private ChallengeConverter challengeConverter;
+	@Mock private RoundRepository roundRepository;
+	@Mock private RoundRecordRepository roundRecordRepository;
 	@Mock private S3UrlUtil s3UrlUtil;
 
 	@InjectMocks
@@ -77,5 +88,61 @@ class ChallengeServiceImplTest {
 		assertThat(result).hasSize(1);
 		assertThat(result.get(0).getInfo().getChallengeId()).isEqualTo(1L);
 		assertThat(result.get(0).getRanking()).isEqualTo(1);
+	}
+
+	@Test
+	@DisplayName("챌린지 라운드 목록 조회 시 로그인 사용자의 라운드별 RoundRecord 존재 여부를 함께 반환한다")
+	void getChallengeRounds_ReturnsParticipationStatus() {
+		// Arrange
+		Long userId = 10L;
+		Long challengeId = 1L;
+		User user = User.builder().id(userId).build();
+		Round round1 = Round.builder().id(101L).roundNumber(1).build();
+		Round round2 = Round.builder().id(102L).roundNumber(2).build();
+		Challenge challenge = Challenge.builder().id(challengeId).currentRound(round2).build();
+
+		ChallengeResponseDto.RoundDto roundDto1 = ChallengeResponseDto.RoundDto.builder()
+				.roundNumber(1)
+				.isCurrentRound(false)
+				.isParticipated(true)
+				.build();
+		ChallengeResponseDto.RoundDto roundDto2 = ChallengeResponseDto.RoundDto.builder()
+				.roundNumber(2)
+				.isCurrentRound(true)
+				.isParticipated(false)
+				.build();
+
+		given(challengeRepository.findById(challengeId)).willReturn(java.util.Optional.of(challenge));
+		given(roundRepository.findAllByChallengeIdOrderByRoundNumberAsc(challengeId)).willReturn(List.of(round1, round2));
+		given(roundRecordRepository.findParticipatedRoundNumbers(userId, challengeId))
+				.willReturn(List.of(1));
+		given(challengeConverter.toRoundDto(round1, false, true)).willReturn(roundDto1);
+		given(challengeConverter.toRoundDto(round2, true, false)).willReturn(roundDto2);
+
+		// Act
+		List<ChallengeResponseDto.RoundDto> result = challengeService.getChallengeRounds(user, challengeId);
+
+		// Assert
+		assertThat(result).containsExactly(roundDto1, roundDto2);
+		then(roundRecordRepository).should(times(1))
+				.findParticipatedRoundNumbers(userId, challengeId);
+	}
+
+	@Test
+	@DisplayName("챌린지 라운드 목록 조회 시 챌린지가 없으면 기존 예외를 유지한다")
+	void getChallengeRounds_ChallengeNotFound() {
+		// Arrange
+		Long challengeId = 1L;
+		User user = User.builder().id(10L).build();
+		given(challengeRepository.findById(challengeId)).willReturn(java.util.Optional.empty());
+
+		// Act & Assert
+		assertThatThrownBy(() -> challengeService.getChallengeRounds(user, challengeId))
+				.isInstanceOf(GlobalException.class)
+				.extracting("errorCode")
+				.isEqualTo(ErrorCode.CHALLENGE_NOT_FOUND);
+
+		then(roundRepository).shouldHaveNoInteractions();
+		then(roundRecordRepository).shouldHaveNoInteractions();
 	}
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #355 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

챌린지 라운드 목록 조회 API 응답에 로그인한 사용자의 라운드별 참여 여부를 추가했습니다.

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

| 라운드 목록 조회 API |
|---|
| <img width="1334" height="948" alt="image" src="https://github.com/user-attachments/assets/f1327391-5bf0-4101-833c-bbc65e6d2356" /> |
---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 로그인한 사용자의 챌린지 기록에 해당 라운드가 존재하는 경우 isParticipated가 true로 반환되는지 확인 부탁드립니다.
- 기록이 없는 라운드는 false로 반환되는지 확인 부탁드립니다.
- 기존 roundNumber, isCurrentRound 응답에 영향이 없는지 확인 부탁드립니다.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 챌린지 라운드 목록에서 로그인한 사용자의 라운드별 참여 여부를 확인할 수 있습니다.
  - 각 라운드 응답에 참여 여부 정보가 추가되었습니다.

- **버그 수정**
  - 존재하지 않는 챌린지 조회 시 기존 오류 처리가 유지됩니다.

- **테스트**
  - 라운드 참여 여부와 챌린지 미존재 상황에 대한 검증을 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->