### PR TITLE
[Fix] 팔로우 알림 생성 트랜잭션 처리 수정

### DIFF
--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventRepository.java
@@ -9,7 +9,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-public interface NotificationEventRepository extends JpaRepository<NotificationEvent, Long> {
+public interface NotificationEventRepository extends JpaRepository<NotificationEvent, Long>, NotificationEventUpsertRepository {
 
     // 특정 리소스 + 특정 알림 타입 + 특정 날짜로 이벤트가 이미 생성됐는지 확인
     boolean existsByContextTypeAndContextIdAndTypeTypeNameAndCreatedDate(

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventUpsertRepository.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventUpsertRepository.java
@@ -1,0 +1,7 @@
+package com.hrr.backend.domain.notification.repository;
+
+import com.hrr.backend.domain.notification.entity.NotificationEvent;
+
+public interface NotificationEventUpsertRepository {
+    void upsert(NotificationEvent event);
+}

--- a/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventUpsertRepositoryImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/repository/NotificationEventUpsertRepositoryImpl.java
@@ -1,0 +1,86 @@
+package com.hrr.backend.domain.notification.repository;
+
+import com.hrr.backend.domain.notification.entity.NotificationEvent;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.hibernate.Session;
+
+import java.time.LocalDateTime;
+
+public class NotificationEventUpsertRepositoryImpl implements NotificationEventUpsertRepository {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Override
+    public void upsert(NotificationEvent event) {
+        if (isH2()) {
+            upsertForH2(event);
+            return;
+        }
+
+        upsertForMySql(event);
+    }
+
+    private void upsertForMySql(NotificationEvent event) {
+        entityManager.createNativeQuery("""
+                        INSERT INTO notification_event (
+                            actor_id, category, context_id, context_type, created_at, created_date,
+                            image_key, message, target_id, target_type, title, type_id, updated_at
+                        )
+                        VALUES (
+                            :actorId, :category, :contextId, :contextType, :createdAt, :createdDate,
+                            :imageKey, :message, :targetId, :targetType, :title, :typeId, :updatedAt
+                        )
+                        ON DUPLICATE KEY UPDATE id = id
+                        """)
+                .setParameter("actorId", event.getActor() == null ? null : event.getActor().getId())
+                .setParameter("category", event.getCategory().name())
+                .setParameter("contextId", event.getContextId())
+                .setParameter("contextType", event.getContextType().name())
+                .setParameter("createdAt", LocalDateTime.now())
+                .setParameter("createdDate", event.getCreatedDate())
+                .setParameter("imageKey", event.getImageKey())
+                .setParameter("message", event.getMessage())
+                .setParameter("targetId", event.getTargetId())
+                .setParameter("targetType", event.getTargetType().name())
+                .setParameter("title", event.getTitle())
+                .setParameter("typeId", event.getType().getId())
+                .setParameter("updatedAt", LocalDateTime.now())
+                .executeUpdate();
+    }
+
+    private void upsertForH2(NotificationEvent event) {
+        entityManager.createNativeQuery("""
+                        MERGE INTO notification_event (
+                            actor_id, category, context_id, context_type, created_at, created_date,
+                            image_key, message, target_id, target_type, title, type_id, updated_at
+                        )
+                        KEY (context_type, context_id, type_id, created_date)
+                        VALUES (
+                            :actorId, :category, :contextId, :contextType, :createdAt, :createdDate,
+                            :imageKey, :message, :targetId, :targetType, :title, :typeId, :updatedAt
+                        )
+                        """)
+                .setParameter("actorId", event.getActor() == null ? null : event.getActor().getId())
+                .setParameter("category", event.getCategory().name())
+                .setParameter("contextId", event.getContextId())
+                .setParameter("contextType", event.getContextType().name())
+                .setParameter("createdAt", LocalDateTime.now())
+                .setParameter("createdDate", event.getCreatedDate())
+                .setParameter("imageKey", event.getImageKey())
+                .setParameter("message", event.getMessage())
+                .setParameter("targetId", event.getTargetId())
+                .setParameter("targetType", event.getTargetType().name())
+                .setParameter("title", event.getTitle())
+                .setParameter("typeId", event.getType().getId())
+                .setParameter("updatedAt", LocalDateTime.now())
+                .executeUpdate();
+    }
+
+    private boolean isH2() {
+        return entityManager.unwrap(Session.class)
+                .doReturningWork(connection ->
+                        connection.getMetaData().getDatabaseProductName().equalsIgnoreCase("H2"));
+    }
+}

--- a/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/NotificationCommandServiceImpl.java
@@ -510,10 +510,10 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
                 () -> createFollowEvent(actor, type, today)
         );
 
-        NotificationEvent mergedEvent = eventRepository.findById(notificationEvent.getId()).orElseThrow();
+        NotificationEvent eventReference = eventRepository.getReferenceById(notificationEvent.getId());
 
         NotificationDelivery delivery = NotificationDelivery.builder()
-                .event(mergedEvent)
+                .event(eventReference)
                 .receiver(receiver)
                 .isRead(false)
                 .build();
@@ -521,10 +521,10 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
         notificationRepository.save(delivery);
 
         if (receiver.getNotificationSetting().isFollowEnabled()) {
-            eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), mergedEvent));
+            eventPublisher.publishEvent(new FcmPushSendEvent(List.of(delivery), notificationEvent));
         }
         log.info("[sendFollowCreatedNotification] 팔로우 알림 생성을 완료했습니다. eventId={}, deliveryCount=1, actorId={}, receiverId={}",
-                mergedEvent.getId(), actor.getId(), receiver.getId());
+                notificationEvent.getId(), actor.getId(), receiver.getId());
     }
 
     private NotificationEvent createFollowEvent(User actor, NotificationType type, LocalDate createdDate) {

--- a/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventHelper.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventHelper.java
@@ -16,7 +16,6 @@ public class NotificationEventHelper {
                                                     NotificationType type, String title,
                                                     String message, LocalDate date,
                                                     java.util.function.Supplier<NotificationEvent> creator) {
-        return eventReader.findIfExists(contextType, contextId, type.getTypeName(), date)
-                .orElseGet(() -> eventReader.tryCreate(creator.get()));
+        return eventReader.upsertAndFind(creator.get());
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventHelper.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventHelper.java
@@ -3,42 +3,20 @@ package com.hrr.backend.domain.notification.service.helper; // 👈 오타 수�
 import com.hrr.backend.domain.notification.entity.NotificationEvent;
 import com.hrr.backend.domain.notification.entity.NotificationType;
 import com.hrr.backend.domain.notification.entity.enums.ResourceType;
-import com.hrr.backend.domain.notification.repository.NotificationEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
-import java.util.Optional;
-
 @Component
 @RequiredArgsConstructor
 public class NotificationEventHelper {
-    private final NotificationEventRepository eventRepository;
     private final NotificationEventReader eventReader;
 
     public NotificationEvent getOrCreateSharedEvent(ResourceType contextType, Long contextId,
                                                     NotificationType type, String title,
                                                     String message, LocalDate date,
                                                     java.util.function.Supplier<NotificationEvent> creator) {
-        // 새 트랜잭션에서 조회 시도
-        Optional<NotificationEvent> existing = eventReader.findIfExists(contextType, contextId, type.getTypeName(), date);
-        if (existing.isPresent()) {
-            return existing.get();
-        }
-
-        // 새 트랜잭션에서 생성 시도
-        try {
-            return eventReader.tryCreate(creator.get());
-        } catch (org.springframework.dao.DataIntegrityViolationException e) {
-            // 충돌 시 새 트랜잭션에서 재조회
-            Optional<NotificationEvent> persisted = eventReader.findIfExists(contextType, contextId, type.getTypeName(), date);
-
-            if (persisted.isPresent()) {
-                return persisted.get(); // 경쟁 상태에서 다른 스레드가 먼저 생성한 경우 정상 반환
-            }
-
-            // 재조회 결과가 없다면 유니크 제약 위반이 아닌 다른 무결성 에러이므로 원본 예외를 다시 던짐
-            throw e;
-        }
+        return eventReader.findIfExists(contextType, contextId, type.getTypeName(), date)
+                .orElseGet(() -> eventReader.tryCreate(creator.get()));
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventReader.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventReader.java
@@ -1,27 +1,28 @@
 package com.hrr.backend.domain.notification.service.helper;
 
 import com.hrr.backend.domain.notification.entity.NotificationEvent;
-import com.hrr.backend.domain.notification.entity.enums.NotificationTypeName;
-import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.notification.repository.NotificationEventRepository;
+import com.hrr.backend.global.exception.GlobalException;
+import com.hrr.backend.global.response.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-
-import java.time.LocalDate;
-import java.util.Optional;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
 public class NotificationEventReader {
     private final NotificationEventRepository eventRepository;
 
-    public Optional<NotificationEvent> findIfExists(ResourceType contextType, Long contextId,
-                                                    NotificationTypeName typeName, LocalDate date) {
-        return eventRepository.findByContextTypeAndContextIdAndTypeTypeNameAndCreatedDate(
-                contextType, contextId, typeName, date);
-    }
+    @Transactional(propagation = Propagation.MANDATORY)
+    public NotificationEvent upsertAndFind(NotificationEvent event) {
+        eventRepository.upsert(event);
 
-    public NotificationEvent tryCreate(NotificationEvent event) {
-        return eventRepository.saveAndFlush(event);
+        return eventRepository.findByContextTypeAndContextIdAndTypeTypeNameAndCreatedDate(
+                        event.getContextType(),
+                        event.getContextId(),
+                        event.getType().getTypeName(),
+                        event.getCreatedDate())
+                .orElseThrow(() -> new GlobalException(ErrorCode._INTERNAL_SERVER_ERROR));
     }
 }

--- a/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventReader.java
+++ b/src/main/java/com/hrr/backend/domain/notification/service/helper/NotificationEventReader.java
@@ -6,8 +6,6 @@ import com.hrr.backend.domain.notification.entity.enums.ResourceType;
 import com.hrr.backend.domain.notification.repository.NotificationEventRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Propagation;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.util.Optional;
@@ -17,14 +15,12 @@ import java.util.Optional;
 public class NotificationEventReader {
     private final NotificationEventRepository eventRepository;
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Optional<NotificationEvent> findIfExists(ResourceType contextType, Long contextId,
                                                     NotificationTypeName typeName, LocalDate date) {
         return eventRepository.findByContextTypeAndContextIdAndTypeTypeNameAndCreatedDate(
                 contextType, contextId, typeName, date);
     }
 
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public NotificationEvent tryCreate(NotificationEvent event) {
         return eventRepository.saveAndFlush(event);
     }

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
@@ -55,6 +55,11 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -627,7 +632,50 @@ class NotificationIntegrationTest {
     }
 
     @Test
-    @DisplayName("14. 팔로우 알림: 후속 처리 실패 시 이벤트만 단독으로 커밋되지 않는다")
+    @DisplayName("14. 팔로우 알림: 같은 actor의 두 수신자 동시 호출은 이벤트 하나와 수신 내역 두 개를 저장한다")
+    void followCreated_ConcurrentReceiversShareOneEvent_Test() throws Exception {
+        // given
+        User actor = createUser("conc_actor", true);
+        User receiver1 = createUser("conc_recv1", true);
+        User receiver2 = createUser("conc_recv2", true);
+        CountDownLatch ready = new CountDownLatch(2);
+        CountDownLatch start = new CountDownLatch(1);
+        ExecutorService executor = Executors.newFixedThreadPool(2);
+
+        try {
+            Future<?> first = executor.submit(() -> sendFollowCreatedAfterStart(actor, receiver1, ready, start));
+            Future<?> second = executor.submit(() -> sendFollowCreatedAfterStart(actor, receiver2, ready, start));
+
+            assertThat(ready.await(3, TimeUnit.SECONDS)).isTrue();
+            start.countDown();
+            first.get(5, TimeUnit.SECONDS);
+            second.get(5, TimeUnit.SECONDS);
+        } finally {
+            executor.shutdownNow();
+        }
+
+        // then
+        transactionTemplate.executeWithoutResult(status -> {
+            List<NotificationEvent> events = notificationEventRepository.findAll();
+            List<NotificationDelivery> deliveries = notificationRepository.findAll();
+
+            assertThat(events).hasSize(1);
+            assertThat(events.get(0).getContextType()).isEqualTo(ResourceType.USER);
+            assertThat(events.get(0).getContextId()).isEqualTo(actor.getId());
+            assertThat(events.get(0).getType().getTypeName()).isEqualTo(NotificationTypeName.FOLLOW_CREATED);
+
+            assertThat(deliveries).hasSize(2);
+            assertThat(deliveries)
+                    .extracting(delivery -> delivery.getEvent().getId())
+                    .containsOnly(events.get(0).getId());
+            assertThat(deliveries)
+                    .extracting(delivery -> delivery.getReceiver().getId())
+                    .containsExactlyInAnyOrder(receiver1.getId(), receiver2.getId());
+        });
+    }
+
+    @Test
+    @DisplayName("15. 팔로우 알림: 후속 처리 실패 시 이벤트만 단독으로 커밋되지 않는다")
     void followCreated_RollbackDoesNotLeaveEventOnly_Test() {
         // given
         User actor = createUser("rollback_actor", true);
@@ -645,6 +693,19 @@ class NotificationIntegrationTest {
 
         assertThat(notificationEventRepository.findAll()).isEmpty();
         assertThat(notificationRepository.findAll()).isEmpty();
+    }
+
+    private void sendFollowCreatedAfterStart(User actor, User receiver, CountDownLatch ready, CountDownLatch start) {
+        try {
+            ready.countDown();
+            if (!start.await(3, TimeUnit.SECONDS)) {
+                throw new IllegalStateException("Concurrent notification test did not start");
+            }
+            notificationCommandService.sendFollowCreatedNotification(new FollowCreatedEvent(actor, receiver));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
     }
 
     private User createUser(String name, boolean enabled) {

--- a/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
+++ b/src/test/java/com/hrr/backend/domain/notification/NotificationIntegrationTest.java
@@ -57,6 +57,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @ActiveProfiles("test")
@@ -623,6 +624,27 @@ class NotificationIntegrationTest {
                     .isEqualTo(NotificationTypeName.FOLLOW_CREATED);
         });
         assertThat(countPayloadEvents(FcmPushSendEvent.class)).isZero();
+    }
+
+    @Test
+    @DisplayName("14. 팔로우 알림: 후속 처리 실패 시 이벤트만 단독으로 커밋되지 않는다")
+    void followCreated_RollbackDoesNotLeaveEventOnly_Test() {
+        // given
+        User actor = createUser("rollback_actor", true);
+        User receiverWithoutSetting = userRepository.save(User.builder()
+                .name("rollback_recv")
+                .nickname("rollback_recv_nick")
+                .profileImage("rollback_receiver-profile-image")
+                .isPublic(true)
+                .build());
+
+        // when & then
+        assertThatThrownBy(() -> notificationCommandService.sendFollowCreatedNotification(
+                new FollowCreatedEvent(actor, receiverWithoutSetting)))
+                .isInstanceOf(RuntimeException.class);
+
+        assertThat(notificationEventRepository.findAll()).isEmpty();
+        assertThat(notificationRepository.findAll()).isEmpty();
     }
 
     private User createUser(String name, boolean enabled) {


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> 관련된 이슈 번호를 적어주세요.\
> Close #이슈번호

## ✨ 작업 내용 (Summary)

> 이번 PR에서 작업한 내용을 간략히 설명해주세요. (이미지 첨부 가능)

팔로우 알림 생성 과정에서 발생하던 두 가지 에러를 수정했습니다.

  1. `NotificationEvent` 생성 후 다시 조회하는 과정에서
  `NoSuchElementException`이 발생하던 문제를 수정했습니다.
     - 기존에는 생성된 이벤트를 `findById(...).orElseThrow()`로 재조회해
  delivery에 연결했습니다.
     - 이를 `getReferenceById(...)`로 변경해 불필요한 재조회를 제거하고,
  delivery 저장에는 JPA reference를 사용하도록 했습니다.

  2. 팔로우 알림 생성 중 예외가 발생했을 때 `notification_event`만 DB에 남고
  `notification_delivery`가 생성되지 않을 수 있는 문제를 수정했습니다.
     - 기존에는 팔로우 알림의 공유 이벤트 생성 로직이 별도 `REQUIRES_NEW` 트랜
  잭션으로 실행되었습니다.
     - 이제 event 생성과 delivery 저장이 같은 트랜잭션 안에서 처리되어 함께 성
  공하거나 함께 롤백됩니다.


---

## ✅ 변경 사항 체크리스트

> 다음 항목들을 확인하고 체크해주세요.

- [ ] 코드에 영향이 있는 모든 부분에 대한 테스트를 작성하고 실행했나요?
- [ ] 문서를 작성하거나 수정했나요? (필요한 경우)
- [ ] 중요한 변경 사항이 팀에 공유되었나요?

---

## 🧪 테스트 결과

> 코드 변경에 대해 테스트를 수행한 결과를 요약해주세요.

* **테스트 환경:** 로컬
* **테스트 방법:** 스웨거 및 통합 테스트
* **결과 요약:** 팔로우 알림 생성/롤백 관련 통합 테스트 통과 및 로컬 DB에서 확인

---

## 📸 스크린샷

> 관련된 스크린샷 또는 GIF가 있다면 여기에 첨부해주세요.

<img width="570" height="108" alt="image" src="https://github.com/user-attachments/assets/ff571445-e354-46ee-8f79-5ebddea8d692" />


---

## 💬 리뷰 요구사항

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.

- 해당 수정사항이 다른 알림 로직에 오류를 발생시키지 않는지

---

## 📎 참고 자료

> 관련 문서, 레퍼런스 링크 등이 있다면 여기에 첨부해주세요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 팔로우 알림 처리 중 오류가 발생하면 관련 알림 정보가 저장되지 않고 전체 작업이 안전하게 취소되도록 개선했습니다.
  * 알림 이벤트 조회 및 생성 과정의 처리 안정성과 효율성을 높였습니다.
  * 알림 전달 과정에서 동일한 이벤트 정보가 일관되게 사용되도록 수정했습니다.

* **테스트**
  * 팔로우 알림 후속 처리 실패 시 데이터가 남지 않는 트랜잭션 롤백 시나리오를 검증하는 통합 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->