### PR TITLE
[Feat] 스크랩한 인증 글 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/hrr/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/hrr/backend/domain/user/controller/UserController.java
@@ -4,6 +4,7 @@ import com.hrr.backend.domain.user.dto.*;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.service.UserService;
 import com.hrr.backend.domain.verification.dto.VerificationResponseDto;
+import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
 import com.hrr.backend.domain.verification.service.VerificationService;
 import com.hrr.backend.global.config.CustomUserDetails;
 import com.hrr.backend.global.response.ApiResponse;
@@ -228,6 +229,38 @@ public class UserController {
     ) {
         VerificationResponseDto.OtherUserHistoryResponse response =
                 verificationService.getOtherUserVerificationHistory(userId, customUserDetails.getUser(), page - 1, size);
+
+        return ApiResponse.onSuccess(SuccessCode.OK, response);
+    }
+
+    @GetMapping("/me/verifications/scrap")
+    @Operation(
+            summary = "스크랩한 인증 글 목록 조회",
+            description = "현재 로그인한 사용자가 스크랩한 인증 글 목록을 최신 스크랩순으로 조회합니다. " +
+                    "type으로 사진 인증(CAMERA)과 글 인증(TEXT)을 구분해 조회할 수 있습니다."
+    )
+    public ApiResponse<SliceResponseDto<UserResponseDto.ScrappedVerificationDto>> getMyScrappedVerifications(
+            @AuthenticationPrincipal CustomUserDetails customUserDetails,
+
+            @RequestParam(name = "type", required = false)
+            @Parameter(description = "인증 유형 필터 (CAMERA: 사진 인증, TEXT: 글 인증)", example = "CAMERA")
+            VerificationPostType type,
+
+            @RequestParam(name = "page", defaultValue = "1")
+            @Min(1)
+            @Parameter(description = "페이지 번호 (1부터 시작)", example = "1") int page,
+
+            @RequestParam(name = "size", defaultValue = "10")
+            @Min(1) @Max(100)
+            @Parameter(description = "페이지당 데이터 개수", example = "10") int size
+    ) {
+        SliceResponseDto<UserResponseDto.ScrappedVerificationDto> response =
+                userService.getScrappedVerifications(
+                        customUserDetails.getUser(),
+                        type,
+                        page - 1,
+                        size
+                );
 
         return ApiResponse.onSuccess(SuccessCode.OK, response);
     }

--- a/src/main/java/com/hrr/backend/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/hrr/backend/domain/user/dto/UserResponseDto.java
@@ -1,11 +1,13 @@
 package com.hrr.backend.domain.user.dto;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.hrr.backend.domain.user.entity.User;
 import com.hrr.backend.domain.user.entity.enums.UserLevel;
 import com.hrr.backend.domain.user.entity.enums.UserRole;
 import com.hrr.backend.domain.user.entity.enums.UserStatus;
+import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
@@ -210,5 +212,50 @@ public class UserResponseDto {
         @JsonProperty("image")
         @Schema(description = "챌린지 대표 이미지 URL", example = "http://example.com/challenge_301.jpg")
         private String image;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Schema(description = "스크랩한 인증글 목록 항목 DTO")
+    public static class ScrappedVerificationDto {
+
+        @Schema(description = "인증 ID", example = "10")
+        private Long verificationId;
+
+        @Schema(description = "인증 유형 (CAMERA: 사진, TEXT: 글)", example = "TEXT")
+        private VerificationPostType type;
+
+        @Schema(description = "제목", example = "오늘의 질문입니다!")
+        private String title;
+
+        @Schema(description = "내용 (글 인증 미리보기용)", example = "이 부분 어떻게 해결하나요?")
+        private String content;
+
+        @Schema(description = "인증 사진 URL (사진 인증인 경우)", example = "https://example.com/photo.jpg")
+        private String imageUrl;
+
+        @Schema(description = "외부 링크 포함 여부 (true: 링크 있음, false: 없음)", example = "true")
+        private Boolean hasLink;
+
+        @Schema(description = "질문글 여부 (Q 마크 표시)", example = "true")
+        private Boolean isQuestion;
+
+        @Schema(description = "질문 해결 여부 (채택 완료됨 - 정렬 후순위)", example = "false")
+        private Boolean isResolved;
+
+        @Schema(description = "작성자 닉네임", example = "해빗")
+        private String writerNickname;
+
+        @Schema(description = "작성자 프로필 URL", example = "https://example.com/profile.jpg")
+        private String writerProfileUrl;
+
+        @Schema(description = "작성자 ID (본인 글 확인용)", example = "1")
+        private Long writerId;
+
+        @Schema(description = "작성일자", example = "2025.12.05")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy.MM.dd")
+        private LocalDateTime createdDate;
     }
 }

