### PR TITLE
[BUG] 주간 랭킹 스냅샷 미생성 버그 해결

### DIFF
--- a/src/main/java/com/hrr/backend/domain/ranking/repository/UserRankSnapshotRepository.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/repository/UserRankSnapshotRepository.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.ranking.repository;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -55,11 +56,10 @@ public interface UserRankSnapshotRepository extends JpaRepository<UserRankSnapsh
             Pageable pageable
     );
 
-    // 특정 스냅샷일의 기존 행을 전부 삭제 (같은 트랜잭션에서 upsertWeeklySnapshot 이전에 호출하여 원자적 교체)
-    @Modifying
-    int deleteBySnapshotDate(LocalDate snapshotDate);
+    /** 해당 스냅샷일의 행이 이미 존재하는지 확인. */
+    boolean existsBySnapshotDate(LocalDate snapshotDate);
 
-    /** 매주 월요일 00시, 전체 ACTIVE 유저를 대상으로 포인트 내림차순 등수를 계산하여 스냅샷 테이블에 UPSERT*/
+    /** 지정한 스냅샷일 기준으로 전체 ACTIVE 유저의 주간 랭킹 스냅샷을 생성한다. (컷오프 이전 포인트만 집계) */
     @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Query(value = """
 		INSERT INTO user_rank_snapshot (user_id, ranking, points, total_user_count, snapshot_date, achieved_at, created_at, updated_at)
@@ -74,19 +74,20 @@ public interface UserRankSnapshotRepository extends JpaRepository<UserRankSnapsh
 		    NOW()
 		FROM (
 		    SELECT
-		        u.id,
-		        u.points,
-		        COUNT(*) OVER () AS total_count,
-		        (SELECT MAX(ph.created_at) FROM point_history ph WHERE ph.user_id = u.id) AS achieved_at
+		        u.id                        AS id,
+		        COALESCE(SUM(ph.points), 0) AS points,
+		        COUNT(*) OVER ()            AS total_count,
+		        MAX(ph.created_at)          AS achieved_at
 		    FROM user u
+		    LEFT JOIN point_history ph
+		           ON ph.user_id = u.id
+		          AND ph.created_at < :cutoff
 		    WHERE u.status = 'ACTIVE'
+		    GROUP BY u.id
 		) t
-		ON DUPLICATE KEY UPDATE
-		    ranking = VALUES(ranking),
-		    points = VALUES(points),
-		    total_user_count = VALUES(total_user_count),
-		    achieved_at = VALUES(achieved_at),
-		    updated_at = NOW()
 		""", nativeQuery = true)
-    int upsertWeeklySnapshot(@Param("snapshotDate") LocalDate snapshotDate);
+    int insertWeeklySnapshot(
+            @Param("snapshotDate") LocalDate snapshotDate,
+            @Param("cutoff") LocalDateTime cutoff
+    );
 }

--- a/src/main/java/com/hrr/backend/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/service/RankingService.java
@@ -1,5 +1,7 @@
 package com.hrr.backend.domain.ranking.service;
 
+import java.time.LocalDate;
+
 import com.hrr.backend.domain.ranking.dto.RankingResponseDto;
 import com.hrr.backend.domain.user.entity.User;
 
@@ -7,4 +9,8 @@ public interface RankingService {
 
     // 내 랭킹 보드 조회 (상단 프로필은 실시간, 랭킹보드는 주간 스냅샷 기준)
     RankingResponseDto.BoardDto getMyRankingBoard(User user);
+
+    // 주간 랭킹 스냅샷 보장(catch-up)
+    /** 지정한 월요일자 스냅샷이 없으면 생성한다. (이미 있으면 아무것도 하지 않음) */
+    int ensureWeeklySnapshot(LocalDate snapshotDate);
 }

--- a/src/main/java/com/hrr/backend/domain/ranking/service/RankingService.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/service/RankingService.java
@@ -11,6 +11,6 @@ public interface RankingService {
     RankingResponseDto.BoardDto getMyRankingBoard(User user);
 
     // 주간 랭킹 스냅샷 보장(catch-up)
-    /** 지정한 월요일자 스냅샷이 없으면 생성한다. (이미 있으면 아무것도 하지 않음) */
-    int ensureWeeklySnapshot(LocalDate snapshotDate);
+    /**지정한 월요일자 스냅샷이 없으면 생성한다. (이미 있으면 아무것도 하지 않음)*/
+    boolean ensureWeeklySnapshot(LocalDate snapshotDate);
 }

--- a/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
@@ -1,6 +1,7 @@
 package com.hrr.backend.domain.ranking.service;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -85,6 +86,28 @@ public class RankingServiceImpl implements RankingService {
         return rankingConverter.toBoardDto(
                 user, topRankers, mySnapshot, myRank, totalUserCount, topPercent, rankChange, rankChangeMessage);
     }