--- a/src/main/java/com/hrr/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserService.java
@@ -3,6 +3,7 @@ package com.hrr.backend.domain.user.service;
 import com.hrr.backend.domain.user.dto.*;
 import com.hrr.backend.global.response.SliceResponseDto;
 import com.hrr.backend.domain.user.entity.User;
+import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
 
 public interface UserService {
 
@@ -57,6 +58,16 @@ public interface UserService {
      */
     SliceResponseDto<UserResponseDto.CompletedChallengeDto> getCompletedChallenges(
             Long userId,
+            int page,
+            int size
+    );
+
+    /**
+     * 현재 로그인한 사용자가 스크랩한 인증글 목록 조회 (페이징)
+     */
+    SliceResponseDto<UserResponseDto.ScrappedVerificationDto> getScrappedVerifications(
+            User currentUser,
+            VerificationPostType type,
             int page,
             int size
     );

--- a/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/user/service/UserServiceImpl.java
@@ -35,8 +35,11 @@ import lombok.RequiredArgsConstructor;
 import com.hrr.backend.domain.challenge.entity.Challenge;
 import com.hrr.backend.domain.challenge.entity.ChallengeDayJoin;
 import com.hrr.backend.domain.challenge.repository.ChallengeRepository;
+import com.hrr.backend.domain.verification.entity.Verification;
+import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
 import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
 import com.hrr.backend.domain.verification.repository.VerificationRepository;
+import com.hrr.backend.domain.verification.repository.VerificationScrapRepository;
 import com.hrr.backend.global.common.enums.ChallengeDays;
 
 import java.time.LocalDate;
@@ -55,6 +58,7 @@ public class UserServiceImpl implements UserService {
 
     private final ChallengeRepository challengeRepository;
     private final VerificationRepository verificationRepository;
+    private final VerificationScrapRepository verificationScrapRepository;
 
     private final S3UrlUtil s3UrlUtil;
     private final ApplicationEventPublisher eventPublisher;
@@ -390,6 +394,57 @@ public class UserServiceImpl implements UserService {
 
         // SliceResponseDto로 변환하여 반환
         return new SliceResponseDto<>(slice);
+    }
+
+    @Override
+    public SliceResponseDto<UserResponseDto.ScrappedVerificationDto> getScrappedVerifications(
+            User currentUser,
+            VerificationPostType type,
+            int page,
+            int size
+    ) {
+        Pageable pageable = PageRequest.of(page, size);
+        Slice<Verification> verificationSlice = verificationScrapRepository.findVisibleScrappedVerifications(
+                currentUser.getId(),
+                type,
+                VerificationStatus.COMPLETED,
+                pageable
+        );
+
+        Slice<UserResponseDto.ScrappedVerificationDto> dtoSlice =
+                verificationSlice.map(this::toScrappedVerificationDto);
+
+        return new SliceResponseDto<>(dtoSlice);
+    }
+
+    private UserResponseDto.ScrappedVerificationDto toScrappedVerificationDto(Verification verification) {
+        User writer = verification.getRoundRecord().getUserChallenge().getUser();
+
+        boolean hasLink = verification.getTextUrl() != null && !verification.getTextUrl().isBlank();
+        String imageUrl = null;
+
+        if (verification.getType() == VerificationPostType.CAMERA) {
+            if (verification.getPhotoUrl() != null) {
+                imageUrl = s3UrlUtil.toFullUrl(verification.getPhotoUrl());
+            }
+        } else if (verification.getTextImages() != null && !verification.getTextImages().isEmpty()) {
+            imageUrl = s3UrlUtil.toFullUrl(verification.getTextImages().get(0));
+        }
+
+        return UserResponseDto.ScrappedVerificationDto.builder()
+                .verificationId(verification.getId())
+                .type(verification.getType())
+                .title(verification.getTitle())
+                .content(verification.getContent())
+                .imageUrl(imageUrl)
+                .hasLink(hasLink)
+                .isQuestion(verification.getIsQuestion())
+                .isResolved(verification.getIsResolved())
+                .writerNickname(writer.getDisplayNickname())
+                .writerProfileUrl(writer.getProfileImage())
+                .writerId(writer.getId())
+                .createdDate(verification.getCreatedAt())
+                .build();
     }
 
     // 내 정보 수정

--- a/src/main/java/com/hrr/backend/domain/verification/repository/VerificationScrapRepository.java
+++ b/src/main/java/com/hrr/backend/domain/verification/repository/VerificationScrapRepository.java
@@ -1,6 +1,11 @@
 package com.hrr.backend.domain.verification.repository;
 
+import com.hrr.backend.domain.verification.entity.Verification;
 import com.hrr.backend.domain.verification.entity.VerificationScrap;
+import com.hrr.backend.domain.verification.entity.enums.VerificationPostType;
+import com.hrr.backend.domain.verification.entity.enums.VerificationStatus;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -19,4 +24,44 @@ public interface VerificationScrapRepository extends JpaRepository<VerificationS
     void insertIgnore(@Param("userId") Long userId, @Param("verificationId") Long verificationId);
 
     void deleteByUserIdAndVerificationId(Long userId, Long verificationId);
+
+    @Query("""
+            SELECT v FROM VerificationScrap vs
+            JOIN vs.verification v
+            JOIN FETCH v.roundRecord rr
+            JOIN FETCH rr.userChallenge uc
+            JOIN FETCH uc.user author
+            JOIN FETCH uc.challenge c
+            WHERE vs.user.id = :currentUserId
+            AND v.status = :status
+            AND (:type IS NULL OR v.type = :type)
+            AND author.userStatus = com.hrr.backend.domain.user.entity.enums.UserStatus.ACTIVE
+            AND NOT EXISTS (
+                SELECT 1 FROM UserBlock b
+                WHERE b.blocker.id = :currentUserId
+                AND b.blocked.id = author.id
+            )
+            AND NOT EXISTS (
+                SELECT 1 FROM UserBlock b
+                WHERE b.blocker.id = author.id
+                AND b.blocked.id = :currentUserId
+            )
+            AND (
+                c.isPublic = true
+                OR author.id = :currentUserId
+                OR EXISTS (
+                    SELECT 1 FROM UserChallenge viewerUc
+                    WHERE viewerUc.user.id = :currentUserId
+                    AND viewerUc.challenge = c
+                    AND viewerUc.status = com.hrr.backend.domain.user.entity.enums.ChallengeJoinStatus.JOINED
+                )
+            )
+            ORDER BY vs.createdAt DESC
+            """)
+    Slice<Verification> findVisibleScrappedVerifications(
+            @Param("currentUserId") Long currentUserId,
+            @Param("type") VerificationPostType type,
+            @Param("status") VerificationStatus status,
+            Pageable pageable
+    );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.
> Close #364 

## ✨ 작업 내용 (Summary)

* `GET /api/v1/user/{userId}/verifications/scrap` 스크랩한 인증 글 목록 조회 API를 구현했습니다.
* 사용자가 스크랩한 인증 글을 기준으로 목록을 조회하도록 구현했습니다.
* 사진인증 / 글인증 타입에 따라 스크랩 목록을 조회할 수 있도록 처리했습니다.
* 목록 조회에 오프셋 기반 페이징을 적용했습니다.
* 삭제되었거나 현재 사용자에게 노출할 수 없는 인증 글은 조회 결과에서 제외하도록 처리했습니다.
* 기존 인증 글 및 스크랩 관련 구조와 공통 응답 형식을 재사용했습니다.

---

## ✅ 변경 사항 체크리스트

* [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
* [x] 문서를 작성하거나 수정했나요? (필요한 경우)
* [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

* **테스트 환경:** 로컬
* **테스트 방법:** Swagger / API 수동 테스트
* **결과 요약:** 스크랩한 인증 글 목록 조회 및 커서 기반 페이징 동작 확인

---

## 📸 스크린샷

| 사진인증 | 글인증 |
|---|---|
| <img width="1330" height="990" alt="image" src="https://github.com/user-attachments/assets/1b9b50ed-933e-49d1-bce7-69b8c85dfab4" /> | <img width="1328" height="976" alt="image" src="https://github.com/user-attachments/assets/49a90bd3-a283-417c-9c8f-c16d32b48c8d" /> |

---

## 💬 리뷰 요구사항

* 사진인증 / 글인증 구분에 따라 올바른 데이터가 반환되는지 확인 부탁드립니다.
* 커서 기반 페이징 시 데이터의 중복이나 누락 없이 다음 페이지가 조회되는지 확인 부탁드립니다.
* 삭제되었거나 접근할 수 없는 인증 글이 목록에서 제외되는지 확인 부탁드립니다.
* 기존 인증 글 조회 및 스크랩 로직에 영향이 없는지 확인 부탁드립니다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 내가 스크랩한 인증 게시물 목록을 조회할 수 있습니다.
  * 인증 게시물 유형별 필터와 페이지·조회 개수 설정을 지원합니다.
  * 최신 스크랩 순으로 인증 이미지, 링크, 작성자, 상태 및 작성일을 확인할 수 있습니다.
  * 공개 범위와 차단 설정을 반영해 조회 가능한 게시물만 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->