+
+    // ensureWeeklySnapshot - 주간 랭킹 스냅샷 catch-up 로직
+    // 존재 확인 후 없을 때만 INSERT  ->  그 주 최초 1회만 값이 확정됨 (월요일 고정값 보장)
+    @Override
+    @Transactional
+    public int ensureWeeklySnapshot(LocalDate snapshotDate) {
+        // 이미 이번 주 스냅샷이 있으면 아무것도 하지 않는다.
+        if (userRankSnapshotRepository.existsBySnapshotDate(snapshotDate)) {
+            return 0;
+        }
+
+        // 컷오프 = 스냅샷일 00:00:00 (미만)
+        LocalDateTime cutoff = snapshotDate.atStartOfDay();
+
+        int created = userRankSnapshotRepository.insertWeeklySnapshot(snapshotDate, cutoff);
+
+        log.info("[ensureWeeklySnapshot] 주간 랭킹 snapshot을 생성했습니다. snapshotDate={}, cutoff={}, createdCount={}",
+                snapshotDate, cutoff, created);
+
+        return created;
+    }
+
     // rankChange 값을 기반으로 문구 생성 (이전 데이터 없으면 null)
     private String buildRankChangeMessage(Integer rankChange) {
         if (rankChange == null) {

--- a/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
@@ -103,8 +103,6 @@ public class RankingServiceImpl implements RankingService {
         int created = userRankSnapshotRepository.insertWeeklySnapshot(snapshotDate, cutoff);
 
         if (created == 0) {
-            log.warn("[ensureWeeklySnapshot] 대상 ACTIVE 유저가 없어 주간 랭킹 snapshot이 생성되지 않았습니다. snapshotDate={}, cutoff={}",
-                    snapshotDate, cutoff);
             return false;
         }
 

--- a/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/ranking/service/RankingServiceImpl.java
@@ -91,10 +91,10 @@ public class RankingServiceImpl implements RankingService {
     // 존재 확인 후 없을 때만 INSERT  ->  그 주 최초 1회만 값이 확정됨 (월요일 고정값 보장)
     @Override
     @Transactional
-    public int ensureWeeklySnapshot(LocalDate snapshotDate) {
+    public boolean ensureWeeklySnapshot(LocalDate snapshotDate) {
         // 이미 이번 주 스냅샷이 있으면 아무것도 하지 않는다.
         if (userRankSnapshotRepository.existsBySnapshotDate(snapshotDate)) {
-            return 0;
+            return true;
         }
 
         // 컷오프 = 스냅샷일 00:00:00 (미만)
@@ -102,10 +102,16 @@ public class RankingServiceImpl implements RankingService {
 
         int created = userRankSnapshotRepository.insertWeeklySnapshot(snapshotDate, cutoff);
 
+        if (created == 0) {
+            log.warn("[ensureWeeklySnapshot] 대상 ACTIVE 유저가 없어 주간 랭킹 snapshot이 생성되지 않았습니다. snapshotDate={}, cutoff={}",
+                    snapshotDate, cutoff);
+            return false;
+        }
+
         log.info("[ensureWeeklySnapshot] 주간 랭킹 snapshot을 생성했습니다. snapshotDate={}, cutoff={}, createdCount={}",
                 snapshotDate, cutoff, created);
 
-        return created;
+        return true;
     }
 
     // rankChange 값을 기반으로 문구 생성 (이전 데이터 없으면 null)

--- a/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
@@ -4,15 +4,11 @@ import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
-import org.springframework.dao.DataIntegrityViolationException;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.hrr.backend.domain.ranking.service.RankingService;
-import org.springframework.transaction.annotation.Transactional;
-
-import com.hrr.backend.domain.ranking.repository.UserRankSnapshotRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -40,28 +36,13 @@ public class RankingScheduler {
         }
 
         try {
-            int created = rankingService.ensureWeeklySnapshot(mondayOfThisWeek);
+            boolean confirmed = rankingService.ensureWeeklySnapshot(mondayOfThisWeek);
 
-            //  created > 0 : 방금 내가 만들었음
-            //  created == 0: 이미 존재함(다른 인스턴스가 만들었거나 이전 주기에 만들어짐)
-            lastConfirmedSnapshotDate = mondayOfThisWeek;
-
-
-            if (created > 0) {
-                log.info("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성을 완료했습니다. snapshotDate={}, createdCount={}",
-                        mondayOfThisWeek, created);
+            if (confirmed) {
+                lastConfirmedSnapshotDate = mondayOfThisWeek;
             }
 
-        } catch (DataIntegrityViolationException e) {
-            // 인스턴스 간 경합 처리 (분산 락 대체)
-            lastConfirmedSnapshotDate = mondayOfThisWeek;
-
-            log.info("[takeWeeklyRankSnapshot] 다른 인스턴스가 먼저 snapshot을 생성하여 건너뜁니다. snapshotDate={}",
-                    mondayOfThisWeek);
-
         } catch (Exception e) {
-            // 실패해도 스케줄러 밖으로 예외를 던지지 않는다.
-            //  이 경로에서는 lastConfirmedSnapshotDate를 갱신하지 않는다. 스냅샷이 확보되지 않았으므로 30초 뒤에 다시 시도되어야 한다.
             log.error("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성에 실패했습니다. 다음 주기에 재시도합니다. snapshotDate={}",
                     mondayOfThisWeek, e);
         }

--- a/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
@@ -1,10 +1,15 @@
 package com.hrr.backend.global.scheduler;
 
 import java.time.Clock;
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.temporal.TemporalAdjusters;
+import org.springframework.dao.DataIntegrityViolationException;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+
+import com.hrr.backend.domain.ranking.service.RankingService;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.hrr.backend.domain.ranking.repository.UserRankSnapshotRepository;
@@ -17,21 +22,48 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RankingScheduler {
 
-    private final UserRankSnapshotRepository userRankSnapshotRepository;
+    private final RankingService rankingService;
     private final Clock clock;
 
-    // 매주 월요일 00:00(한국시간)에 전체 유저 랭킹 스냅샷 생성
-    @Scheduled(cron = "0 0 0 * * MON", zone = "Asia/Seoul")
-    @Transactional
+    private volatile LocalDate lastConfirmedSnapshotDate;
+
+    /** 이번 주 월요일자 랭킹 스냅샷이 확보될 때까지 30초마다 생성을 시도한다. */
+    @Scheduled(cron = "*/30 * * * * *", zone = "Asia/Seoul")
     public void takeWeeklyRankSnapshot() {
-        LocalDate today = LocalDate.now(clock);
-        // 같은 날짜로 재실행되는 경우(예: 배치 재처리)를 대비해, 기존 행을 먼저 지우고 다시 적재한다.
-        // (ACTIVE 집합에서 빠진 유저의 예전 행이 그대로 남아 total_user_count/노출 순위가 어긋나는 것을 방지)
-        int deleted = userRankSnapshotRepository.deleteBySnapshotDate(today);
 
-        int affected = userRankSnapshotRepository.upsertWeeklySnapshot(today);
+        LocalDate mondayOfThisWeek = LocalDate.now(clock)
+                .with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
 
-        log.info("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성을 완료했습니다. snapshotDate={}, deletedCount={}, affectedCount={}",
-                today, deleted, affected);
+        // 이번 주 스냅샷이 이미 확보되었으면 DB에 가지 않고 즉시 종료
+        if (mondayOfThisWeek.equals(lastConfirmedSnapshotDate)) {
+            return;
+        }
+
+        try {
+            int created = rankingService.ensureWeeklySnapshot(mondayOfThisWeek);
+
+            //  created > 0 : 방금 내가 만들었음
+            //  created == 0: 이미 존재함(다른 인스턴스가 만들었거나 이전 주기에 만들어짐)
+            lastConfirmedSnapshotDate = mondayOfThisWeek;
+
+
+            if (created > 0) {
+                log.info("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성을 완료했습니다. snapshotDate={}, createdCount={}",
+                        mondayOfThisWeek, created);
+            }
+
+        } catch (DataIntegrityViolationException e) {
+            // 인스턴스 간 경합 처리 (분산 락 대체)
+            lastConfirmedSnapshotDate = mondayOfThisWeek;
+
+            log.info("[takeWeeklyRankSnapshot] 다른 인스턴스가 먼저 snapshot을 생성하여 건너뜁니다. snapshotDate={}",
+                    mondayOfThisWeek);
+
+        } catch (Exception e) {
+            // 실패해도 스케줄러 밖으로 예외를 던지지 않는다.
+            //  이 경로에서는 lastConfirmedSnapshotDate를 갱신하지 않는다. 스냅샷이 확보되지 않았으므로 30초 뒤에 다시 시도되어야 한다.
+            log.error("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성에 실패했습니다. 다음 주기에 재시도합니다. snapshotDate={}",
+                    mondayOfThisWeek, e);
+        }
     }
 }

--- a/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
+++ b/src/main/java/com/hrr/backend/global/scheduler/RankingScheduler.java
@@ -4,6 +4,7 @@ import java.time.Clock;
 import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.temporal.TemporalAdjusters;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -18,10 +19,15 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RankingScheduler {
 
+    private static final int FAILURE_ALERT_THRESHOLD = 10;
+    private static final int FAILURE_ALERT_INTERVAL = 120;
+
     private final RankingService rankingService;
     private final Clock clock;
 
     private volatile LocalDate lastConfirmedSnapshotDate;
+
+    private final AtomicInteger consecutiveFailures = new AtomicInteger();
 
     /** 이번 주 월요일자 랭킹 스냅샷이 확보될 때까지 30초마다 생성을 시도한다. */
     @Scheduled(cron = "*/30 * * * * *", zone = "Asia/Seoul")
@@ -40,11 +46,37 @@ public class RankingScheduler {
 
             if (confirmed) {
                 lastConfirmedSnapshotDate = mondayOfThisWeek;
+
+                // 복구 로그
+
+                int recoveredFailureCount = consecutiveFailures.getAndSet(0);
+                if (recoveredFailureCount > 0) {
+                    log.info("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성이 복구되었습니다. snapshotDate={}, previousFailureCount={}",
+                            mondayOfThisWeek, recoveredFailureCount);
+                }
+                return;
             }
 
+            // 예외 없이 스냅샷이 확보되지 않은 경우
+
+            handleFailure(mondayOfThisWeek, "대상 ACTIVE User가 없어 주간 랭킹 snapshot이 생성되지 않았습니다.", null);
+
         } catch (Exception e) {
-            log.error("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성에 실패했습니다. 다음 주기에 재시도합니다. snapshotDate={}",
-                    mondayOfThisWeek, e);
+            // log.error -> handleFailure()로 위임
+            handleFailure(mondayOfThisWeek, "주간 랭킹 snapshot 생성에 실패했습니다.", e);
+        }
+    }
+
+    // 실패 처리 및 로깅 (로깅 컨벤션 1번 / 5번 반영)
+    private void handleFailure(LocalDate snapshotDate, String reason, Exception e) {
+        int failureCount = consecutiveFailures.incrementAndGet();
+
+        log.warn("[takeWeeklyRankSnapshot] {} 다음 주기에 재시도합니다. snapshotDate={}, exception={}",
+                reason, snapshotDate, e == null ? "none" : e.getClass().getSimpleName());
+
+        if (failureCount == FAILURE_ALERT_THRESHOLD || failureCount % FAILURE_ALERT_INTERVAL == 0) {
+            log.error("[takeWeeklyRankSnapshot] 주간 랭킹 snapshot 생성의 연속 실패가 누적되었습니다. snapshotDate={}, consecutiveFailureCount={}",
+                    snapshotDate, failureCount, e);
         }
     }
 }

--- a/src/test/java/com/hrr/backend/domain/ranking/service/RankingServiceImplTest.java
+++ b/src/test/java/com/hrr/backend/domain/ranking/service/RankingServiceImplTest.java
@@ -1,12 +1,14 @@
 package com.hrr.backend.domain.ranking.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -22,8 +24,6 @@ import com.hrr.backend.domain.ranking.dto.RankingResponseDto;
 import com.hrr.backend.domain.ranking.entity.UserRankSnapshot;
 import com.hrr.backend.domain.ranking.repository.UserRankSnapshotRepository;
 import com.hrr.backend.domain.user.entity.User;
-import com.hrr.backend.global.exception.GlobalException;
-import com.hrr.backend.global.response.ErrorCode;
 import com.hrr.backend.global.s3.S3UrlUtil;
 
 @ExtendWith(MockitoExtension.class)
@@ -40,19 +40,21 @@ class RankingServiceImplTest {
     private final RankingConverter rankingConverter = new RankingConverter(new S3UrlUtil("https://example.com"));
 
     @Test
-    @DisplayName("아직 랭킹 스냅샷이 한 번도 생성되지 않았으면 예외가 발생한다")
-    void getMyRankingBoard_throws_whenNoSnapshotExists() {
+    @DisplayName("아직 랭킹 스냅샷이 한 번도 생성되지 않았으면 에러 대신 board=null로 응답한다")
+    void getMyRankingBoard_returnsNullBoard_whenNoSnapshotExists() {
         // given
         rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
         User user = User.builder().id(1L).nickname("tester").points(0L).build();
 
         given(userRankSnapshotRepository.findLatestSnapshotDate()).willReturn(Optional.empty());
 
-        // when & then
-        assertThatThrownBy(() -> rankingService.getMyRankingBoard(user))
-                .isInstanceOf(GlobalException.class)
-                .extracting(e -> ((GlobalException) e).getErrorCode())
-                .isEqualTo(ErrorCode.RANKING_SNAPSHOT_NOT_FOUND);
+        // when
+        RankingResponseDto.BoardDto result = rankingService.getMyRankingBoard(user);
+
+        // then: 랭킹 보드는 null이지만, 상단 프로필은 실시간 값으로 정상 응답
+        assertThat(result.getBoard()).isNull();
+        assertThat(result.getMyProfile().getNickname()).isEqualTo("tester");
+        assertThat(result.getMyProfile().getPoints()).isEqualTo(0L);
     }
 
     @Test
@@ -71,6 +73,8 @@ class RankingServiceImplTest {
 
         given(userRankSnapshotRepository.findLatestSnapshotDate()).willReturn(Optional.of(latest));
         given(userRankSnapshotRepository.findTopByRanking(eq(latest), any())).willReturn(List.of(topSnapshot));
+        // 전체 인원수는 스냅샷 저장값이 아니라 활성 유저 기준 COUNT로 재계산된다
+        given(userRankSnapshotRepository.countActiveBySnapshotDate(latest)).willReturn(132L);
         given(userRankSnapshotRepository.findByUserIdAndSnapshotDate(1L, latest)).willReturn(Optional.empty());
 
         // when
@@ -82,7 +86,7 @@ class RankingServiceImplTest {
         assertThat(result.getBoard().getRankChange()).isNull();
         assertThat(result.getBoard().getRankChangeMessage()).isNull();
         assertThat(result.getBoard().getMyPoints()).isNull();
-        // 상위 5명은 그대로 노출되고, 전체 인원수는 상위 랭커의 스냅샷 값에서 가져옴
+        // 전체 인원수는 상위 랭커 스냅샷 값이 아니라 countActiveBySnapshotDate 결과다
         assertThat(result.getBoard().getTopRankers()).hasSize(1);
         assertThat(result.getBoard().getTotalUserCount()).isEqualTo(132);
         assertThat(result.getBoard().getSnapshotDate()).isEqualTo(latest);
@@ -112,6 +116,12 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.findByUserIdAndSnapshotDate(1L, latest)).willReturn(Optional.of(mySnapshot));
         given(userRankSnapshotRepository.findPreviousSnapshots(eq(1L), eq(latest), any()))
                 .willReturn(List.of(previousSnapshot));
+        // 등수/전체인원은 저장값이 아니라 COUNT 쿼리로 재계산되므로 스텁이 필요하다.
+        //        myRank      = countHigherRankers(latest, 100) + 1 = 89 + 1 = 90
+        //        previousRank= countHigherRankers(previous, 80) + 1 = 99 + 1 = 100
+        given(userRankSnapshotRepository.countActiveBySnapshotDate(latest)).willReturn(1000L);
+        given(userRankSnapshotRepository.countHigherRankers(latest, 100L)).willReturn(89L);
+        given(userRankSnapshotRepository.countHigherRankers(previous, 80L)).willReturn(99L);
 
         // when
         RankingResponseDto.BoardDto result = rankingService.getMyRankingBoard(user);
@@ -145,6 +155,10 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.findByUserIdAndSnapshotDate(1L, latest)).willReturn(Optional.of(mySnapshot));
         given(userRankSnapshotRepository.findPreviousSnapshots(eq(1L), eq(latest), any()))
                 .willReturn(List.of(previousSnapshot));
+        // myRank = 49 + 1 = 50 / previousRank = 39 + 1 = 40
+        given(userRankSnapshotRepository.countActiveBySnapshotDate(latest)).willReturn(1000L);
+        given(userRankSnapshotRepository.countHigherRankers(latest, 80L)).willReturn(49L);
+        given(userRankSnapshotRepository.countHigherRankers(previous, 90L)).willReturn(39L);
 
         // when
         RankingResponseDto.BoardDto result = rankingService.getMyRankingBoard(user);
@@ -172,6 +186,9 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.findByUserIdAndSnapshotDate(1L, latest)).willReturn(Optional.of(mySnapshot));
         given(userRankSnapshotRepository.findPreviousSnapshots(eq(1L), eq(latest), any()))
                 .willReturn(List.of());
+        // myRank = 29 + 1 = 30, 전체 100명
+        given(userRankSnapshotRepository.countActiveBySnapshotDate(latest)).willReturn(100L);
+        given(userRankSnapshotRepository.countHigherRankers(latest, 100L)).willReturn(29L);
 
         // when
         RankingResponseDto.BoardDto result = rankingService.getMyRankingBoard(user);
@@ -181,5 +198,46 @@ class RankingServiceImplTest {
         assertThat(result.getBoard().getRankChangeMessage()).isNull();
         // 상위 퍼센트: 30 / 100 * 100 = 30(올림)
         assertThat(result.getBoard().getTopPercent()).isEqualTo(30);
+    }
+
+    // ensureWeeklySnapshot() 테스트 2개
+    //  이 메서드가 "이미 있으면 절대 덮어쓰지 않는다"는 점이 핵심
+    //  30초마다 호출되는데 덮어쓰기가 일어나면 '월요일에 고정된 값'이라는 스펙이 깨지기 때문에,
+    //  스킵 동작을 반드시 테스트로 고정해 둔다.
+    @Test
+    @DisplayName("ensureWeeklySnapshot: 이미 해당 주 스냅샷이 있으면 생성하지 않고 0을 반환한다")
+    void ensureWeeklySnapshot_skips_whenSnapshotAlreadyExists() {
+        // given
+        rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
+        LocalDate monday = LocalDate.of(2026, 8, 17);
+
+        given(userRankSnapshotRepository.existsBySnapshotDate(monday)).willReturn(true);
+
+        // when
+        int created = rankingService.ensureWeeklySnapshot(monday);
+
+        // then: INSERT는 절대 호출되지 않아야 한다 (월요일 확정값 덮어쓰기 방지)
+        assertThat(created).isZero();
+        verify(userRankSnapshotRepository, never()).insertWeeklySnapshot(any(), any());
+    }
+
+    @Test
+    @DisplayName("ensureWeeklySnapshot: 스냅샷이 없으면 '월요일 00:00 미만' 컷오프로 생성한다")
+    void ensureWeeklySnapshot_insertsWithMidnightCutoff_whenSnapshotMissing() {
+        // given
+        rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
+        LocalDate monday = LocalDate.of(2026, 8, 17);
+        // 2026-08-16(일) 23:59:59.999999 까지의 포인트만 집계되도록 하는 컷오프
+        LocalDateTime expectedCutoff = LocalDateTime.of(2026, 8, 17, 0, 0);
+
+        given(userRankSnapshotRepository.existsBySnapshotDate(monday)).willReturn(false);
+        given(userRankSnapshotRepository.insertWeeklySnapshot(monday, expectedCutoff)).willReturn(120);
+
+        // when
+        int created = rankingService.ensureWeeklySnapshot(monday);
+
+        // then
+        assertThat(created).isEqualTo(120);
+        verify(userRankSnapshotRepository).insertWeeklySnapshot(monday, expectedCutoff);
     }
 }

--- a/src/test/java/com/hrr/backend/domain/ranking/service/RankingServiceImplTest.java
+++ b/src/test/java/com/hrr/backend/domain/ranking/service/RankingServiceImplTest.java
@@ -86,7 +86,6 @@ class RankingServiceImplTest {
         assertThat(result.getBoard().getRankChange()).isNull();
         assertThat(result.getBoard().getRankChangeMessage()).isNull();
         assertThat(result.getBoard().getMyPoints()).isNull();
-        // 전체 인원수는 상위 랭커 스냅샷 값이 아니라 countActiveBySnapshotDate 결과다
         assertThat(result.getBoard().getTopRankers()).hasSize(1);
         assertThat(result.getBoard().getTotalUserCount()).isEqualTo(132);
         assertThat(result.getBoard().getSnapshotDate()).isEqualTo(latest);
@@ -116,9 +115,9 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.findByUserIdAndSnapshotDate(1L, latest)).willReturn(Optional.of(mySnapshot));
         given(userRankSnapshotRepository.findPreviousSnapshots(eq(1L), eq(latest), any()))
                 .willReturn(List.of(previousSnapshot));
-        // 등수/전체인원은 저장값이 아니라 COUNT 쿼리로 재계산되므로 스텁이 필요하다.
-        //        myRank      = countHigherRankers(latest, 100) + 1 = 89 + 1 = 90
-        //        previousRank= countHigherRankers(previous, 80) + 1 = 99 + 1 = 100
+        // 등수/전체인원은 저장값이 아니라 COUNT 쿼리로 재계산된다.
+        //   myRank       = countHigherRankers(latest, 100) + 1 = 89 + 1 = 90
+        //   previousRank = countHigherRankers(previous, 80) + 1 = 99 + 1 = 100
         given(userRankSnapshotRepository.countActiveBySnapshotDate(latest)).willReturn(1000L);
         given(userRankSnapshotRepository.countHigherRankers(latest, 100L)).willReturn(89L);
         given(userRankSnapshotRepository.countHigherRankers(previous, 80L)).willReturn(99L);
@@ -200,12 +199,8 @@ class RankingServiceImplTest {
         assertThat(result.getBoard().getTopPercent()).isEqualTo(30);
     }
 
-    // ensureWeeklySnapshot() 테스트 2개
-    //  이 메서드가 "이미 있으면 절대 덮어쓰지 않는다"는 점이 핵심
-    //  30초마다 호출되는데 덮어쓰기가 일어나면 '월요일에 고정된 값'이라는 스펙이 깨지기 때문에,
-    //  스킵 동작을 반드시 테스트로 고정해 둔다.
     @Test
-    @DisplayName("ensureWeeklySnapshot: 이미 해당 주 스냅샷이 있으면 생성하지 않고 0을 반환한다")
+    @DisplayName("ensureWeeklySnapshot: 이미 해당 주 스냅샷이 있으면 생성하지 않고 true를 반환한다")
     void ensureWeeklySnapshot_skips_whenSnapshotAlreadyExists() {
         // given
         rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
@@ -214,15 +209,16 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.existsBySnapshotDate(monday)).willReturn(true);
 
         // when
-        int created = rankingService.ensureWeeklySnapshot(monday);
+        // int created -> boolean confirmed (반환 타입 변경)
+        boolean confirmed = rankingService.ensureWeeklySnapshot(monday);
 
         // then: INSERT는 절대 호출되지 않아야 한다 (월요일 확정값 덮어쓰기 방지)
-        assertThat(created).isZero();
+        assertThat(confirmed).isTrue();
         verify(userRankSnapshotRepository, never()).insertWeeklySnapshot(any(), any());
     }
 
     @Test
-    @DisplayName("ensureWeeklySnapshot: 스냅샷이 없으면 '월요일 00:00 미만' 컷오프로 생성한다")
+    @DisplayName("ensureWeeklySnapshot: 스냅샷이 없으면 '월요일 00:00 미만' 컷오프로 생성하고 true를 반환한다")
     void ensureWeeklySnapshot_insertsWithMidnightCutoff_whenSnapshotMissing() {
         // given
         rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
@@ -234,10 +230,29 @@ class RankingServiceImplTest {
         given(userRankSnapshotRepository.insertWeeklySnapshot(monday, expectedCutoff)).willReturn(120);
 
         // when
-        int created = rankingService.ensureWeeklySnapshot(monday);
+        // int created -> boolean confirmed
+        boolean confirmed = rankingService.ensureWeeklySnapshot(monday);
 
         // then
-        assertThat(created).isEqualTo(120);
+        assertThat(confirmed).isTrue();
         verify(userRankSnapshotRepository).insertWeeklySnapshot(monday, expectedCutoff);
+    }
+
+    @Test
+    @DisplayName("ensureWeeklySnapshot: 대상 ACTIVE 유저가 없어 0건이 삽입되면 false를 반환한다")
+    void ensureWeeklySnapshot_returnsFalse_whenNoRowInserted() {
+        // given
+        rankingService = new RankingServiceImpl(userRankSnapshotRepository, rankingConverter);
+        LocalDate monday = LocalDate.of(2026, 8, 17);
+        LocalDateTime expectedCutoff = LocalDateTime.of(2026, 8, 17, 0, 0);
+
+        given(userRankSnapshotRepository.existsBySnapshotDate(monday)).willReturn(false);
+        given(userRankSnapshotRepository.insertWeeklySnapshot(monday, expectedCutoff)).willReturn(0);
+
+        // when
+        boolean confirmed = rankingService.ensureWeeklySnapshot(monday);
+
+        // then: 스냅샷이 만들어지지 않았으므로 확보되지 않은 것으로 보고해야 한다
+        assertThat(confirmed).isFalse();
     }
 }

--- a/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
+++ b/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
@@ -19,7 +19,6 @@ import org.springframework.dao.DataIntegrityViolationException;
 
 import com.hrr.backend.domain.ranking.service.RankingService;
 
-
 @ExtendWith(MockitoExtension.class)
 class RankingSchedulerTest {
 

--- a/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
+++ b/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
@@ -28,7 +28,6 @@ class RankingSchedulerTest {
     private RankingService rankingService;
 
     // 실행 시점의 실제 시각 대신, 테스트마다 원하는 날짜/시각으로 고정된 Clock을 주입해서 검증한다.
-    // (실제 시각을 그대로 읽으면 테스트 실행 요일에 따라 결과가 달라진다)
     private Clock fixedClockAt(LocalDateTime dateTime) {
         return Clock.fixed(dateTime.atZone(KST).toInstant(), KST);
     }
@@ -41,7 +40,8 @@ class RankingSchedulerTest {
         RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
 
         LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
-        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
+        // thenReturn(120) -> thenReturn(true) (반환 타입 int -> boolean)
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(true);
 
         // when
         rankingScheduler.takeWeeklyRankSnapshot();
@@ -58,7 +58,8 @@ class RankingSchedulerTest {
         RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
 
         LocalDate expectedMonday = LocalDate.of(2026, 8, 24);
-        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
+        // thenReturn(120) -> thenReturn(true)
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(true);
 
         // when
         rankingScheduler.takeWeeklyRankSnapshot();
@@ -75,7 +76,8 @@ class RankingSchedulerTest {
         RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
 
         LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
-        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
+        // thenReturn(120) -> thenReturn(true)
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(true);
 
         // when: 30초 주기로 세 번 깨어난 상황을 가정
         rankingScheduler.takeWeeklyRankSnapshot();
@@ -84,6 +86,48 @@ class RankingSchedulerTest {
 
         // then: 첫 호출에서 확보되었으므로 서비스는 단 한 번만 호출되어야 한다
         verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+
+    //  ACTIVE 유저가 없어 스냅샷이 실제로 만들어지지 않은 경우(false 반환),
+    //  스케줄러가 이를 확보 완료로 오인해 그 주 재시도를 중단하면 안 된다.
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 스냅샷이 확보되지 않으면(false) 확정하지 않고 다음 주기에 다시 시도한다")
+    void takeWeeklyRankSnapshot_retriesNextCycle_whenSnapshotNotConfirmed() {
+        // given: 대상 ACTIVE 유저가 없어 스냅샷이 생성되지 않은 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(false);
+
+        // when: 두 주기 연속 실행
+        rankingScheduler.takeWeeklyRankSnapshot();
+        rankingScheduler.takeWeeklyRankSnapshot();
+
+        // then: 확보되지 않았으므로 매 주기마다 다시 시도되어야 한다
+        verify(rankingService, times(2)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 무결성 오류가 나도 확정하지 않고 다음 주기에 DB로 재확인한다")
+    void takeWeeklyRankSnapshot_retriesNextCycle_whenIntegrityViolationOccurs() {
+        // given: 첫 주기에는 무결성 오류, 다음 주기에는 (다른 인스턴스가 만든) 스냅샷이 확인되는 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"))
+                .thenReturn(true);
+
+        // when & then: 예외가 스케줄러 밖으로 새어 나가면 안 된다
+        assertThatCode(rankingScheduler::takeWeeklyRankSnapshot).doesNotThrowAnyException();
+        rankingScheduler.takeWeeklyRankSnapshot();  // 두 번째 주기에 확보 확인
+        rankingScheduler.takeWeeklyRankSnapshot();  // 확보 후에는 더 이상 호출되지 않아야 함
+
+        // 1회차(예외) + 2회차(확보 확인) = 2번만 호출되고, 3회차는 캐시에서 걸러진다
+        verify(rankingService, times(2)).ensureWeeklySnapshot(expectedMonday);
     }
 
     @Test
@@ -103,24 +147,5 @@ class RankingSchedulerTest {
 
         // 실패한 경우에는 확보 처리를 하지 않으므로, 다음 주기에도 다시 시도되어야 한다
         verify(rankingService, times(2)).ensureWeeklySnapshot(expectedMonday);
-    }
-
-    @Test
-    @DisplayName("takeWeeklyRankSnapshot: 다른 인스턴스가 먼저 생성해 유니크 제약에 걸려도 정상 종료하고 재시도하지 않는다")
-    void takeWeeklyRankSnapshot_stopsRetrying_whenAnotherInstanceCreatedSnapshot() {
-        // given: 블루/그린 두 인스턴스가 동시에 INSERT를 시도해 늦은 쪽이 롤백된 상황
-        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
-        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
-
-        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
-        when(rankingService.ensureWeeklySnapshot(expectedMonday))
-                .thenThrow(new DataIntegrityViolationException("duplicate key"));
-
-        // when
-        assertThatCode(rankingScheduler::takeWeeklyRankSnapshot).doesNotThrowAnyException();
-        rankingScheduler.takeWeeklyRankSnapshot();
-
-        // then: 이미 스냅샷이 존재하는 상태이므로 두 번째 주기에는 서비스를 호출하지 않는다
-        verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
     }
 }

--- a/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
+++ b/src/test/java/com/hrr/backend/global/scheduler/RankingSchedulerTest.java
@@ -1,51 +1,127 @@
 package com.hrr.backend.global.scheduler;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InOrder;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
-import com.hrr.backend.domain.ranking.repository.UserRankSnapshotRepository;
+import com.hrr.backend.domain.ranking.service.RankingService;
+
 
 @ExtendWith(MockitoExtension.class)
 class RankingSchedulerTest {
 
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
     @Mock
-    private UserRankSnapshotRepository userRankSnapshotRepository;
+    private RankingService rankingService;
 
-    // 실행 시점의 실제 시각 대신, 테스트마다 원하는 날짜로 고정된 Clock을 주입해서 검증한다.
-    // (실제 시각을 그대로 읽으면 테스트 실행이 자정을 넘는 순간 간헐적으로 결과가 달라질 수 있음)
+    // 실행 시점의 실제 시각 대신, 테스트마다 원하는 날짜/시각으로 고정된 Clock을 주입해서 검증한다.
+    // (실제 시각을 그대로 읽으면 테스트 실행 요일에 따라 결과가 달라진다)
+    private Clock fixedClockAt(LocalDateTime dateTime) {
+        return Clock.fixed(dateTime.atZone(KST).toInstant(), KST);
+    }
+
     @Test
-    @DisplayName("takeWeeklyRankSnapshot: 주입된 Clock 기준 날짜로 기존 스냅샷을 먼저 삭제한 뒤 upsert를 호출한다")
-    void takeWeeklyRankSnapshot_deletesExistingRowsBeforeUpsert() {
-        // given
-        LocalDate fixedDate = LocalDate.of(2026, 7, 20); // 임의로 고정한 날짜(월요일)
-        Clock fixedClock = Clock.fixed(
-                fixedDate.atStartOfDay(ZoneId.of("Asia/Seoul")).toInstant(),
-                ZoneId.of("Asia/Seoul")
-        );
-        RankingScheduler rankingScheduler = new RankingScheduler(userRankSnapshotRepository, fixedClock);
+    @DisplayName("takeWeeklyRankSnapshot: 화요일에 실행돼도 그 주의 월요일 날짜로 스냅샷 생성을 요청한다")
+    void takeWeeklyRankSnapshot_usesMondayOfCurrentWeek_whenRunOnOtherDay() {
+        // given: 2026-08-18(화) 09:30에 실행된 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
 
-        when(userRankSnapshotRepository.deleteBySnapshotDate(any())).thenReturn(3);
-        when(userRankSnapshotRepository.upsertWeeklySnapshot(any())).thenReturn(100);
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
 
         // when
         rankingScheduler.takeWeeklyRankSnapshot();
 
-        // then: 삭제 -> upsert 순서로, 고정된 날짜 그대로 호출되어야 함
-        InOrder inOrder = Mockito.inOrder(userRankSnapshotRepository);
-        inOrder.verify(userRankSnapshotRepository, times(1)).deleteBySnapshotDate(fixedDate);
-        inOrder.verify(userRankSnapshotRepository, times(1)).upsertWeeklySnapshot(fixedDate);
+        // then: 오늘(08-18)이 아니라 그 주의 월요일(08-17)로 호출되어야 함
+        verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 월요일 00:00에 실행되면 오늘 날짜가 그대로 스냅샷 기준일이 된다")
+    void takeWeeklyRankSnapshot_usesToday_whenRunOnMonday() {
+        // given: 2026-08-24(월) 00:00:00에 실행된 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 24, 0, 0));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 24);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
+
+        // when
+        rankingScheduler.takeWeeklyRankSnapshot();
+
+        // then: previousOrSame(MONDAY)이므로 월요일 당일에는 오늘 날짜 그대로
+        verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 이번 주 스냅샷이 확보된 뒤에는 다시 호출해도 DB를 조회하지 않는다")
+    void takeWeeklyRankSnapshot_doesNotHitServiceAgain_afterSnapshotConfirmed() {
+        // given
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday)).thenReturn(120);
+
+        // when: 30초 주기로 세 번 깨어난 상황을 가정
+        rankingScheduler.takeWeeklyRankSnapshot();
+        rankingScheduler.takeWeeklyRankSnapshot();
+        rankingScheduler.takeWeeklyRankSnapshot();
+
+        // then: 첫 호출에서 확보되었으므로 서비스는 단 한 번만 호출되어야 한다
+        verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 생성에 실패하면 예외를 삼키고 다음 주기에 다시 시도한다")
+    void takeWeeklyRankSnapshot_retriesNextCycle_whenSnapshotCreationFails() {
+        // given: DB 오류 등으로 생성이 실패하는 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday))
+                .thenThrow(new IllegalStateException("DB 연결 실패"));
+
+        // when & then: 예외가 스케줄러 밖으로 새어 나가면 안 된다
+        assertThatCode(rankingScheduler::takeWeeklyRankSnapshot).doesNotThrowAnyException();
+        assertThatCode(rankingScheduler::takeWeeklyRankSnapshot).doesNotThrowAnyException();
+
+        // 실패한 경우에는 확보 처리를 하지 않으므로, 다음 주기에도 다시 시도되어야 한다
+        verify(rankingService, times(2)).ensureWeeklySnapshot(expectedMonday);
+    }
+
+    @Test
+    @DisplayName("takeWeeklyRankSnapshot: 다른 인스턴스가 먼저 생성해 유니크 제약에 걸려도 정상 종료하고 재시도하지 않는다")
+    void takeWeeklyRankSnapshot_stopsRetrying_whenAnotherInstanceCreatedSnapshot() {
+        // given: 블루/그린 두 인스턴스가 동시에 INSERT를 시도해 늦은 쪽이 롤백된 상황
+        Clock fixedClock = fixedClockAt(LocalDateTime.of(2026, 8, 18, 9, 30));
+        RankingScheduler rankingScheduler = new RankingScheduler(rankingService, fixedClock);
+
+        LocalDate expectedMonday = LocalDate.of(2026, 8, 17);
+        when(rankingService.ensureWeeklySnapshot(expectedMonday))
+                .thenThrow(new DataIntegrityViolationException("duplicate key"));
+
+        // when
+        assertThatCode(rankingScheduler::takeWeeklyRankSnapshot).doesNotThrowAnyException();
+        rankingScheduler.takeWeeklyRankSnapshot();
+
+        // then: 이미 스냅샷이 존재하는 상태이므로 두 번째 주기에는 서비스를 호출하지 않는다
+        verify(rankingService, times(1)).ensureWeeklySnapshot(expectedMonday);
     }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #373 

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)
주간 랭킹 스냅샷 미생성 버그를 수정했습니다.
=> 기존 방식) 스냅샷을 놓치면 복구할 방법을 따로 구현해두지 않았음. & 월요일 00:00:00에 배포, 재시작, oom등으로 해당 시점을 놓쳤을 때 그 주 랭킹이 통째로 유실
=> 변경한 방식)

1. 이번주 월요일자 스냅샷이 확보될 때까지 계속 시도: 포인트 산출을 시각 컷오프 기간으로 바꿔서 동일하게함
해당 주 스냅샷 있으면 0 반환 후 종료, 없으면 컷오프 계산 후 추가
2. 만약에 00:00에 배포/재시작 중-> 앱이 뜬 뒤 최대 30초 내 자동 생성
3. db오류로 생성 실패 -> 30초 뒤 재시도하고 성공할 때까지 반복
4. 스냅샷 확보 완료 시 -> 날짜 비교만 하고 종료

---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [x] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [x] 문서를 작성하거나 수정했나요? (필요한 경우)
- [x] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** (예: 로컬, 개발 서버 등)
* **테스트 방법:** (예: Postman, 단위 테스트, 수동 기능 테스트 등)
* **결과 요약:** (예: 모든 테스트 통과, 새로운 테스트 케이스 3개 추가 완료)

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.
<img width="2160" height="849" alt="스크린샷 2026-08-19 133250" src="https://github.com/user-attachments/assets/575ba21f-31f0-409b-a666-b6c03cf716c3" />
<img width="2149" height="821" alt="스크린샷 2026-08-19 133202" src="https://github.com/user-attachments/assets/3e59fd65-81b6-496a-9bef-5147a6ac1ac1" />

---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 주간 랭킹 스냅샷의 중복 생성을 방지합니다.
  * 서울 시간 기준으로 스냅샷을 확인하며, 생성 실패 시 자동으로 재시도합니다.
  * 마감 시각 이전에 적립된 포인트를 기준으로 랭킹을 산정합니다.
  * 기존 스냅샷을 재사용해 랭킹 데이터의 일관성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->